### PR TITLE
Bump 2 dependencies in requirements.txt (medium)

### DIFF
--- a/open-security-data/requirements.txt
+++ b/open-security-data/requirements.txt
@@ -10,7 +10,7 @@ psycopg2-binary==2.9.9
 alembic==1.12.1
 
 # Async HTTP client
-aiohttp==3.13.3
+aiohttp==3.14.0
 aiofiles==23.2.0
 
 # Data processing
@@ -92,4 +92,4 @@ tabulate==0.9.0
 
 # Optional: Configuration management
 pyyaml==6.0.1
-python-dotenv==1.0.0
+python-dotenv==1.2.2


### PR DESCRIPTION
### FabGPT — OSV security bump

**Packages:**
- `aiohttp` `3.13.3` → `3.14.0` (CVE-2026-22815, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265)
- `python-dotenv` `1.0.0` → `1.2.2` (CVE-2026-28684)
**Manifest:** `open-security-data/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-22815, CVE-2026-28684, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `f4a40b11540f38ef` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"f4a40b11540f38ef","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->