### PR TITLE
feat(agents): migrate LLM from OpenAI to Claude (#116)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,9 +57,10 @@ DATA_DATABASE_URL=postgresql://postgres:YOUR_DB_PASSWORD@postgres:5432/data
 # Responder does not use a database, but the compose passes this var; leave set.
 RESPONDER_DATABASE_URL=postgresql://postgres:YOUR_DB_PASSWORD@postgres:5432/responder
 
-# Agents LLM (defaults to the bundled ollama 'llm' service). Leave OPENAI_API_KEY
-# empty to use the local LLM; set it only for a real OpenAI endpoint.
-OPENAI_API_KEY=
+# Agents LLM — Claude (Anthropic). Set your key to enable AI threat analysis;
+# leave empty and the agents service still starts (analysis fails gracefully).
+ANTHROPIC_API_KEY=
+# ANTHROPIC_MODEL=claude-opus-4-8
 
 # Gateway Configuration (CRITICAL for production!)
 # Used for secure internal service-to-service communication

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -457,44 +457,6 @@ services:
   #   networks:
   #     - wildbox
 
-  # Ollama Service (Local LLM API)
-  # Provides OpenAI-compatible API for AI agents using Qwen2.5:0.5b
-  # Much lighter than vLLM (~2GB image + ~300MB model)
-  llm:
-    image: ollama/ollama:0.4.7
-    container_name: wildbox-llm
-    restart: unless-stopped
-    # SECURITY: Ollama only accessible within Docker network, not exposed to host
-    environment:
-      - OLLAMA_ORIGINS=http://open-security-agents:8006
-    volumes:
-      - llm_cache:/root/.ollama
-    deploy:
-      resources:
-        limits:
-          cpus: '2.0'
-          memory: 4G
-        reservations:
-          cpus: '1.0'
-          memory: 2G
-    # Uncomment for GPU support (requires nvidia-docker)
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: 1
-    #           capabilities: [gpu]
-    networks:
-      - wildbox
-    healthcheck:
-      # The ollama image ships no curl/wget; use its own CLI as a liveness probe.
-      test: ["CMD-SHELL", "ollama list || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-
   # Agents Service (Security Agents)
   agents:
     build:
@@ -507,10 +469,10 @@ services:
     ports:
       - "8006:8006"
     environment:
-      # Local LLM configuration (Ollama with OpenAI compatibility)
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-http://llm:11434/v1}
-      - OPENAI_MODEL=${OPENAI_MODEL:-qwen2.5:0.5b}
+      # Claude (Anthropic) — analysis is optional; the service starts without a
+      # key and analysis tasks fail gracefully until one is set.
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-8}
       - WILDBOX_API_URL=${WILDBOX_API_URL:-http://api:8000}  # Tools service endpoint
       # Authentication for tools service (must match API_KEY in tools service)
       - INTERNAL_API_KEY=${API_KEY}
@@ -522,7 +484,6 @@ services:
     depends_on:
       - wildbox-redis
       - api
-      - llm
     networks:
       - wildbox
     healthcheck:
@@ -617,7 +578,6 @@ volumes:
   postgres_data:
   wildbox_redis_data:
   guardian_logs:
-  llm_cache:
   # Service-specific volumes
   sensor_logs:
   sensor_data:

--- a/open-security-agents/app/agents/threat_enrichment_agent.py
+++ b/open-security-agents/app/agents/threat_enrichment_agent.py
@@ -11,26 +11,26 @@ import os
 from datetime import datetime, timezone
 from typing import Dict, Any, List
 
-from langchain_openai import ChatOpenAI
-from langchain.agents import create_openai_tools_agent, AgentExecutor
+from langchain_anthropic import ChatAnthropic
+from langchain.agents import create_tool_calling_agent, AgentExecutor
 from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain.schema.messages import SystemMessage
 
 from ..config import settings
 from ..tools.langchain_tools import ALL_TOOLS
 
-# Circuit breaker for OpenAI API resilience
+# Circuit breaker for Anthropic API resilience
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'open-security-shared'))
 try:
     from circuit_breaker import CircuitBreaker, CircuitBreakerError
-    OPENAI_BREAKER = CircuitBreaker(
-        name="openai_agent",
+    LLM_BREAKER = CircuitBreaker(
+        name="anthropic_agent",
         failure_threshold=3,
         timeout=120,
         recovery_timeout=60,
     )
 except ImportError:
-    OPENAI_BREAKER = None
+    LLM_BREAKER = None
     CircuitBreakerError = Exception
 
 logger = logging.getLogger(__name__)
@@ -40,30 +40,24 @@ class ThreatEnrichmentAgent:
     """
     AI-powered threat enrichment agent
     
-    This agent uses GPT-4o and security tools to analyze IOCs and generate
+    This agent uses Claude and security tools to analyze IOCs and generate
     comprehensive threat intelligence reports.
     """
-    
+
     def __init__(self):
         self.llm = self._initialize_llm()
         self.tools = ALL_TOOLS
         self.agent_executor = self._create_agent()
-    
-    def _initialize_llm(self) -> ChatOpenAI:
-        """Initialize the OpenAI LLM"""
-        llm_kwargs = {
-            "model": settings.openai_model,
-            "temperature": settings.openai_temperature,
-            "openai_api_key": settings.openai_api_key,
-            "streaming": False
-        }
-        
-        # Support for local LLM endpoints (e.g., vLLM container)
-        if settings.openai_base_url:
-            llm_kwargs["base_url"] = settings.openai_base_url
-            logger.info(f"Using custom OpenAI base URL: {settings.openai_base_url}")
-        
-        return ChatOpenAI(**llm_kwargs)
+
+    def _initialize_llm(self) -> ChatAnthropic:
+        """Initialize the Claude (Anthropic) LLM"""
+        return ChatAnthropic(
+            model=settings.anthropic_model,
+            temperature=settings.anthropic_temperature,
+            max_tokens=settings.anthropic_max_tokens,
+            anthropic_api_key=settings.anthropic_api_key,
+            streaming=False,
+        )
     
     def _create_agent(self) -> AgentExecutor:
         """Create the LangChain agent with tools and prompt"""
@@ -106,8 +100,8 @@ Begin your investigation by thinking through your approach, then systematically 
             MessagesPlaceholder(variable_name="agent_scratchpad")
         ])
         
-        # Create the agent
-        agent = create_openai_tools_agent(
+        # Create the agent (provider-agnostic tool-calling agent — works with Claude)
+        agent = create_tool_calling_agent(
             llm=self.llm,
             tools=self.tools,
             prompt=prompt
@@ -147,8 +141,8 @@ Begin your investigation by thinking through your approach, then systematically 
             input_text = f"Please investigate this {ioc_type} IOC: {ioc_value}"
             
             # Execute the agent (protected by circuit breaker)
-            if OPENAI_BREAKER is not None:
-                result = await OPENAI_BREAKER.call(
+            if LLM_BREAKER is not None:
+                result = await LLM_BREAKER.call(
                     self.agent_executor.ainvoke, {"input": input_text}
                 )
             else:
@@ -310,7 +304,7 @@ Verdict:"""
 
 
 # Lazily-built agent instance: constructing it builds the LLM + agent graph
-# (which needs OPENAI_API_KEY), so defer until first use. This lets the worker
+# (which needs ANTHROPIC_API_KEY), so defer until first use. This lets the worker
 # import without the key set instead of crash-looping at import.
 _agent_instance = None
 

--- a/open-security-agents/app/config.py
+++ b/open-security-agents/app/config.py
@@ -17,12 +17,12 @@ class Settings(BaseSettings):
     debug: bool = False
     log_level: str = "INFO"
     
-    # OpenAI Configuration (optional — the worker imports without it; analysis
-    # tasks fail gracefully when it's missing instead of crash-looping at boot)
-    openai_api_key: Optional[str] = None
-    openai_model: str = "gpt-4o"
-    openai_temperature: float = 0.1
-    openai_base_url: Optional[str] = None  # Override for local LLM (e.g., vLLM container)
+    # Anthropic / Claude Configuration (optional — the worker imports without it;
+    # analysis tasks fail gracefully when it's missing instead of crash-looping)
+    anthropic_api_key: Optional[str] = None
+    anthropic_model: str = "claude-opus-4-8"
+    anthropic_temperature: float = 0.1
+    anthropic_max_tokens: int = 4096
     
     # Redis Configuration
     redis_url: str = Field(default="redis://localhost:6379/0", env="REDIS_URL")

--- a/open-security-agents/app/main.py
+++ b/open-security-agents/app/main.py
@@ -62,11 +62,11 @@ async def lifespan(app: FastAPI):
         redis_client.ping()
         logger.info("Redis connection established")
         
-        # Test OpenAI API key
-        if not settings.openai_api_key or settings.openai_api_key == "your_openai_api_key_here":
-            logger.warning("OpenAI API key not configured - AI analysis will fail")
+        # Test Anthropic API key
+        if not settings.anthropic_api_key or settings.anthropic_api_key == "your_anthropic_api_key_here":
+            logger.warning("Anthropic API key not configured - AI analysis will fail")
         else:
-            logger.info("OpenAI API key configured")
+            logger.info("Anthropic API key configured")
         
         # Test Celery connection
         try:
@@ -157,11 +157,11 @@ async def health_check():
     except Exception:
         services["celery"] = "unhealthy"
     
-    # Check OpenAI
-    if settings.openai_api_key and settings.openai_api_key != "your_openai_api_key_here":
-        services["openai"] = "configured"
+    # Check Anthropic
+    if settings.anthropic_api_key and settings.anthropic_api_key != "your_anthropic_api_key_here":
+        services["anthropic"] = "configured"
     else:
-        services["openai"] = "not_configured"
+        services["anthropic"] = "not_configured"
     
     overall_status = "healthy" if all(s in ["healthy", "configured"] for s in services.values()) else "unhealthy"
     

--- a/open-security-agents/app/worker.py
+++ b/open-security-agents/app/worker.py
@@ -164,7 +164,7 @@ def health_check_task() -> Dict[str, Any]:
         redis_client.ping()
         
         # Test AI agent initialization
-        agent_status = "healthy" if settings.openai_api_key else "unhealthy"
+        agent_status = "healthy" if settings.anthropic_api_key else "unhealthy"
         
         return {
             "status": "healthy",

--- a/open-security-agents/requirements.txt
+++ b/open-security-agents/requirements.txt
@@ -13,7 +13,7 @@ redis==5.2.1
 # AI/LLM Framework
 # Pinned versions for reproducible builds and security
 langchain==0.3.30
-langchain-anthropic>=0.3,<0.4
+langchain-anthropic==0.3.22
 langchain-community==0.3.31
 
 # HTTP Client

--- a/open-security-agents/requirements.txt
+++ b/open-security-agents/requirements.txt
@@ -13,7 +13,7 @@ redis==5.2.1
 # AI/LLM Framework
 # Pinned versions for reproducible builds and security
 langchain==0.3.30
-langchain-openai==0.2.14
+langchain-anthropic>=0.3,<0.4
 langchain-community==0.3.31
 
 # HTTP Client


### PR DESCRIPTION
Closes #116.

Swaps the threat-enrichment agent's LLM provider from **OpenAI (LangChain)** to **Claude (`langchain-anthropic`)** — the platform standard. A LangChain provider swap (the agent/tools/executor architecture is unchanged).

### Changes
- **requirements**: `langchain-openai` → `langchain-anthropic` (0.3.x, matches the pinned `langchain` 0.3.x).
- **agent** (`threat_enrichment_agent.py`): `ChatOpenAI` → `ChatAnthropic(model, temperature, max_tokens, anthropic_api_key)`; `create_openai_tools_agent` → `create_tool_calling_agent` (provider-agnostic, verified against the langchain-anthropic reference). Circuit breaker renamed.
- **config**: `openai_*` → `anthropic_*` — `anthropic_model` defaults to **`claude-opus-4-8`**, `anthropic_max_tokens=4096` (Anthropic requires `max_tokens`); dropped `openai_base_url`. Key stays optional (service boots without it; analysis fails gracefully).
- **health checks** (main/worker) report `anthropic` instead of `openai`.
- **compose**: agents env `OPENAI_*` → `ANTHROPIC_API_KEY`/`ANTHROPIC_MODEL`; **removed the now-unused local ollama `llm` service** (it only existed as the agent's OpenAI-compatible endpoint), its `llm_cache` volume, and the agents `depends_on: llm`. `.env.example` documents `ANTHROPIC_API_KEY`.

### Verified (Docker)
```
agents image builds with langchain-anthropic
import ChatAnthropic + create_tool_calling_agent → OK; model = claude-opus-4-8
agent constructs: llm=ChatAnthropic, executor=AgentExecutor
full stack healthy (llm/ollama removed)
```
A live Claude analysis run requires a real `ANTHROPIC_API_KEY` (analysis is intentionally optional, so the stack runs without one).

### Follow-up (separate, noted in the issue)
The agent's structured-report logic still has stubbed fields (hardcoded confidence / empty evidence) — not part of the provider swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)