### PR TITLE
ci(e2e): decouple Playwright into a reliable frontend smoke (#99)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,63 +80,22 @@ jobs:
           cd open-security-dashboard
           npx playwright install --with-deps chromium
       
-      - name: Create CI environment file
-        run: |
-          cat > .env << 'EOF'
-          POSTGRES_USER=postgres
-          POSTGRES_PASSWORD=postgres
-          POSTGRES_DB=identity
-          DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/identity
-          DATA_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/data
-          GUARDIAN_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/guardian
-          RESPONDER_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/responder
-          REDIS_URL=redis://wildbox-redis:6379/0
-          JWT_SECRET_KEY=ci-test-jwt-secret-key-not-for-production
-          NEXTAUTH_SECRET=ci-test-nextauth-secret-not-for-production
-          INITIAL_ADMIN_EMAIL=superadmin@wildbox.com
-          INITIAL_ADMIN_PASSWORD=wildbox123
-          CREATE_INITIAL_ADMIN=true
-          GATEWAY_INTERNAL_SECRET=ci-test-gateway-secret-not-for-production
-          API_KEY=ci-test-api-key-not-for-production
-          OPENAI_API_KEY=sk-test-not-a-real-key
-          EOF
-      
-      - name: Start services
-        run: |
-          # Start infrastructure services first
-          docker compose up -d postgres wildbox-redis
-          echo "Waiting for PostgreSQL to be ready..."
-          sleep 20
-          
-          # Create additional databases needed by services
-          docker exec wildbox-postgres psql -U postgres -c "CREATE DATABASE data;" || true
-          docker exec wildbox-postgres psql -U postgres -c "CREATE DATABASE guardian;" || true
-          docker exec wildbox-postgres psql -U postgres -c "CREATE DATABASE responder;" || true
-          
-          # Now start all remaining services
-          docker compose up -d
-          echo "Waiting for services to initialize..."
-          sleep 60
-          
-          # Wait for dashboard to be ready
-          echo "Checking dashboard health..."
-          timeout 120 bash -c 'until curl -s http://localhost:3000 > /dev/null; do echo "Waiting for dashboard..."; sleep 5; done' || echo "Dashboard may not be ready"
-          
-          # Wait for identity service
-          echo "Checking identity service..."
-          timeout 60 bash -c 'until curl -s http://localhost:8001/health > /dev/null; do echo "Waiting for identity..."; sleep 5; done' || echo "Identity may not be ready"
-          
-          # Wait for gateway
-          echo "Checking gateway..."
-          timeout 60 bash -c 'until curl -s http://localhost/health > /dev/null; do echo "Waiting for gateway..."; sleep 5; done' || echo "Gateway may not be ready"
-          
-          echo "Services should be ready for testing"
-      
-      - name: Run Playwright tests
+      - name: Build dashboard
         run: |
           cd open-security-dashboard
-          npx playwright test --project=chromium
-      
+          npm run build
+
+      - name: Run Playwright frontend smoke tests
+        run: |
+          cd open-security-dashboard
+          # Frontend-only smoke: these specs are backend-free by design (they
+          # assert the dashboard builds, the login UI renders, form validation,
+          # and the client-side auth-guard redirects). Backend-dependent E2E
+          # flows are tracked separately (the full stack was consolidated out).
+          npx playwright test --project=chromium \
+            tests/e2e/admin-ui-only.spec.ts \
+            tests/e2e/quick-login-test.spec.ts
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: always()
@@ -144,10 +103,6 @@ jobs:
           name: playwright-report
           path: open-security-dashboard/playwright-report/
           retention-days: 30
-      
-      - name: Stop services
-        if: always()
-        run: docker compose down -v
 
   security-scan:
     name: Security Scanning

--- a/open-security-dashboard/playwright.config.ts
+++ b/open-security-dashboard/playwright.config.ts
@@ -73,11 +73,13 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
+  /* Playwright manages the dashboard server itself.
+     In CI we build first (see workflow) and serve the production build;
+     locally we use the dev server and reuse one if it's already running. */
   webServer: {
-    command: 'npm run dev',
+    command: process.env.CI ? 'npm run start' : 'npm run dev',
     url: 'http://localhost:3000',
-    reuseExistingServer: true, // Always reuse in CI since docker-compose starts services
+    reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes
   },
 });

--- a/open-security-dashboard/tests/e2e/admin-ui-only.spec.ts
+++ b/open-security-dashboard/tests/e2e/admin-ui-only.spec.ts
@@ -65,7 +65,7 @@ test.describe('Admin UI Testing (Without Backend)', () => {
 
     // Go directly to admin page (will be redirected to login if no auth)
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Check if we're redirected to login or if we access dashboard directly
     if (page.url().includes('/auth/login')) {
@@ -84,7 +84,7 @@ test.describe('Admin UI Testing (Without Backend)', () => {
 
     // Go directly to dashboard page
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Should be redirected to login page if not authenticated
     if (page.url().includes('/auth/login')) {

--- a/open-security-dashboard/tests/e2e/page-objects/admin-page.ts
+++ b/open-security-dashboard/tests/e2e/page-objects/admin-page.ts
@@ -25,7 +25,7 @@ export class AdminPage {
 
   async goto() {
     await this.page.goto('/admin');
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async waitForAdminPageLoad() {

--- a/open-security-dashboard/tests/e2e/page-objects/dashboard-page.ts
+++ b/open-security-dashboard/tests/e2e/page-objects/dashboard-page.ts
@@ -17,7 +17,7 @@ export class DashboardPage {
 
   async goto() {
     await this.page.goto('/dashboard');
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async waitForDashboardLoad() {
@@ -38,7 +38,7 @@ export class DashboardPage {
         const link = this.page.locator(selector).first();
         if (await link.isVisible({ timeout: 2000 })) {
           await link.click();
-          await this.page.waitForLoadState('networkidle');
+          await this.page.waitForLoadState('domcontentloaded');
           return;
         }
       } catch {
@@ -52,7 +52,7 @@ export class DashboardPage {
       const text = await item.textContent();
       if (text && text.toLowerCase().includes(pageName.toLowerCase())) {
         await item.click();
-        await this.page.waitForLoadState('networkidle');
+        await this.page.waitForLoadState('domcontentloaded');
         return;
       }
     }

--- a/open-security-dashboard/tests/e2e/page-objects/login-page.ts
+++ b/open-security-dashboard/tests/e2e/page-objects/login-page.ts
@@ -19,7 +19,7 @@ export class LoginPage {
 
   async goto() {
     await this.page.goto('/auth/login');
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async login(email: string, password: string) {


### PR DESCRIPTION
**Stacked on #102 → #101 → #96.** E2E (Playwright) had **never passed** — it booted the full docker stack (the same one consolidated out for integration) and relied on the dockerized dashboard serving :3000; when it didn't, Playwright fell back to `npm run dev` and hit a **root-owned `.next`** (compose bind-mount + anonymous `/app/.next` volume) → `EACCES`.

### Change — self-contained frontend smoke
- **Playwright owns the server**: build the dashboard, then `npm run start` (`reuseExistingServer=false` in CI). No docker, no root-owned `.next`.
- Run only the **backend-free** specs (`admin-ui-only` — 6 UI tests — + `quick-login-test`): they assert the dashboard builds, the login UI renders, form validation, and the client-side auth-guard redirects.
- Replaced the `networkidle` waits (a documented Playwright anti-pattern) with `domcontentloaded` in the smoke path — the login page keeps a request pending with no backend, so `networkidle` never settled.

**Verified green: `7 passed (10.1s)`** (dispatch run on the branch).

### Deferred (tracked)
Backend-dependent E2E flows (login→dashboard, admin-comprehensive, settings, threat-intel) need a real full-stack harness → **#103** (also notes a `next/font` build-hardening item).

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)