### PR TITLE
fix(gateway): real X-Gateway-Secret + correct identity port (security boundary)

### DIFF
--- a/open-security-gateway/docker-compose.yml
+++ b/open-security-gateway/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - WILDBOX_ENV=${WILDBOX_ENV:-development}
       - GATEWAY_LOG_LEVEL=${GATEWAY_LOG_LEVEL:-info}
       # Authentication service configuration (Blueprint Phase 1 requirements)
-      - IDENTITY_SERVICE_URL=${IDENTITY_SERVICE_URL:-http://open-security-identity:8000}
+      - IDENTITY_SERVICE_URL=${IDENTITY_SERVICE_URL:-http://open-security-identity:8001}
       - GATEWAY_INTERNAL_SECRET=${GATEWAY_INTERNAL_SECRET:?Set GATEWAY_INTERNAL_SECRET in .env}
       - AUTH_CACHE_TTL=${AUTH_CACHE_TTL:-300}
       - GATEWAY_DEBUG=${GATEWAY_DEBUG:-false}

--- a/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
+++ b/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
@@ -377,6 +377,7 @@ server {
                 }),
                 headers = {
                     ["Content-Type"] = "application/json",
+                    ["X-Gateway-Secret"] = os.getenv("GATEWAY_INTERNAL_SECRET") or "",
                 }
             })
             

--- a/open-security-gateway/nginx/lua/auth_handler.lua
+++ b/open-security-gateway/nginx/lua/auth_handler.lua
@@ -42,7 +42,7 @@ local function get_config()
         -- Build config from environment variables (Blueprint security requirement)
         local config = {
             identity_service_url = os.getenv("IDENTITY_SERVICE_URL") or "http://open-security-identity:8001",
-            gateway_secret = os.getenv("GATEWAY_INTERNAL_SECRET") or ngx.log(ngx.ERR, "GATEWAY_INTERNAL_SECRET not set"),
+            gateway_secret = os.getenv("GATEWAY_INTERNAL_SECRET") or "",
             cache_ttl = tonumber(os.getenv("AUTH_CACHE_TTL")) or CACHE_TTL,
             debug_mode = os.getenv("GATEWAY_DEBUG") == "true"
         }

--- a/open-security-gateway/nginx/nginx.conf
+++ b/open-security-gateway/nginx/nginx.conf
@@ -141,17 +141,11 @@ http {
         require "utils"
         require "auth_handler"
         
-        -- Global configuration
-        local config = {
-            identity_service_url = "http://open-security-identity:8001",
-            auth_cache_ttl = 300, -- 5 minutes
-            rate_limit_window = 3600, -- 1 hour
-            log_level = os.getenv("GATEWAY_LOG_LEVEL") or "info"
-        }
-        
-        -- Store config in shared dict
-        local config_cache = ngx.shared.config_cache
-        config_cache:set("gateway_config", require("cjson").encode(config))
+        -- NOTE: do NOT pre-seed config_cache here. Gateway configuration
+        -- (incl. GATEWAY_INTERNAL_SECRET) is built lazily from environment
+        -- variables in auth_handler.get_config() on the first request; a
+        -- partial config without `gateway_secret` would shadow that build and
+        -- make the gateway send an empty X-Gateway-Secret to identity.
         
         ngx.log(ngx.INFO, "Wildbox Security Gateway initialized")
     }


### PR DESCRIPTION
Fixes the gateway's **internal-auth trust boundary**, which was effectively broken (audit 🔴 #1 for gateway).

### Root cause + fixes
1. **`X-Gateway-Secret` was always empty.** `nginx.conf` `init_by_lua_block` pre-seeded `config_cache["gateway_config"]` with a config that had **no `gateway_secret` key**, so `auth_handler.get_config()` short-circuited on the cache hit and its env-var branch (the "Blueprint security requirement" reading `GATEWAY_INTERNAL_SECRET`) never ran → `config.gateway_secret = nil` → every `/internal/authorize` call sent an empty secret. **Removed the pre-seed** → config is built lazily from env (with the secret).
2. **`auth_handler.lua`** `gateway_secret = os.getenv(...) or ngx.log(...)` returned `nil` when unset → now `or ""` (consistent with the fallback branch).
3. **Agents route** (`wildbox_gateway.conf`) called `/internal/authorize` with **no** `X-Gateway-Secret` — added it.
4. **`docker-compose.yml`** defaulted `IDENTITY_SERVICE_URL` to **:8000**; identity listens on **:8001** → gateway couldn't reach it (503 on every protected route). Fixed.

### ⚠️ Verification gap
The gateway is OpenResty/Lua and has **no CI coverage** — it's not in the Python unit-test matrix, and there's no auth integration test. So green CI here only means *nothing else broke*; the gateway behavior itself is verified by **analysis + `luac` syntax check only**. Filing a follow-up for a real gateway auth integration test. If you want hard verification before merge, I can spin up Docker Desktop and smoke-test gateway→identity locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)