### PR TITLE
fix: clear known runtime errors (scheduler race, hydration warning, icon 404)

### DIFF
--- a/open-security-dashboard/public/icon.svg
+++ b/open-security-dashboard/public/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="7" fill="#0ea5e9"/>
+  <path d="M16 5l8 3v6c0 5.2-3.4 9.6-8 11-4.6-1.4-8-5.8-8-11V8l8-3z"
+        fill="none" stroke="#ffffff" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M12 16.5l2.8 2.8L20 13.5" fill="none" stroke="#ffffff"
+        stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/open-security-dashboard/src/app/layout.tsx
+++ b/open-security-dashboard/src/app/layout.tsx
@@ -50,13 +50,9 @@ export const metadata: Metadata = {
     maximumScale: 1,
   },
   icons: {
-    icon: [
-      { url: '/favicon.ico', sizes: 'any' },
-      { url: '/icon.svg', type: 'image/svg+xml' },
-    ],
-    apple: [
-      { url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' },
-    ],
+    // Only the SVG is shipped (public/icon.svg). An explicit icon link makes
+    // browsers use it instead of auto-requesting a (missing) /favicon.ico.
+    icon: [{ url: '/icon.svg', type: 'image/svg+xml' }],
   },
 }
 
@@ -66,7 +62,9 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    // suppressHydrationWarning: the theme provider sets the light/dark class on
+    // <html> on the client, which legitimately differs from the server render.
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
       <body className="min-h-screen bg-background font-sans antialiased">
         <Providers>
           {children}

--- a/open-security-data/app/scheduler/main.py
+++ b/open-security-data/app/scheduler/main.py
@@ -16,7 +16,7 @@ from sqlalchemy import and_
 
 from app.config import get_config
 from app.models import Source, CollectionRun
-from app.utils.database import get_db_session
+from app.utils.database import get_db_session, create_tables
 from app.collectors import CollectorRegistry
 # Import collectors to register them
 import app.collectors.sources  # noqa: F401
@@ -44,7 +44,13 @@ class CollectionScheduler:
         """Start the scheduler"""
         logger.info("Starting collection scheduler")
         self.running = True
-        
+
+        # Ensure the schema exists before querying. The scheduler shares the data
+        # service's database but can start before the API has run create_tables(),
+        # which otherwise causes a transient "relation sources does not exist" on
+        # a cold start. create_tables() is idempotent.
+        create_tables()
+
         # Load sources and create initial schedule
         await self._load_sources()
         


### PR DESCRIPTION
Knocks out the small known errors surfaced during the full-stack bring-up.

- **data-scheduler cold-start race** — the scheduler queried `sources` before the data API ran `create_tables()`, logging a transient `relation "sources" does not exist`. It now calls `create_tables()` (idempotent) before loading sources. **Verified:** wiped the data schema, recreated the scheduler alone → it created the 9 tables and loaded sources with **0** "does not exist" errors.
- **dashboard hydration warning** — `suppressHydrationWarning` on `<html>`; the theme provider sets the light/dark class client-side (legitimately differs from SSR). (Was `Prop className did not match` in the console.)
- **favicon / icon 404** — shipped `public/icon.svg` (a real shield icon) and pointed the icon metadata at it only. An explicit SVG icon link stops the browser auto-requesting a missing `/favicon.ico`. **Verified:** `/icon.svg` → 200, dashboard → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)