### PR TITLE
fix(agents): close SSRF via tool-name path fallback + flag missing internal key

### DIFF
--- a/open-security-agents/app/tools/wildbox_client.py
+++ b/open-security-agents/app/tools/wildbox_client.py
@@ -35,7 +35,12 @@ class WildboxAPIClient:
         self.guardian_url = settings.wildbox_guardian_url
         self.responder_url = settings.wildbox_responder_url
         self.api_key = settings.internal_api_key
-        
+        if not self.api_key:
+            logger.warning(
+                "INTERNAL_API_KEY is not set — internal tool calls will go out "
+                "without an X-API-Key and be rejected by the backend services."
+            )
+
         # HTTP client configuration
         self.timeout = httpx.Timeout(30.0, connect=10.0)
         self.headers = {
@@ -56,13 +61,16 @@ class WildboxAPIClient:
             Tool execution results
         """
         try:
-            # Get endpoint mapping
-            if tool_name not in self.TOOL_ENDPOINT_MAP:
-                logger.warning(f"No endpoint mapping for tool '{tool_name}', using default")
-                endpoint_name = tool_name
-                param_mapping = {}
-            else:
-                endpoint_name, param_mapping = self.TOOL_ENDPOINT_MAP[tool_name]
+            # SSRF protection: only call explicitly-allowlisted tool endpoints.
+            # An LLM-chosen (or prompt-injected) tool_name must never become a
+            # raw URL path component — f"{api_url}/api/tools/{tool_name}" would
+            # otherwise let a crafted IOC steer the agent to arbitrary internal
+            # paths. Reject anything not in the fixed endpoint map.
+            mapping = self.TOOL_ENDPOINT_MAP.get(tool_name)
+            if mapping is None:
+                logger.warning(f"Rejected unmapped tool '{tool_name}' (not in allowlist)")
+                return {"error": f"Unknown tool: {tool_name}", "success": False}
+            endpoint_name, param_mapping = mapping
             
             # Transform parameters according to mapping
             transformed_params = {}


### PR DESCRIPTION
The threat-enrichment agent is an autonomous tool-caller driven by an attacker-influenceable IOC value. `wildbox_client.run_tool` fell back to using **any** `tool_name` the agent chose as a raw URL path — `f"{api_url}/api/tools/{tool_name}"` — when it wasn't in `TOOL_ENDPOINT_MAP`. A prompt-injected IOC could therefore steer the agent to arbitrary internal paths (audit 🔴 prompt-injection→SSRF).

### Fix
- `run_tool` now **rejects** any `tool_name` not in the fixed `TOOL_ENDPOINT_MAP` allowlist (returns an error) — the path segment is always an allowlisted endpoint string (`whois_lookup`, `dns_enumerator`, …).
- Warn at client init when `INTERNAL_API_KEY` is unset (was silently sending an empty `X-API-Key`).

### Verification
Inspection + `py_compile`: the only `/api/tools/{…}` construction now interpolates the allowlisted `endpoint_name`; the other two service URLs are fixed paths. IOC values are already character-whitelisted before reaching the prompt — the allowlist is the load-bearing defense against injection→tool-abuse.

**Deferred (tracked):** the agents service still uses OpenAI (via LangChain) instead of the platform-standard Claude — see follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)