### PR TITLE
Bump aiohttp to 3.14.1 (medium)

### DIFF
--- a/open-security-cspm/requirements.txt
+++ b/open-security-cspm/requirements.txt
@@ -59,7 +59,7 @@ pyyaml==6.0.1
 
 # HTTP clients
 httpx==0.25.2
-aiohttp==3.14.0
+aiohttp==3.14.1
 
 # Security utilities
 cryptography==46.0.7


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.14.0` → `3.14.1`
**Manifest:** `open-security-cspm/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-54273, CVE-2026-54274, CVE-2026-54275, CVE-2026-54276, CVE-2026-54277, CVE-2026-54278, CVE-2026-54279, CVE-2026-54280

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `5a08dffd87e7c562` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"5a08dffd87e7c562","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->