### PR TITLE
Bump aiohttp to 3.14.1 (medium)

### DIFF
--- a/open-security-sensor/requirements.txt
+++ b/open-security-sensor/requirements.txt
@@ -2,7 +2,7 @@
 
 # Core dependencies
 asyncio-mqtt==0.16.2
-aiohttp==3.14.0
+aiohttp==3.14.1
 aiohttp-cors==0.7.0
 PyYAML==6.0.2
 psutil==6.1.1


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.14.0` → `3.14.1`
**Manifest:** `open-security-sensor/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-54273, CVE-2026-54274, CVE-2026-54275, CVE-2026-54276, CVE-2026-54277, CVE-2026-54278, CVE-2026-54279, CVE-2026-54280

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `85856266e22e910f` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"85856266e22e910f","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->