### PR TITLE
Bump 3 dependencies in requirements.txt (medium)

### DIFF
--- a/open-security-tools/requirements.txt
+++ b/open-security-tools/requirements.txt
@@ -6,7 +6,7 @@ fastapi==0.115.5
 uvicorn[standard]==0.32.1
 pydantic==2.10.3
 pydantic-settings==2.10.1
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 Jinja2==3.1.6
 aiofiles==24.1.0
 
@@ -19,9 +19,9 @@ python-whois==0.9.4
 python-nmap==0.7.1
 
 # Web vulnerability scanning dependencies
-aiohttp==3.13.3
+aiohttp==3.14.0
 beautifulsoup4==4.12.3
-requests==2.32.5
+requests==2.33.0
 
 # SSL/TLS analysis dependencies
 cryptography==46.0.5


### PR DESCRIPTION
### FabGPT — OSV security bump

**Packages:**
- `aiohttp` `3.13.3` → `3.14.0` (CVE-2026-22815, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265)
- `python-dotenv` `1.0.1` → `1.2.2` (CVE-2026-28684)
- `requests` `2.32.5` → `2.33.0` (CVE-2026-25645)
**Manifest:** `open-security-tools/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-22815, CVE-2026-25645, CVE-2026-28684, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `a8c7fcff114a2e37` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"a8c7fcff114a2e37","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->