### PR TITLE
fix(compose): bring the full stack up healthy on docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,9 +44,22 @@ POSTGRES_DB=identity
 # Guardian Service
 GUARDIAN_SECRET_KEY=generate-guardian-secret-key
 GUARDIAN_DB_PASSWORD=generate-guardian-db-password
-# Guardian uses its own database (provisioned by scripts/init-guardian-db.sql).
+
+# CSPM Service (Django SECRET_KEY, min 32 chars)
+CSPM_SECRET_KEY=generate-cspm-secret-key-min-32-characters
+# Guardian uses its own database (provisioned by scripts/init-databases.sql).
 # Must use the same POSTGRES_PASSWORD as above. (psycopg2/Django driver — no +asyncpg.)
 GUARDIAN_DATABASE_URL=postgresql://postgres:YOUR_DB_PASSWORD@postgres:5432/guardian
+
+# Data service — its own database (psycopg2, sync; provisioned by init-databases.sql)
+DATA_DATABASE_URL=postgresql://postgres:YOUR_DB_PASSWORD@postgres:5432/data
+
+# Responder does not use a database, but the compose passes this var; leave set.
+RESPONDER_DATABASE_URL=postgresql://postgres:YOUR_DB_PASSWORD@postgres:5432/responder
+
+# Agents LLM (defaults to the bundled ollama 'llm' service). Leave OPENAI_API_KEY
+# empty to use the local LLM; set it only for a real OpenAI endpoint.
+OPENAI_API_KEY=
 
 # Gateway Configuration (CRITICAL for production!)
 # Used for secure internal service-to-service communication

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - ENVIRONMENT=${ENVIRONMENT:-development}
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000}
-      - REDIS_URL=redis://wildbox-redis:6379/2
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/2
       # Increased rate limits for AI agent service
       - RATE_LIMIT_REQUESTS=${RATE_LIMIT_REQUESTS:-500}
       - RATE_LIMIT_WINDOW=${RATE_LIMIT_WINDOW:-60}
@@ -93,7 +93,7 @@ services:
       - DEBUG=${DEBUG:-false}
       - LOG_LEVEL=DEBUG
       - ENVIRONMENT=${ENVIRONMENT:-development}
-      - REDIS_URL=redis://wildbox-redis:6379/2
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/2
     depends_on:
       - wildbox-redis
       - api
@@ -118,12 +118,22 @@ services:
     ports:
       - "127.0.0.1:5555:5555"
     environment:
-      - REDIS_URL=redis://wildbox-redis:6379/2
+      # app.config.Settings requires API_KEY (shared with api/tools-worker);
+      # without it flower crashes on startup with "api_key Field required".
+      - API_KEY=${API_KEY}
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/2
     depends_on:
       - wildbox-redis
       - tools-worker
     networks:
       - wildbox
+    # Override the image's HEALTHCHECK (curl :8000/health) — flower serves its
+    # own UI + /healthcheck on 5555.
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5555/healthcheck || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   # Data Service (Threat Intelligence & IOCs)
   data:
@@ -171,7 +181,9 @@ services:
     networks:
       - wildbox
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'python -m app.scheduler.main' || exit 1"]
+      # The data image has no procps (pgrep/ps); the scheduler is PID 1, so
+      # check its cmdline directly.
+      test: ["CMD-SHELL", "grep -q scheduler /proc/1/cmdline || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -257,6 +269,13 @@ services:
     depends_on:
       - gateway
       - identity
+    # node is always present in the image; use it (no curl in node:18-alpine).
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3000/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   # PostgreSQL Database (Identity Service)
   postgres:
@@ -281,9 +300,9 @@ services:
     #   - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      # Provision the separate Guardian database on first init (Guardian is a
-      # Django service with its own tables; identity is FastAPI).
-      - ./scripts/init-guardian-db.sql:/docker-entrypoint-initdb.d/10-init-guardian-db.sql:ro
+      # Provision per-service databases on first init (guardian, data; identity
+      # uses POSTGRES_DB). See scripts/init-databases.sql.
+      - ./scripts/init-databases.sql:/docker-entrypoint-initdb.d/10-init-databases.sql:ro
     networks:
       - wildbox
     healthcheck:
@@ -331,9 +350,9 @@ services:
     environment:
       - SECRET_KEY=${GUARDIAN_SECRET_KEY}
       - DATABASE_URL=${GUARDIAN_DATABASE_URL}
-      - REDIS_URL=${GUARDIAN_REDIS_URL:-redis://wildbox-redis:6379/1}
-      - CELERY_BROKER_URL=${GUARDIAN_CELERY_BROKER_URL:-redis://wildbox-redis:6379/1}
-      - CELERY_RESULT_BACKEND=${GUARDIAN_CELERY_RESULT_BACKEND:-redis://wildbox-redis:6379/1}
+      - REDIS_URL=${GUARDIAN_REDIS_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/1}
+      - CELERY_BROKER_URL=${GUARDIAN_CELERY_BROKER_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/1}
+      - CELERY_RESULT_BACKEND=${GUARDIAN_CELERY_RESULT_BACKEND:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/1}
       - DEBUG=${DEBUG:-false}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - LOG_FILE=/app/logs/guardian.log
@@ -366,7 +385,7 @@ services:
       - "8018:8018"
     environment:
       - DATABASE_URL=${RESPONDER_DATABASE_URL}
-      - REDIS_URL=${RESPONDER_REDIS_URL:-redis://wildbox-redis:6379/2}
+      - REDIS_URL=${RESPONDER_REDIS_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/2}
       - DEBUG=${DEBUG:-false}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     depends_on:
@@ -396,9 +415,12 @@ services:
     ports:
       - "8019:8019"
     environment:
-      - REDIS_URL=${CSPM_REDIS_URL:-redis://wildbox-redis:6379/3}
-      - CELERY_BROKER_URL=${CSPM_CELERY_BROKER_URL:-redis://wildbox-redis:6379/3}
-      - CELERY_RESULT_BACKEND=${CSMP_CELERY_RESULT_BACKEND:-redis://wildbox-redis:6379/3}
+      # cspm requires SECRET_KEY (min 32 chars); without it the service crashes
+      # on startup with a pydantic "secret_key Field required" error.
+      - SECRET_KEY=${CSPM_SECRET_KEY}
+      - REDIS_URL=${CSPM_REDIS_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/3}
+      - CELERY_BROKER_URL=${CSPM_CELERY_BROKER_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/3}
+      - CELERY_RESULT_BACKEND=${CSPM_CELERY_RESULT_BACKEND:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/3}
       - DEBUG=${DEBUG:-false}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     depends_on:
@@ -420,9 +442,9 @@ services:
   #   restart: unless-stopped
   #   command: celery -A app.worker worker --loglevel=info --concurrency=4
   #   environment:
-  #     - REDIS_URL=redis://wildbox-redis:6379/3
-  #     - CELERY_BROKER_URL=redis://wildbox-redis:6379/3
-  #     - CELERY_RESULT_BACKEND=redis://wildbox-redis:6379/3
+  #     - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/3
+  #     - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/3
+  #     - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/3
   #     - LOG_LEVEL=INFO
   #   depends_on:
   #     - wildbox-redis
@@ -460,7 +482,8 @@ services:
     networks:
       - wildbox
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/"]
+      # The ollama image ships no curl/wget; use its own CLI as a liveness probe.
+      test: ["CMD-SHELL", "ollama list || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -485,9 +508,9 @@ services:
       - WILDBOX_API_URL=${WILDBOX_API_URL:-http://api:8000}  # Tools service endpoint
       # Authentication for tools service (must match API_KEY in tools service)
       - INTERNAL_API_KEY=${API_KEY}
-      - REDIS_URL=${AGENTS_REDIS_URL:-redis://wildbox-redis:6379/4}
-      - CELERY_BROKER_URL=${AGENTS_CELERY_BROKER_URL:-redis://wildbox-redis:6379/4}
-      - CELERY_RESULT_BACKEND=${AGENTS_CELERY_RESULT_BACKEND:-redis://wildbox-redis:6379/4}
+      - REDIS_URL=${AGENTS_REDIS_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/4}
+      - CELERY_BROKER_URL=${AGENTS_CELERY_BROKER_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/4}
+      - CELERY_RESULT_BACKEND=${AGENTS_CELERY_RESULT_BACKEND:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/4}
       - DEBUG=${DEBUG:-false}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     depends_on:
@@ -577,7 +600,9 @@ services:
     networks:
       - wildbox
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5678/healthz"]
+      # The n8n image has no curl and its BusyBox wget is unreliable here; use
+      # node (always present) to probe the /healthz liveness endpoint.
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:5678/healthz',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/open-security-agents/requirements.txt
+++ b/open-security-agents/requirements.txt
@@ -4,6 +4,7 @@ fastapi==0.115.5
 uvicorn[standard]==0.32.1
 pydantic==2.10.3
 pydantic-settings==2.10.1
+slowapi==0.1.9  # rate limiting; imported in app/main.py
 
 # Task Queue
 celery[redis]==5.4.0

--- a/open-security-dashboard/Dockerfile.dev
+++ b/open-security-dashboard/Dockerfile.dev
@@ -9,6 +9,11 @@ RUN npm ci
 # Copy source code
 COPY . .
 
+# Pre-create the .next dir so the anonymous volume mounted there (see compose)
+# inherits nextjs ownership; otherwise Docker creates it root-owned and the dev
+# server hits EACCES writing /app/.next/package.json.
+RUN mkdir -p /app/.next
+
 # Run as non-root user
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nextjs -u 1001 -G nodejs && \

--- a/scripts/init-databases.sql
+++ b/scripts/init-databases.sql
@@ -1,0 +1,8 @@
+-- Provision the per-service databases on first PostgreSQL init (empty data
+-- volume). identity uses the default POSTGRES_DB; guardian (Django) and data
+-- (FastAPI) keep their own databases. Idempotent via \gexec.
+SELECT 'CREATE DATABASE guardian'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'guardian')\gexec
+
+SELECT 'CREATE DATABASE data'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'data')\gexec

--- a/scripts/init-guardian-db.sql
+++ b/scripts/init-guardian-db.sql
@@ -1,5 +1,0 @@
--- Create the Guardian service database if it does not already exist.
--- Runs once on first PostgreSQL init (empty data volume). Guardian is a Django
--- service and keeps its own tables separate from the FastAPI identity service.
-SELECT 'CREATE DATABASE guardian'
-WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'guardian')\gexec


### PR DESCRIPTION
A component-by-component bring-up of the root `docker compose` found that most services never actually started. **Verified live on Docker: 17/17 now report healthy** (was 7 crash-looping + 3 false-unhealthy).

### Startup crashes fixed
| Service(s) | Root cause | Fix |
|---|---|---|
| responder, + tools/cspm/agents redis | redis runs `--requirepass`, but `REDIS_URL`/`CELERY_*` omitted the password → `AuthenticationError` | inject `redis://:${REDIS_PASSWORD:-changeme}@…` everywhere |
| cspm | `secret_key` required, not passed | pass `SECRET_KEY=${CSPM_SECRET_KEY}` (+ `.env.example`) |
| tools-flower | missing `API_KEY` (shared `app.config.Settings`) | pass `API_KEY`; also override the inherited `:8000/health` HEALTHCHECK with flower's `:5555/healthcheck` |
| agents | `ModuleNotFoundError: slowapi` | add `slowapi==0.1.9` to requirements |
| dashboard | `/app/.next` anonymous volume root-owned → `EACCES` | pre-create `/app/.next` (nextjs-owned) in `Dockerfile.dev` |

### Other wiring
- Provision the `data` database (generalised `init-guardian-db.sql` → `init-databases.sql`: guardian + data); added `DATA_DATABASE_URL` / `RESPONDER_DATABASE_URL` / `OPENAI_API_KEY` to `.env.example`.
- Fixed `CSMP_CELERY_RESULT_BACKEND` → `CSPM_` typo.

### Health checks (were false-negatives — service fine, probe tool absent)
- **llm** (ollama): no curl → `ollama list`.
- **data-scheduler**: no procps → check `/proc/1/cmdline` (scheduler is PID 1).
- **automations** (n8n): no curl + flaky busybox wget → `node` probe of `/healthz` (returns 200).
- **dashboard**: added a `node`-based healthcheck (no curl in `node:18-alpine`).

### Verified
```
docker compose ps → 17/17 healthy
dashboard: 200 (direct :3000 and via gateway HTTPS /)
```

### Note (left as-is)
data-scheduler can log a one-time `relation "sources" does not exist` on a cold start (it queries before the `data` service's `create_all` finishes) and recovers next cycle — harmless startup race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)