### PR TITLE
Bump aiohttp to 3.14.1 (medium)

### DIFF
--- a/open-security-data/requirements.txt
+++ b/open-security-data/requirements.txt
@@ -10,7 +10,7 @@ psycopg2-binary==2.9.9
 alembic==1.12.1
 
 # Async HTTP client
-aiohttp==3.14.0
+aiohttp==3.14.1
 aiofiles==23.2.0
 
 # Data processing


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.14.0` → `3.14.1`
**Manifest:** `open-security-data/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-54273, CVE-2026-54274, CVE-2026-54275, CVE-2026-54276, CVE-2026-54277, CVE-2026-54278, CVE-2026-54279, CVE-2026-54280

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `251d3efd1e5fc001` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"251d3efd1e5fc001","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->