### PR TITLE
Bump 2 dependencies in requirements.txt (medium)

### DIFF
--- a/open-security-sensor/requirements.txt
+++ b/open-security-sensor/requirements.txt
@@ -2,7 +2,7 @@
 
 # Core dependencies
 asyncio-mqtt==0.16.2
-aiohttp==3.13.3
+aiohttp==3.14.0
 aiohttp-cors==0.7.0
 PyYAML==6.0.2
 psutil==6.1.1
@@ -19,7 +19,7 @@ watchdog==6.0.0
 structlog==24.4.0
 
 # Security
-cryptography==46.0.5
+cryptography==46.0.7
 certifi==2024.12.14
 
 # Development dependencies (optional)


### PR DESCRIPTION
### FabGPT — OSV security bump

**Packages:**
- `aiohttp` `3.13.3` → `3.14.0` (CVE-2026-22815, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265)
- `cryptography` `46.0.5` → `46.0.7` (CVE-2026-34073, CVE-2026-39892)
**Manifest:** `open-security-sensor/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-22815, CVE-2026-34073, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-39892, CVE-2026-47265

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `38688c5a66b6d9fe` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"38688c5a66b6d9fe","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->