### PR TITLE
fix(tools): block SSRF in static_malware_analyzer + url_analyzer

### DIFF
--- a/open-security-tools/app/tools/static_malware_analyzer/main.py
+++ b/open-security-tools/app/tools/static_malware_analyzer/main.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Any, Optional
 import aiohttp
 import asyncio
 
+from app.input_validation import InputSanitizer  # SSRF guard (blocks private/metadata targets)
+
 from schemas import (
     StaticMalwareAnalyzerInput,
     StaticMalwareAnalyzerOutput,
@@ -153,6 +155,8 @@ async def execute_tool(data: StaticMalwareAnalyzerInput) -> StaticMalwareAnalyze
 async def download_file(url: str) -> Optional[bytes]:
     """Download file from URL for analysis"""
     try:
+        # SSRF protection: reject private/internal/cloud-metadata targets.
+        InputSanitizer.validate_url(url)
         async with aiohttp.ClientSession() as session:
             async with session.get(url, timeout=30) as response:
                 if response.status == 200:

--- a/open-security-tools/app/tools/url_analyzer/main.py
+++ b/open-security-tools/app/tools/url_analyzer/main.py
@@ -14,6 +14,8 @@ from datetime import datetime
 import time
 import re
 
+from app.input_validation import InputSanitizer  # SSRF guard
+
 try:
     from schemas import URLShortenerInput, URLShortenerOutput, RedirectHop, SecurityAnalysis
 except ImportError:
@@ -88,6 +90,8 @@ class URLShortenerAnalyzer:
         custom_timeout = aiohttp.ClientTimeout(total=timeout)
         
         try:
+            # SSRF protection: reject private/internal/cloud-metadata targets.
+            InputSanitizer.validate_url(current_url)
             async with aiohttp.ClientSession(
                 timeout=custom_timeout,
                 connector=connector


### PR DESCRIPTION
Both tools fetched **user-supplied URLs with no SSRF check**, while the service already ships a hardened validator (`InputSanitizer.validate_url`) that `url_security_scanner` uses correctly — these two just didn't call it, so a caller could reach `169.254.169.254`, `localhost`, private ranges, etc.

- `static_malware_analyzer.download_file` — validate `file_url` before fetching (existing `except Exception` → clean no-download on reject).
- `url_analyzer.analyze_url` — validate before the session opens (existing `except (ValueError, …)` → graceful error).

### Verified (functionally, not just inspection)
Ran `InputSanitizer.validate_url` directly (it's stdlib-only): **blocks** `169.254.169.254`, `127.0.0.1`, `localhost`, `10.0.0.5`, `metadata.google.internal`; **allows** `example.com`. Both tools compile.

**Follow-up:** `url_analyzer` follows redirect chains — this guards the user-supplied URL; re-validating each redirect hop (redirect-based SSRF) is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)