### PR TITLE
fix(identity): stop 3 user endpoints 500ing on TeamMembership fields

### DIFF
--- a/open-security-identity/app/api_v1/endpoints/users.py
+++ b/open-security-identity/app/api_v1/endpoints/users.py
@@ -717,8 +717,8 @@ async def get_my_activity_log(
             {
                 "team_id": str(m.team_id),
                 "team_name": m.team.name,
-                "role": m.role.value,
-                "joined_at": m.created_at
+                "role": m.role,
+                "joined_at": m.joined_at
             }
             for m in memberships.scalars()
         ],
@@ -781,7 +781,7 @@ async def create_my_api_key(
     team_membership = await db.execute(
         select(TeamMembership)
         .where(TeamMembership.user_id == current_user.id)
-        .order_by(TeamMembership.created_at.asc())
+        .order_by(TeamMembership.joined_at.asc())
     )
     primary_membership = team_membership.scalar_one_or_none()
     
@@ -878,7 +878,7 @@ async def get_team_members(
         select(TeamMembership)
         .options(selectinload(TeamMembership.user))
         .where(TeamMembership.team_id == team_id)
-        .order_by(TeamMembership.created_at.asc())
+        .order_by(TeamMembership.joined_at.asc())
     )
     
     members = []
@@ -886,8 +886,8 @@ async def get_team_members(
         members.append({
             "user_id": str(membership.user_id),
             "team_id": str(membership.team_id),
-            "role": membership.role.value,
-            "joined_at": membership.created_at.isoformat(),
+            "role": membership.role,
+            "joined_at": membership.joined_at.isoformat(),
             "user": {
                 "id": str(membership.user.id),
                 "email": membership.user.email,


### PR DESCRIPTION
`TeamMembership.role` is a `Column(String(50))` (a plain `str`, defaulting to `TeamRole.MEMBER.value`) and the model has a `joined_at` column — **not** `created_at` ([app/models.py:108-111](open-security-identity/app/models.py)). Three endpoints assumed an *enum* role (`.role.value`) and a `created_at` column, so each raised `AttributeError` → **500** on the happy path:

| Endpoint | Bad reference |
|---|---|
| `GET /users/me/activity` | `m.role.value`, `m.created_at` |
| `POST /users/me/api-keys` | `order_by(TeamMembership.created_at)` |
| team-members listing | `.role.value`, `.created_at`, `order_by(...created_at)` |

### Fix
Use the `role` string directly and `joined_at` throughout. Line 99 already did exactly this via an `isinstance(role, str)` guard — the fix just makes the other three call sites consistent with the model.

### Verification
`grep` confirms no `TeamMembership.created_at` / unguarded `.role.value` / `membership.created_at` references remain; `py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)