### PR TITLE
Bump aiohttp to 3.14.0 (medium)

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,7 +14,7 @@ requests==2.32.5
 httpx==0.27.2
 
 # Async testing support
-aiohttp==3.13.3
+aiohttp==3.14.0
 
 # Environment management
 python-dotenv==1.0.1


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.13.3` → `3.14.0`
**Manifest:** `tests/requirements.txt`
**Severity:** medium
**Advisory:** AIOHTTP accepts duplicate Host headers CVE-2026-22815, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `de52cd1893a45e75` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"de52cd1893a45e75","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->