### PR TITLE
ci: de-rot CI — trivy pin, pyOpenSSL/cryptography, postgres secret

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,9 +31,12 @@ jobs:
       postgres:
         image: postgres:15
         env:
-          POSTGRES_PASSWORD: ${{ secrets.CI_POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           POSTGRES_USER: wildbox
           POSTGRES_DB: wildbox
+          # Allow startup even when the secret is empty (e.g. fork PRs from the
+          # fabgpt bot, which never receive repo secrets). Ephemeral CI DB only.
+          POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -81,7 +84,7 @@ jobs:
 
       - name: Start API services in background
         env:
-          DATABASE_URL: postgresql://wildbox:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/wildbox
+          DATABASE_URL: postgresql://wildbox:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/wildbox
           REDIS_URL: redis://localhost:6379/0
           JWT_SECRET_KEY: ${{ secrets.CI_JWT_SECRET_KEY }}
           API_KEY: ${{ secrets.CI_API_KEY }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -86,8 +86,8 @@ jobs:
         env:
           DATABASE_URL: postgresql://wildbox:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/wildbox
           REDIS_URL: redis://localhost:6379/0
-          JWT_SECRET_KEY: ${{ secrets.CI_JWT_SECRET_KEY }}
-          API_KEY: ${{ secrets.CI_API_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          API_KEY: ${{ secrets.API_KEY }}
         run: |
           # Start each service in background on different ports
           # Identity Service

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,8 +15,8 @@ env:
   # For initial setup, generate random values with: openssl rand -hex 32
   JWT_SECRET_KEY: ${{ secrets.CI_JWT_SECRET_KEY }}
   API_KEY: ${{ secrets.CI_API_KEY }}
-  POSTGRES_PASSWORD: ${{ secrets.CI_POSTGRES_PASSWORD }}
-  DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.CI_POSTGRES_PASSWORD }}@postgres:5432/identity
+  POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+  DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/identity
   REDIS_URL: redis://redis:6379/0
   GATEWAY_INTERNAL_SECRET: ${{ secrets.CI_GATEWAY_INTERNAL_SECRET }}
   N8N_BASIC_AUTH_USER: admin
@@ -35,8 +35,11 @@ jobs:
         image: postgres:15
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ${{ secrets.CI_POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           POSTGRES_DB: identity
+          # Allow startup even when the secret is empty (e.g. fork PRs from the
+          # fabgpt bot, which never receive repo secrets). Ephemeral CI DB only.
+          POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -103,7 +106,7 @@ jobs:
           cd open-security-identity
           alembic upgrade head
         env:
-          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/identity
+          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
 
       - name: Start Identity Service
         run: |
@@ -112,7 +115,7 @@ jobs:
           IDENTITY_PID=$!
           echo "IDENTITY_PID=$IDENTITY_PID" >> $GITHUB_ENV
         env:
-          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/identity
+          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
           REDIS_URL: redis://localhost:6379/0
           JWT_SECRET_KEY: ${{ secrets.CI_JWT_SECRET_KEY }}
           CREATE_INITIAL_ADMIN: "false"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,16 +13,16 @@ env:
   # SECURITY: All secrets sourced from GitHub Secrets.
   # Configure these in repo Settings > Secrets and variables > Actions.
   # For initial setup, generate random values with: openssl rand -hex 32
-  JWT_SECRET_KEY: ${{ secrets.CI_JWT_SECRET_KEY }}
-  API_KEY: ${{ secrets.CI_API_KEY }}
+  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+  API_KEY: ${{ secrets.API_KEY }}
   POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
   DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/identity
   REDIS_URL: redis://redis:6379/0
-  GATEWAY_INTERNAL_SECRET: ${{ secrets.CI_GATEWAY_INTERNAL_SECRET }}
+  GATEWAY_INTERNAL_SECRET: ${{ secrets.GATEWAY_INTERNAL_SECRET }}
   N8N_BASIC_AUTH_USER: admin
-  N8N_BASIC_AUTH_PASSWORD: ${{ secrets.CI_N8N_PASSWORD }}
-  GRAFANA_ADMIN_PASSWORD: ${{ secrets.CI_GRAFANA_PASSWORD }}
-  NEXTAUTH_SECRET: ${{ secrets.CI_NEXTAUTH_SECRET }}
+  N8N_BASIC_AUTH_PASSWORD: ${{ secrets.N8N_BASIC_AUTH_PASSWORD }}
+  GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+  NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
 
 jobs:
   integration-tests:
@@ -117,7 +117,7 @@ jobs:
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
           REDIS_URL: redis://localhost:6379/0
-          JWT_SECRET_KEY: ${{ secrets.CI_JWT_SECRET_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
           CREATE_INITIAL_ADMIN: "false"
 
       - name: Install Tools Service Dependencies
@@ -132,7 +132,7 @@ jobs:
           TOOLS_PID=$!
           echo "TOOLS_PID=$TOOLS_PID" >> $GITHUB_ENV
         env:
-          API_KEY: ${{ secrets.CI_API_KEY }}
+          API_KEY: ${{ secrets.API_KEY }}
           REDIS_URL: redis://localhost:6379/2
 
       - name: Wait for all services to be healthy
@@ -160,7 +160,7 @@ jobs:
         env:
           IDENTITY_SERVICE_URL: http://localhost:8001
           TOOLS_SERVICE_URL: http://localhost:8000
-          TEST_API_KEY: ${{ secrets.CI_API_KEY }}
+          TEST_API_KEY: ${{ secrets.API_KEY }}
         timeout-minutes: 10
 
       - name: Upload Test Results

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy security scanner
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy security scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/open-security-data/requirements.txt
+++ b/open-security-data/requirements.txt
@@ -81,7 +81,7 @@ dnspython==2.6.1
 python-whois==0.8.0
 
 # Optional: Certificate parsing
-pyopenssl==24.3.0
+pyOpenSSL==25.3.0
 
 # Optional: ASN lookups
 pyasn==1.6.2

--- a/open-security-data/requirements.txt
+++ b/open-security-data/requirements.txt
@@ -81,7 +81,7 @@ dnspython==2.6.1
 python-whois==0.8.0
 
 # Optional: Certificate parsing
-pyOpenSSL==25.3.0
+pyOpenSSL==26.0.0
 
 # Optional: ASN lookups
 pyasn==1.6.2

--- a/open-security-tools/requirements-secure.txt
+++ b/open-security-tools/requirements-secure.txt
@@ -24,7 +24,7 @@ requests==2.33.0
 
 # SSL/TLS analysis dependencies - Latest secure
 cryptography==46.0.5
-pyOpenSSL==25.3.0
+pyOpenSSL==26.0.0
 
 # Additional security and performance - Latest secure
 slowapi==0.1.9

--- a/open-security-tools/requirements-secure.txt
+++ b/open-security-tools/requirements-secure.txt
@@ -24,7 +24,7 @@ requests==2.33.0
 
 # SSL/TLS analysis dependencies - Latest secure
 cryptography==46.0.5
-pyOpenSSL==25.1.0
+pyOpenSSL==25.3.0
 
 # Additional security and performance - Latest secure
 slowapi==0.1.9

--- a/open-security-tools/requirements.txt
+++ b/open-security-tools/requirements.txt
@@ -25,7 +25,7 @@ requests==2.33.0
 
 # SSL/TLS analysis dependencies
 cryptography==46.0.5
-pyOpenSSL==25.3.0
+pyOpenSSL==26.0.0
 
 # Additional security and performance
 slowapi==0.1.9

--- a/open-security-tools/requirements.txt
+++ b/open-security-tools/requirements.txt
@@ -25,7 +25,7 @@ requests==2.33.0
 
 # SSL/TLS analysis dependencies
 cryptography==46.0.5
-pyOpenSSL==24.3.0
+pyOpenSSL==25.3.0
 
 # Additional security and performance
 slowapi==0.1.9


### PR DESCRIPTION
Fixes the **pre-existing CI-rot** failures on `main` (unrelated to any code change).

### 1. `Security Scan` / Trivy — unresolvable / rotting action
`pr-validation.yml` pinned `aquasecurity/trivy-action@0.28.0`; the action now only publishes **v-prefixed** tags, and even `@v0.28.0` rots because its internal `setup-trivy@v0.2.1` was removed. Bumped to **`@v0.36.0`** (latest; SHA-pins `setup-trivy@v0.2.6`). Also pinned `test.yml`'s `@master` → `@v0.36.0`. → **`Security Scan` / `Security Scanning` jobs green** (Trivy now actually runs and uploads SARIF — see note below).

### 2. pip `ResolutionImpossible` — pyOpenSSL caps cryptography
`pyopenssl 24.3.0` caps `cryptography<45`, conflicting with the repo's `cryptography==46.0.5`. Bumped to **`pyOpenSSL==26.0.0`** (`requires cryptography<47,>=46.0.0` → accepts 46.0.5; verified resolving in a clean venv) in `open-security-tools/requirements.txt` + `requirements-secure.txt` + `open-security-data/requirements.txt` (the last was a lowercase `pyopenssl==24.3.0` a case-sensitive grep had missed). Landed on **26.0.0** rather than 25.3.0 because Trivy (now running) flagged `CVE-2026-27459` (HIGH) in 25.3.0, fixed in 26.0.0. → **All Unit Tests green.**

### 3. `Integration Tests` / `Deploy Docs` — services won't start (wrong secret names)
The workflows referenced `CI_`-prefixed secret names, but the repo's configured secrets are **unprefixed** → all empty → postgres "superuser password not specified", then identity `jwt_secret_key` min-length error. Renamed every reference to its configured secret (`CI_POSTGRES_PASSWORD`→`POSTGRES_PASSWORD`, `CI_JWT_SECRET_KEY`→`JWT_SECRET_KEY`, `CI_API_KEY`→`API_KEY`, `CI_GATEWAY_INTERNAL_SECRET`→`GATEWAY_INTERNAL_SECRET`, `CI_N8N_PASSWORD`→`N8N_BASIC_AUTH_PASSWORD`, `CI_NEXTAUTH_SECRET`→`NEXTAUTH_SECRET`), and added **`POSTGRES_HOST_AUTH_METHOD: trust`** to both postgres services so they also start on the fabgpt bot's **fork PRs** (which never receive repo secrets; ephemeral CI DB — no security impact). → Integration infra now healthy: services start, DB/Redis connect, **14/18 integration tests pass** (was: total failure).

> **Note — the `Trivy` code-scanning check:** this is GitHub Advanced Security, *not* a workflow, and its appearance is a side-effect of #1 working — Trivy can now run and upload SARIF. Any remaining `Trivy` alerts are pre-existing baseline findings on unchanged lines (see #100), not introduced by this PR.

---

### Out of scope — real (non-rot) bugs uncovered, tracked separately
- #97 — docker-compose `data-test` crashes (`create_engine('')`: reads `DATABASE_URL`, compose sets only `DATA_DATABASE_URL`)
- #98 — integration-tests.yml: 2 real failures (registration 500 "Billing service configuration error" with Stripe unset; `/metrics` 403≠200)
- #99 — E2E Playwright `.next` EACCES (docker dashboard never binds :3000 → Playwright self-starts → root-owned `.next`)
- #100 — pre-existing `cryptography==46.0.5` CVEs in tools/data (rest of repo already on 46.0.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)