### PR TITLE
fix(identity): optional billing + correct registration session + metrics test (#98)

### DIFF
--- a/open-security-identity/app/billing.py
+++ b/open-security-identity/app/billing.py
@@ -33,7 +33,7 @@ class StripeBillingService:
             }
         }
     
-    async def create_customer(self, user: User) -> str:
+    async def create_customer(self, user: User) -> Optional[str]:
         """
         Create a Stripe customer for the user.
         
@@ -46,6 +46,13 @@ class StripeBillingService:
         Raises:
             HTTPException: If Stripe operation fails
         """
+        # Billing is optional. When Stripe is not configured (a self-hosted
+        # instance without billing, or CI), skip customer creation rather than
+        # failing user registration — callers treat a None customer id as "free
+        # tier, no billing".
+        if not settings.stripe_secret_key:
+            return None
+
         try:
             customer = stripe.Customer.create(
                 email=user.email,

--- a/open-security-identity/app/user_manager.py
+++ b/open-security-identity/app/user_manager.py
@@ -78,14 +78,17 @@ class UserManager(BaseUserManager[User, uuid.UUID]):
             logger.warning("No database session found in request state")
             return
             
-        db: AsyncSession = request.state.db
+        # Use fastapi-users' own session — the one `user` is attached to.
+        # request.state.db is a *separate* session (set by db_session_middleware);
+        # adding the already-attached `user` to it raises InvalidRequestError.
+        db: AsyncSession = self.user_db.session
 
         # Crea Stripe customer
         try:
             stripe_customer_id = await billing_service.create_customer(user)
-            user.stripe_customer_id = stripe_customer_id
-            db.add(user)
-        except (ValueError, KeyError, TypeError, ConnectionError, TimeoutError) as e:
+            if stripe_customer_id:
+                user.stripe_customer_id = stripe_customer_id
+        except Exception as e:  # noqa: BLE001 - billing must never block signup
             logger.warning(f"Failed to create Stripe customer for {user.email}: {e}")
 
         # Crea team con l'utente come owner

--- a/tests/integration/test_ci_integration.py
+++ b/tests/integration/test_ci_integration.py
@@ -24,12 +24,24 @@ def test_identity_health(service_urls: Dict[str, str]):
 @pytest.mark.integration
 @pytest.mark.smoke
 def test_identity_metrics(service_urls: Dict[str, str]):
-    """Test identity service metrics endpoint"""
-    response = requests.get(f"{service_urls['identity']}/metrics", timeout=10)
+    """Test identity service metrics endpoint (gateway-secret protected)."""
+    import os
+    # /metrics exposes user/team counts, so it is gated behind the gateway
+    # secret. Authenticate with the same secret the service was started with.
+    gateway_secret = os.environ.get("GATEWAY_INTERNAL_SECRET", "")
+    if not gateway_secret:
+        pytest.skip("GATEWAY_INTERNAL_SECRET not set (e.g. fork PR without secrets)")
+    response = requests.get(
+        f"{service_urls['identity']}/metrics",
+        headers={"X-Gateway-Secret": gateway_secret},
+        timeout=10,
+    )
     assert response.status_code == 200
-    
+
     data = response.json()
-    assert data.get("service") == "identity"
+    # Success path reports the human app name; the DB-unavailable fallback
+    # reports the "identity" slug — accept either.
+    assert "identity" in data.get("service", "").lower()
     assert "metrics" in data
     assert "timestamp" in data
     


### PR DESCRIPTION
**Stacked on #101 → #96.** Makes `integration-tests.yml` fully green (**16 passed, 2 skipped**, verified via dispatch). Three real (non-rot) bugs, peeled one after another:

1. **Billing was mandatory.** Registration 500'd with *"Billing service configuration error"* whenever Stripe was unconfigured — `create_customer` raised `HTTPException` on Stripe's `AuthenticationError`, which the call sites didn't catch. Billing is now **optional**: `create_customer` returns `None` when `stripe_secret_key` is unset, and the hook never lets a billing hiccup block signup. Correct for any self-hosted instance.

2. **Cross-session registration bug.** With billing no longer short-circuiting, `on_after_register` reached team/subscription creation for the first time and 500'd (*"Internal server error"*). It used `request.state.db` — a **separate** session from the one fastapi-users created `user` in — so `db.add(user)` raised `InvalidRequestError`. Fixed to use `self.user_db.session`.

3. **Stale `/metrics` test.** `test_identity_metrics` called the (gateway-secret-gated) endpoint with no auth → 403, and asserted `service == "identity"` while the success path returns the app display name. Test now sends `X-Gateway-Secret` and asserts tolerantly; skips when the secret is absent (fork PRs).

Closes #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)