### PR TITLE
fix(cspm): undefined CheckResult.get_current_timestamp + trending-metrics arity

### DIFF
--- a/open-security-cspm/app/checks/framework.py
+++ b/open-security-cspm/app/checks/framework.py
@@ -49,6 +49,11 @@ class CheckResult(BaseModel):
     compliance_frameworks: List[str] = Field(default_factory=list)
     timestamp: datetime = Field(default_factory=datetime.utcnow)
 
+    @staticmethod
+    def get_current_timestamp() -> str:
+        """ISO-8601 timestamp string for embedding in check evidence/details."""
+        return datetime.utcnow().isoformat()
+
 
 class CheckMetadata(BaseModel):
     """Metadata for a security check."""

--- a/open-security-cspm/app/main.py
+++ b/open-security-cspm/app/main.py
@@ -589,7 +589,7 @@ async def get_dashboard_summary(
         total_skipped = sum(s["summary"].get("skipped", 0) for s in team_scans)
         
         # Get trending metrics
-        trending_metrics = _get_trending_metrics(current_user["team_id"])
+        trending_metrics = _get_trending_metrics(redis_client, "all", current_user["team_id"])
         
         return schemas.DashboardSummaryResponse(
             total_scans=total_scans,


### PR DESCRIPTION
Two guaranteed runtime crashes found in the component audit.

### 1. `CheckResult.get_current_timestamp()` — never defined (AttributeError)
7 check sites across 6 files embed `'check_timestamp': CheckResult.get_current_timestamp()` in their evidence:
AWS root-MFA, password-policy (×2), EBS encryption, SG open-ports; GCP instances-public-IPs; Azure VM-NSGs. `CheckResult` is a Pydantic model ([framework.py:37](open-security-cspm/app/checks/framework.py)) with **no such method**, so every check raises `AttributeError` the moment it builds a finding.

**Fix:** added `get_current_timestamp()` as a `@staticmethod` returning `datetime.utcnow().isoformat()` — one definition, all 7 call sites fixed.

### 2. `_get_trending_metrics` arity — TypeError on dashboard summary
`get_dashboard_summary` called `_get_trending_metrics(current_user["team_id"])` (1 arg), but the function requires `(redis_client, provider, account_id, days=30)` → `TypeError`. The executive-summary endpoint ([main.py:656](open-security-cspm/app/main.py)) already calls it correctly; aligned the summary call to `(redis_client, "all", current_user["team_id"])`.

### Verification
`py_compile` passes on both files; `grep` confirms no 1-arg trending call and no other `get_current_timestamp` definition gap remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)