### PR TITLE
fix: make a fresh stack usable end-to-end (guardian migrate + admin team)

### DIFF
--- a/open-security-guardian/Dockerfile
+++ b/open-security-guardian/Dockerfile
@@ -31,7 +31,8 @@ RUN pip install --no-cache-dir --upgrade pip \
 COPY . .
 
 # Create directories for media and static files
-RUN mkdir -p /app/media /app/staticfiles
+RUN mkdir -p /app/media /app/staticfiles \
+    && chmod +x scripts/docker-entrypoint.sh
 
 # Create non-root user
 RUN adduser --disabled-password --gecos '' guardian \
@@ -44,6 +45,9 @@ EXPOSE 8013
 # Health check
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8013/health/ || exit 1
+
+# Apply migrations on startup, then run the CMD.
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
 
 # Default command
 CMD ["gunicorn", "--bind", "0.0.0.0:8013", "--workers", "3", "--timeout", "120", "guardian.wsgi:application"]

--- a/open-security-guardian/scripts/docker-entrypoint.sh
+++ b/open-security-guardian/scripts/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Apply Django migrations before serving. Guardian has no migrate-on-boot, so a
+# fresh database (e.g. first `docker compose up`) would leave its tables absent
+# and every API request would 500 with 'relation "auth_user" does not exist'.
+# migrate is idempotent — it only applies what's pending.
+set -e
+
+echo "[entrypoint] Applying database migrations..."
+python manage.py migrate --no-input
+
+exec "$@"

--- a/open-security-identity/scripts/init.sh
+++ b/open-security-identity/scripts/init.sh
@@ -62,9 +62,23 @@ import asyncio
 import os
 import sys
 from app.database import get_db
-from app.models import User
+from app.models import User, Team, TeamMembership
 from app.user_manager import get_user_manager, get_user_db
 from sqlalchemy import select
+
+async def ensure_default_team(db, user):
+    # The gateway's /internal/authorize inner-joins team membership, so an admin
+    # with no team can log in but every authenticated API call 401s. Give the
+    # initial admin a default team (owner) so a fresh stack is usable.
+    res = await db.execute(select(TeamMembership).where(TeamMembership.user_id == user.id))
+    if res.scalars().first():
+        return
+    team = Team(name='Default', owner_id=user.id)
+    db.add(team)
+    await db.flush()
+    db.add(TeamMembership(user_id=user.id, team_id=team.id, role='owner'))
+    await db.commit()
+    print(f'✅ Ensured default team (owner) for {user.email}')
 
 async def create_initial_superuser():
     admin_email = os.getenv('INITIAL_ADMIN_EMAIL', 'admin@wildbox.security')
@@ -87,6 +101,7 @@ async def create_initial_superuser():
         
         if existing_admin:
             print(f'ℹ️  Admin user {admin_email} already exists, skipping creation.')
+            await ensure_default_team(db, existing_admin)
             await db.close()
             return
         
@@ -107,7 +122,8 @@ async def create_initial_superuser():
         admin_user.is_verified = True
         db.add(admin_user)
         await db.commit()
-        
+        await ensure_default_team(db, admin_user)
+
         print(f'✅ Created initial admin user: {admin_email}')
         print(f'🔑 Password: {admin_password}')
         print('⚠️  Please change the default password after first login!')


### PR DESCRIPTION
Two fresh-stack-usability gaps found while bringing the full stack up and logging into the dashboard. On a clean `docker compose up` you could reach the login page but **couldn't actually use the app**:

1. **Guardian never migrated.** It ran only gunicorn (no migrate-on-boot), so a fresh DB left its tables absent → every guardian API 500'd with `relation "auth_user" does not exist` (hit via the gateway-user mirror in `GatewayAuthMiddleware`). Added a `scripts/docker-entrypoint.sh` that runs `manage.py migrate --no-input` (idempotent) before gunicorn.
2. **Initial admin had no team.** The gateway's `/internal/authorize` inner-joins team membership, so the seeded admin could log in but every authenticated call 401'd. `init.sh` now ensures a default team (owner) for the initial admin (create + already-exists paths).

### Verified live
- Dropped the guardian schema → recreated container → entrypoint migrated **0 → 76 tables** → guardian healthy, `GET /api/v1/guardian/vulnerabilities/` (with JWT) → **200**.
- Wiped the admin's team → recreated identity → `✅ Ensured default team (owner)` → admin has `Default`/`owner`; authenticated calls work.

Together with #122–#127 this makes a fresh `docker compose up` fully usable: 17/17 healthy, dashboard renders, login + authenticated API calls work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)