### PR TITLE
fix: stop data/agents/responder crash-looping at startup on missing config

### DIFF
--- a/open-security-agents/app/agents/threat_enrichment_agent.py
+++ b/open-security-agents/app/agents/threat_enrichment_agent.py
@@ -309,5 +309,14 @@ Verdict:"""
             }
 
 
-# Global agent instance
-threat_enrichment_agent = ThreatEnrichmentAgent()
+# Lazily-built agent instance: constructing it builds the LLM + agent graph
+# (which needs OPENAI_API_KEY), so defer until first use. This lets the worker
+# import without the key set instead of crash-looping at import.
+_agent_instance = None
+
+
+def get_threat_enrichment_agent() -> ThreatEnrichmentAgent:
+    global _agent_instance
+    if _agent_instance is None:
+        _agent_instance = ThreatEnrichmentAgent()
+    return _agent_instance

--- a/open-security-agents/app/config.py
+++ b/open-security-agents/app/config.py
@@ -17,8 +17,9 @@ class Settings(BaseSettings):
     debug: bool = False
     log_level: str = "INFO"
     
-    # OpenAI Configuration
-    openai_api_key: str
+    # OpenAI Configuration (optional — the worker imports without it; analysis
+    # tasks fail gracefully when it's missing instead of crash-looping at boot)
+    openai_api_key: Optional[str] = None
     openai_model: str = "gpt-4o"
     openai_temperature: float = 0.1
     openai_base_url: Optional[str] = None  # Override for local LLM (e.g., vLLM container)

--- a/open-security-agents/app/worker.py
+++ b/open-security-agents/app/worker.py
@@ -13,7 +13,7 @@ from celery import Celery
 import redis
 
 from .config import settings
-from .agents.threat_enrichment_agent import threat_enrichment_agent
+from .agents.threat_enrichment_agent import get_threat_enrichment_agent
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -94,7 +94,7 @@ def run_threat_enrichment_task(self, task_id: str, ioc: Dict[str, Any]) -> Dict[
             
             # Execute the analysis
             result = loop.run_until_complete(
-                threat_enrichment_agent.analyze_ioc(ioc)
+                get_threat_enrichment_agent().analyze_ioc(ioc)
             )
             
             # Set the task_id in the result
@@ -164,7 +164,7 @@ def health_check_task() -> Dict[str, Any]:
         redis_client.ping()
         
         # Test AI agent initialization
-        agent_status = "healthy" if threat_enrichment_agent else "unhealthy"
+        agent_status = "healthy" if settings.openai_api_key else "unhealthy"
         
         return {
             "status": "healthy",

--- a/open-security-data/app/utils/database.py
+++ b/open-security-data/app/utils/database.py
@@ -11,40 +11,65 @@ from app.config import get_config
 
 config = get_config()
 
-# Create database engine
-engine = create_engine(
-    config.database.url,
-    pool_size=config.database.pool_size,
-    max_overflow=config.database.max_overflow,
-    pool_timeout=config.database.pool_timeout,
-    pool_pre_ping=True,
-    echo=config.database.echo,
-    poolclass=StaticPool if "sqlite" in config.database.url else None,
-    connect_args={"check_same_thread": False} if "sqlite" in config.database.url else {}
-)
+# Lazy engine/session: built on first use so this module imports cleanly even
+# when DATABASE_URL is unset (CLI, tests, partial env) instead of crashing at
+# import time on create_engine("").
+_engine = None
+_SessionLocal = None
 
-# Create session factory
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def _init_engine():
+    global _engine, _SessionLocal
+    if _engine is None:
+        url = config.database.url
+        if not url:
+            raise RuntimeError(
+                "DATABASE_URL is not set — configure it before accessing the database."
+            )
+        is_sqlite = "sqlite" in url
+        _engine = create_engine(
+            url,
+            pool_size=config.database.pool_size,
+            max_overflow=config.database.max_overflow,
+            pool_timeout=config.database.pool_timeout,
+            pool_pre_ping=True,
+            echo=config.database.echo,
+            poolclass=StaticPool if is_sqlite else None,
+            connect_args={"check_same_thread": False} if is_sqlite else {},
+        )
+        _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+    return _engine
+
+
+def get_engine():
+    """Return the lazily-created SQLAlchemy engine."""
+    return _init_engine()
+
 
 def get_db_session() -> Session:
     """Get a database session"""
-    return SessionLocal()
+    _init_engine()
+    return _SessionLocal()
+
 
 @contextmanager
 def get_db():
     """Context manager for database sessions"""
-    db = SessionLocal()
+    _init_engine()
+    db = _SessionLocal()
     try:
         yield db
     finally:
         db.close()
 
+
 def create_tables():
     """Create all database tables"""
     from app.models import Base
-    Base.metadata.create_all(bind=engine)
+    Base.metadata.create_all(bind=get_engine())
+
 
 def drop_tables():
     """Drop all database tables"""
     from app.models import Base
-    Base.metadata.drop_all(bind=engine)
+    Base.metadata.drop_all(bind=get_engine())

--- a/open-security-data/manage.py
+++ b/open-security-data/manage.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.config import get_config
 from app.models import Source, Base
-from app.utils.database import engine, get_db_session, create_tables, drop_tables
+from app.utils.database import get_db_session, create_tables, drop_tables
 from app.collectors.sources import (
     MalwareDomainListCollector, PhishTankCollector, FeodoTrackerCollector,
     ThreatFoxCollector, MalwareBazaarCollector

--- a/open-security-responder/docker-compose.yml
+++ b/open-security-responder/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     environment:
       - DEBUG=${DEBUG:-false}
       # For standalone development (uses local Redis)
-      - REDIS_URL=redis://redis:6379/0
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
       # For integration with main stack, use:
       # - REDIS_URL=redis://wildbox-redis:6379/2
       - WILDBOX_API_URL=http://localhost:8000
@@ -59,7 +59,7 @@ services:
     environment:
       - DEBUG=${DEBUG:-false}
       # For standalone development (uses local Redis)
-      - REDIS_URL=redis://redis:6379/0
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
       # For integration with main stack, use:
       # - REDIS_URL=redis://wildbox-redis:6379/2
       - WILDBOX_API_URL=http://localhost:8000


### PR DESCRIPTION
Three independent "won't boot" bugs (audit 🔴 startup crashes):

- **data** — `app/utils/database.py` built the engine at **import** (`create_engine(config.database.url)`); with `DATABASE_URL` unset that's `create_engine("")` → `ArgumentError`, so the module couldn't be imported at all (blocks CLI/tests). Engine + session are now **lazy** (built on first DB access, clear error if URL missing). Dropped the unused `engine` import from `manage.py`.
- **agents** — `openai_api_key` was a **required** Settings field *and* the agent was instantiated at module top level (imported by `worker.py`) → the Celery worker **crash-looped at import** without `OPENAI_API_KEY`. Key is now `Optional`, agent **lazily built** (`get_threat_enrichment_agent()`); the worker imports without a key and analysis tasks fail gracefully.
- **responder** — compose ran Redis with `--requirepass` but the app + dramatiq worker used a **password-less** `REDIS_URL` → `NOAUTH` at startup. Put the password into `REDIS_URL` for both services.

### Verification
`py_compile` + inspection. These are import-time/boot fixes; the services have **no runtime test that imports without full env**, so the behavior isn't CI-verified — noted as debt (ties into the broader "services lack real tests" theme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)