### PR TITLE
Bump python-dotenv to 1.2.2 (medium)

### DIFF
--- a/open-security-responder/requirements.txt
+++ b/open-security-responder/requirements.txt
@@ -30,5 +30,5 @@ pytest-cov==6.0.0
 gunicorn==23.0.0
 
 # Utilities
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 structlog==24.4.0


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `python-dotenv` `1.0.1` → `1.2.2`
**Manifest:** `open-security-responder/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-28684

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `2a408c1f521aae2e` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"2a408c1f521aae2e","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->