### PR TITLE
Bump aiohttp to 3.14.1 (medium)

### DIFF
--- a/open-security-tools/requirements.txt
+++ b/open-security-tools/requirements.txt
@@ -19,7 +19,7 @@ python-whois==0.9.4
 python-nmap==0.7.1
 
 # Web vulnerability scanning dependencies
-aiohttp==3.14.0
+aiohttp==3.14.1
 beautifulsoup4==4.12.3
 requests==2.33.0
 


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.14.0` → `3.14.1`
**Manifest:** `open-security-tools/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-54273, CVE-2026-54274, CVE-2026-54275, CVE-2026-54276, CVE-2026-54277, CVE-2026-54278, CVE-2026-54279, CVE-2026-54280

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `2add416d8c3531c3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"2add416d8c3531c3","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->