### PR TITLE
fix(dashboard): render through the gateway — CSP unsafe-eval (dev) + drop redundant Google Fonts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,7 +246,9 @@ services:
       - /app/node_modules
       - /app/.next
     environment:
-      - NODE_ENV=${NODE_ENV:-production}
+      # This stack runs the Next.js dev server (Dockerfile.dev -> next dev),
+      # so NODE_ENV must be development; production here breaks dev-mode CSP/HMR.
+      - NODE_ENV=${NODE_ENV:-development}
       - NEXT_PUBLIC_DEBUG=${NEXT_PUBLIC_DEBUG:-false}
       - NEXT_PUBLIC_USE_GATEWAY=true
       - NEXT_PUBLIC_GATEWAY_URL=http://localhost:8080

--- a/open-security-dashboard/next.config.js
+++ b/open-security-dashboard/next.config.js
@@ -1,3 +1,10 @@
+// Next.js' dev server (next dev) compiles with eval-source-map, which needs
+// 'unsafe-eval' in the CSP. Production (next start) does not — keep it strict.
+const isDev = process.env.NODE_ENV !== 'production';
+const scriptSrc = isDev
+  ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+  : "script-src 'self' 'unsafe-inline'";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
@@ -29,7 +36,7 @@ const nextConfig = {
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
-          { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' http://localhost:* https://localhost:* ws://localhost:* wss://localhost:*;" },
+          { key: 'Content-Security-Policy', value: `default-src 'self'; ${scriptSrc}; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' http://localhost:* https://localhost:* ws://localhost:* wss://localhost:*;` },
         ],
       },
       {

--- a/open-security-dashboard/src/app/globals.css
+++ b/open-security-dashboard/src/app/globals.css
@@ -1,4 +1,6 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=JetBrains+Mono:wght@100;200;300;400;500;600;700;800&display=swap');
+/* Inter + JetBrains Mono are loaded (self-hosted) via next/font/google in
+   src/app/layout.tsx — no external Google Fonts request needed, and it avoids
+   the CSP style-src/font-src violation an @import here would cause. */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
+++ b/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
@@ -291,6 +291,21 @@ server {
     # API calls it makes are authenticated at their own /api/* routes.
     # (Previously this used access_by_lua_file, which silently did nothing.)
     location / {
+        # The dashboard (Next.js) sets its OWN Content-Security-Policy, which is
+        # dev/prod-aware (dev needs 'unsafe-eval' for next dev's eval-source-map;
+        # prod is strict). Re-declaring the other security headers here means the
+        # server-level add_headers are NOT inherited for this location, so the
+        # gateway's generic CSP is dropped and the app's CSP (proxied from the
+        # upstream) is authoritative — avoiding a conflicting double CSP that
+        # blocked the dashboard's scripts/fonts. The strict gateway CSP still
+        # applies to all the API routes below.
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
+
         # Proxy to dashboard
         proxy_pass http://dashboard_service;
         include /etc/nginx/includes/proxy_params.conf;


### PR DESCRIPTION
The dashboard container is healthy and serves HTML, but in the **browser** (via the gateway) its scripts and fonts were CSP-blocked — blank/broken app. Root causes and fixes:

| Console error | Cause | Fix |
|---|---|---|
| `stylesheet 'fonts.googleapis.com' violates style-src` | `globals.css` `@import`s Google Fonts — **redundant**, the same fonts are already self-hosted via `next/font/google` in `layout.tsx` | removed the `@import` |
| `Uncaught EvalError … 'unsafe-eval' is not allowed` + `layout.js Invalid or unexpected token` | `next dev` compiles with `eval-source-map` (needs `'unsafe-eval'`), but the CSP omitted it | `next.config.js` CSP is now **dev-aware**: `'unsafe-eval'` only when `NODE_ENV !== production` (prod `next start` stays strict) |
| (dev/prod mismatch) | compose ran `next dev` but with `NODE_ENV=production` | dev compose sets `NODE_ENV=development` |
| two conflicting CSP headers | gateway **also** imposed its strict CSP on the dashboard → browser enforced the intersection (still no eval) | gateway `location /` re-declares the other security headers so the server-level CSP isn't inherited there; the app's CSP passes through. **Strict gateway CSP still applies to all `/api/*` routes.** |

### Verified live (real Docker stack)
```
GET / via gateway → single CSP (app's, with 'unsafe-eval' in dev), no fonts.googleapis request, 200
GET /api/v1/guardian/... via gateway → strict gateway CSP retained (no unsafe-eval, object-src 'none', …)
```
Production stays secure: prod runs `next start` (NODE_ENV=production) → CSP has no `unsafe-eval`; API CSP unchanged.

### Note (cosmetic, not fixed)
`/favicon.ico` and `/icon.svg` still 404 — no icon assets are shipped. Left for a real asset rather than inventing a logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)