### PR TITLE
Bump 3 dependencies in requirements.txt (medium)

### DIFF
--- a/open-security-cspm/requirements.txt
+++ b/open-security-cspm/requirements.txt
@@ -59,10 +59,10 @@ pyyaml==6.0.1
 
 # HTTP clients
 httpx==0.25.2
-aiohttp==3.13.3
+aiohttp==3.14.0
 
 # Security utilities
-cryptography==46.0.5
+cryptography==46.0.7
 python-jose[cryptography]==3.5.0
 
 # Logging and monitoring
@@ -74,5 +74,5 @@ gunicorn==23.0.0
 
 # Utilities
 python-dateutil==2.8.2
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 click==8.1.7


### PR DESCRIPTION
### FabGPT — OSV security bump

**Packages:**
- `aiohttp` `3.13.3` → `3.14.0` (CVE-2026-22815, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265)
- `cryptography` `46.0.5` → `46.0.7` (CVE-2026-34073, CVE-2026-39892)
- `python-dotenv` `1.0.0` → `1.2.2` (CVE-2026-28684)
**Manifest:** `open-security-cspm/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-22815, CVE-2026-28684, CVE-2026-34073, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-39892, CVE-2026-47265

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `356e381baa04323f` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"356e381baa04323f","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->