### PR TITLE
fix(gateway): enforce auth on routes using the no-op access_by_lua_file form (#123)

### DIFF
--- a/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
+++ b/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
@@ -284,11 +284,13 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # Dashboard (web interface) - requires auth
+    # Dashboard (Next.js SPA) — intentionally NOT gateway-authenticated.
+    # Browser navigations carry a cookie, not an `Authorization: Bearer` header,
+    # so auth_handler (Bearer / API-key based) can't gate them and would block
+    # the login page itself. The SPA enforces its own auth (middleware) and the
+    # API calls it makes are authenticated at their own /api/* routes.
+    # (Previously this used access_by_lua_file, which silently did nothing.)
     location / {
-        # Authentication required (includes rate limiting)
-        access_by_lua_file /etc/nginx/lua/auth_handler.lua;
-        
         # Proxy to dashboard
         proxy_pass http://dashboard_service;
         include /etc/nginx/includes/proxy_params.conf;
@@ -303,10 +305,13 @@ server {
         include /etc/nginx/includes/proxy_params.conf;
     }
     
-    # Identity Service API - Other endpoints (auth required)
+    # Identity Service API - Other endpoints.
+    # Identity is the auth authority: it authenticates the user itself from the
+    # Bearer JWT. The gateway must NOT run auth_handler here — that strips the
+    # Authorization header and injects X-Wildbox-* headers identity doesn't read,
+    # producing a 401 even for valid tokens. Pass the request through unchanged;
+    # identity enforces auth (and returns 401 itself for missing/invalid JWTs).
     location /api/v1/identity/ {
-        access_by_lua_file /etc/nginx/lua/auth_handler.lua;
-        
         proxy_pass http://identity_service/api/v1/;
         include /etc/nginx/includes/proxy_params.conf;
     }
@@ -462,17 +467,21 @@ server {
     # Security Tools API (available to all authenticated users)
     location /api/tools/ {
         # Authentication required
-        access_by_lua_file /etc/nginx/lua/auth_handler.lua;
-        
+        access_by_lua_block {
+            local auth_handler = require "auth_handler"
+            auth_handler.authenticate()
+        }
+
         proxy_pass http://api_service/api/tools/;
         include /etc/nginx/includes/proxy_params.conf;
     }
     
-    # Security Tools Web Interface (available to all authenticated users)
+    # Security Tools standalone web UI (browser HTML, not used by the dashboard,
+    # which calls the JSON API at /api/v1/tools/). Bearer gateway auth doesn't
+    # apply to browser page loads; it relies on the tools service's own auth.
+    # NOTE: gateway-level auth here would need a cookie-based mechanism, not
+    # auth_handler — tracked separately. (Was access_by_lua_file = no-op.)
     location /tools/ {
-        # Authentication required
-        access_by_lua_file /etc/nginx/lua/auth_handler.lua;
-        
         proxy_pass http://api_service/tools/;
         include /etc/nginx/includes/proxy_params.conf;
     }
@@ -490,25 +499,29 @@ server {
 
     # Automations Service API (Business plan and higher)
     location /api/v1/automations/ {
-        access_by_lua_file /etc/nginx/lua/auth_handler.lua;
-        
+        access_by_lua_block {
+            local auth_handler = require "auth_handler"
+            auth_handler.authenticate()
+        }
+
         # Feature gating: Automations requires business plan or higher
-        
+
         proxy_pass http://automations_service/;
         include /etc/nginx/includes/proxy_params.conf;
     }
 
-    # WebSocket endpoints for real-time features
+    # WebSocket endpoints for real-time features.
+    # Browser WS handshakes can't carry an `Authorization: Bearer` header, so
+    # auth_handler can't gate them; WS auth must be done at the app layer (token
+    # in the connection params / cookie). Tracked separately.
+    # (Was access_by_lua_file = no-op.)
     location /ws/ {
-        access_by_lua_file /etc/nginx/lua/auth_handler.lua;
-        
         proxy_pass http://dashboard_service;
         include /etc/nginx/includes/proxy_params.conf;
-        
+
         # Override for WebSocket
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        
     }
 
     # Catch-all for undefined routes.


### PR DESCRIPTION
Closes #123.

`access_by_lua_file /etc/nginx/lua/auth_handler.lua` only *loads* the module (which ends in `return _M`) and never calls `authenticate()` — so those routes silently passed through unauthenticated. Live Docker testing showed the right fix differs by route type:

| Route | Resolution | Why |
|---|---|---|
| `/api/tools/`, `/api/v1/automations/` | **Real auth** — `access_by_lua_block { auth_handler.authenticate() }` | JSON APIs reached with `Authorization: Bearer`; backends trust the gateway (X-Wildbox) or self-protect (n8n basic auth) |
| `/api/v1/identity/` | **Documented pass-through** (no auth_handler) | Identity is the auth authority — it authenticates from the Bearer JWT itself. `auth_handler` strips `Authorization` and injects `X-Wildbox-*`, so it 401s even valid tokens. Identity self-rejects unauthenticated requests, so this stays secure |
| `/` (dashboard SPA), `/tools/` (browser UI), `/ws/` (websocket) | **Documented open** (removed no-op line) | Browser/cookie/WS, not Bearer — `auth_handler` can't gate them, and on `/` it would block the login page itself |

### Verified live (real Docker stack)
```
identity /users/me     + JWT -> 200      no token -> 401 (identity self-rejects)
/api/v1/automations/         no token -> 401   (gateway enforces)
/api/tools/                  no token -> 401   (gateway enforces)
/  /tools/  /ws/             no token -> 502   (reach proxy, NOT blocked)
guardian GET           + JWT -> 200      (no regression)
```

### Follow-up (separate, noted in-config)
Gateway-level auth for the browser UI (`/tools/`) and WebSocket (`/ws/`) would need a **cookie-based** mechanism, not `auth_handler` — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)