### PR TITLE
fix(data): healthcheck pointed at wrong port (8001 → 8002)

### DIFF
--- a/open-security-data/docker-compose.yml
+++ b/open-security-data/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - ./data:/app/data
       - ./logs:/app/logs
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
The open-security-data API listens on **8002** everywhere — `API_PORT=8002`, `EXPOSE 8002`, port mapping `8002:8002`, and the Dockerfile `HEALTHCHECK` all use 8002 — but the **compose** healthcheck curled `http://localhost:8001/health`. The check could never pass, so the container stayed `unhealthy`: anything waiting on `depends_on: condition: service_healthy` would hang, and `restart: unless-stopped` churned the container.

**Fix:** one line, `8001 → 8002`.

### Also checked (no change)
The audit also flagged `IndicatorDetail(**indicator.__dict__, …)` at [app/api/main.py:284](open-security-data/app/api/main.py). Verified it is **not** a bug: the service pins **Pydantic 2.5.0**, whose default `extra="ignore"` silently drops SQLAlchemy's `_sa_instance_state`. Left as-is rather than churn working code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)