### PR TITLE
Bump nltk to 3.9.4 (critical)

### DIFF
--- a/open-security-data/requirements.txt
+++ b/open-security-data/requirements.txt
@@ -68,7 +68,7 @@ scikit-learn==1.5.0
 
 # Optional: Natural language processing for IOC extraction
 spacy==3.7.2
-nltk==3.9.2
+nltk==3.9.4
 
 # Optional: Geolocation
 geoip2==4.8.0


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `nltk` `3.9.2` → `3.9.4`
**Manifest:** `open-security-data/requirements.txt`
**Severity:** critical
**Advisories:** CVE-2025-14009, CVE-2026-0846, CVE-2026-0847, CVE-2026-0848, CVE-2026-33230, CVE-2026-33231

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `4c0d764bda178c9f` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"4c0d764bda178c9f","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->