### PR TITLE
fix(dashboard): make login work through the gateway (route + CORS origin)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,7 +251,11 @@ services:
       - NODE_ENV=${NODE_ENV:-development}
       - NEXT_PUBLIC_DEBUG=${NEXT_PUBLIC_DEBUG:-false}
       - NEXT_PUBLIC_USE_GATEWAY=true
-      - NEXT_PUBLIC_GATEWAY_URL=http://localhost:8080
+      # Must match the origin the dashboard is opened from. The gateway is
+      # HTTPS-only (80/8080 redirect to 443), so browser API calls go to
+      # https://localhost — same-origin, no CORS. (http://localhost:8080 caused
+      # cross-origin XHR to be blocked.)
+      - NEXT_PUBLIC_GATEWAY_URL=${NEXT_PUBLIC_GATEWAY_URL:-https://localhost}
       - NEXT_PUBLIC_API_BASE_URL=http://localhost:80/api/v1/tools
       - NEXT_PUBLIC_IDENTITY_API_URL=http://localhost:80/api/v1/identity
       - NEXT_PUBLIC_DATA_API_URL=http://localhost:80/api/v1/data

--- a/open-security-dashboard/src/lib/api-client.ts
+++ b/open-security-dashboard/src/lib/api-client.ts
@@ -175,8 +175,12 @@ export const getAuthPath = (endpoint: string): string => {
   if (useGateway) {
     // When using gateway with identityClient, transform paths correctly
     // Gateway routes: /auth/ -> identity:/api/v1/auth/ and /auth/users/ -> identity:/api/v1/users/
+    // NOTE: do NOT special-case login to '/auth/login' — the gateway routes
+    // '/auth/login' to the dashboard (the login *page*), so the JWT login POST
+    // would hit the SPA and never reach identity. Let it become
+    // '/auth/jwt/login', which the gateway routes to identity's
+    // /api/v1/auth/jwt/login.
     return endpoint
-      .replace('/api/v1/auth/jwt/login', '/auth/login')  // Special case for login endpoint
       .replace('/api/v1/auth/jwt', '/auth/jwt')
       .replace('/api/v1/auth', '/auth')
       .replace('/api/v1/users', '/auth/users')


### PR DESCRIPTION
Logging in via the dashboard (at `https://localhost`) was impossible — two bugs, both fixed:

1. **Wrong login path.** `getAuthPath` special-cased `/api/v1/auth/jwt/login` → `/auth/login`, but the gateway routes `/auth/login` to the dashboard (login *page*), not identity → the POST got HTML instead of a token. Fixed to `/auth/jwt/login` (gateway → identity).
2. **CORS / wrong origin.** `NEXT_PUBLIC_GATEWAY_URL=http://localhost:8080`, but the dashboard is opened at `https://localhost` (the gateway is HTTPS-only; 80/8080 redirect to 443). Browser API calls were cross-origin → blocked (`No 'Access-Control-Allow-Origin' header`). Point it at `https://localhost` so calls are same-origin.

### Verified live
```
POST https://localhost/auth/jwt/login (form) → 200 {"access_token":"…","token_type":"bearer"}
```
That token then authorizes API calls through the gateway. Admin: `admin@acme.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)