### PR TITLE
Bump 5 dependencies in requirements.txt (high)

### DIFF
--- a/open-security-guardian/requirements.txt
+++ b/open-security-guardian/requirements.txt
@@ -1,7 +1,7 @@
 # Open Security Guardian - Python Dependencies
 
 # Django Framework
-Django==4.2.28
+Django==4.2.30
 djangorestframework==3.15.2
 django-cors-headers==4.3.1
 django-filter==23.2
@@ -20,14 +20,14 @@ django-celery-results==2.5.1
 
 # Security & Authentication
 django-oauth-toolkit==3.0.1
-cryptography==46.0.5
+cryptography==46.0.7
 python-jose[cryptography]==3.5.0
 
 # HTTP Clients & Integrations
-requests==2.32.5
+requests==2.33.0
 httpx==0.25.2
 pydantic==2.8.2
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 
 # Data Processing
 pandas==2.1.4
@@ -56,7 +56,7 @@ validators==0.20.0
 ipaddress==1.0.23
 netaddr==0.8.0
 PyYAML==6.0.1
-Pillow==12.1.1
+Pillow==12.2.0
 
 # Testing
 pytest==7.4.0


### PR DESCRIPTION
### FabGPT — OSV security bump

**Packages:**
- `cryptography` `46.0.5` → `46.0.7` (CVE-2026-34073, CVE-2026-39892)
- `Django` `4.2.28` → `4.2.30` (CVE-2026-25673, CVE-2026-25674, CVE-2026-33033, CVE-2026-33034, CVE-2026-3902, CVE-2026-4277, CVE-2026-4292)
- `Pillow` `12.1.1` → `12.2.0` (CVE-2026-42309, CVE-2026-42310, CVE-2026-42311)
- `python-dotenv` `1.0.0` → `1.2.2` (CVE-2026-28684)
- `requests` `2.32.5` → `2.33.0` (CVE-2026-25645)
**Manifest:** `open-security-guardian/requirements.txt`
**Severity:** high
**Advisories:** CVE-2026-25645, CVE-2026-25673, CVE-2026-25674, CVE-2026-28684, CVE-2026-33033, CVE-2026-33034, CVE-2026-34073, CVE-2026-3902, CVE-2026-39892, CVE-2026-42309, CVE-2026-42310, CVE-2026-42311, CVE-2026-4277, CVE-2026-4292

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `aee3ff1083fedbff` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"aee3ff1083fedbff","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->