### PR TITLE
feat(identity,gateway): enforce API key scopes (least-privilege)

### DIFF
--- a/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
+++ b/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
@@ -446,7 +446,10 @@ server {
             end
             
             ngx.log(ngx.INFO, "AGENTS API: Authentication successful for user: " .. auth_data.user_id)
-            
+
+            -- Enforce API-key least-privilege scopes (no-op for unrestricted keys)
+            require("auth_handler").enforce_scopes(auth_data)
+
             -- SECURITY: Strip ALL client-supplied auth headers to prevent spoofing
             ngx.req.clear_header("X-Wildbox-User-ID")
             ngx.req.clear_header("X-Wildbox-Team-ID")

--- a/open-security-gateway/nginx/lua/auth_handler.lua
+++ b/open-security-gateway/nginx/lua/auth_handler.lua
@@ -316,6 +316,96 @@ local function apply_rate_limiting(auth_data)
     ngx.header["X-RateLimit-Reset"] = tostring(now + window_size)
 end
 
+-- Map a request (path + method) to the API-key scope it requires.
+-- Reads are cheaper than writes; deletes/automation management are privileged.
+local function required_scope_for_request(uri, method)
+    local is_read = (method == "GET" or method == "HEAD" or method == "OPTIONS")
+
+    -- Security tools and AI agents: running them is "execute".
+    if uri:find("^/api/tools/") or uri:find("^/api/v1/tools/")
+       or uri:find("^/api/v1/agents/") then
+        return is_read and "tools:read" or "tools:execute"
+    end
+    -- Automation (n8n) workflow management is administrative.
+    if uri:find("^/api/v1/automations/") then
+        return "tools:admin"
+    end
+    -- Guardian: vulnerability/asset/compliance data.
+    if uri:find("^/api/v1/guardian/") then
+        if is_read then return "data:read" end
+        if method == "DELETE" then return "data:delete" end
+        return "data:write"
+    end
+    -- Any other authenticated API path: generic read vs write.
+    return is_read and "read" or "write"
+end
+
+-- Does the set of granted scopes satisfy the required one?
+-- Hierarchy: "admin" > "write" > "read"; "<res>:admin" > "<res>:write|execute"
+-- > "<res>:read"; generic scopes satisfy resource scopes of equal-or-lower level.
+local function scopes_satisfy(granted, required)
+    local set = {}
+    for _, s in ipairs(granted) do set[s] = true end
+
+    if set[required] then return true end
+    if set["admin"] then return true end  -- global admin satisfies everything
+
+    local res, action = required:match("^(.-):(.+)$")
+    if not res then
+        -- Generic scope (read|write).
+        if required == "read" then
+            return (set["read"] or set["write"]) == true
+        elseif required == "write" then
+            return set["write"] == true
+        end
+        return false
+    end
+
+    -- Resource-scoped requirement. Resource admin satisfies any action.
+    if set[res .. ":admin"] then return true end
+    if action == "read" then
+        return (set[res .. ":read"] or set[res .. ":write"] or set[res .. ":execute"]
+                or set["read"] or set["write"]) == true
+    elseif action == "write" or action == "execute" then
+        return (set[res .. ":write"] or set[res .. ":execute"] or set["write"]) == true
+    elseif action == "delete" then
+        return set[res .. ":delete"] == true  -- needs explicit delete (or res admin, above)
+    end
+    return false
+end
+
+-- Enforce API-key scopes. No-op for interactive/JWT auth and legacy keys, whose
+-- scopes are null (cjson.null / not a table) → unrestricted.
+local function enforce_scopes(auth_data)
+    local scopes = auth_data.scopes
+    if type(scopes) ~= "table" then
+        return  -- unrestricted (bearer/JWT, or legacy key without scopes)
+    end
+
+    local required = required_scope_for_request(ngx.var.uri, ngx.var.request_method)
+    if scopes_satisfy(scopes, required) then
+        return
+    end
+
+    utils.log("warn", "API key missing required scope", {
+        required = required,
+        path = ngx.var.uri,
+        method = ngx.var.request_method
+    })
+    ngx.status = ngx.HTTP_FORBIDDEN
+    ngx.header.content_type = "application/json"
+    ngx.say(utils.json_encode({
+        error = "insufficient_scope",
+        message = "This API key is not authorized for this operation.",
+        required_scope = required
+    }))
+    ngx.exit(ngx.HTTP_FORBIDDEN)
+end
+
+-- Exported so regex locations that authenticate inline (e.g. /api/v1/agents/)
+-- can reuse the same scope enforcement.
+_M.enforce_scopes = enforce_scopes
+
 -- Set authentication headers for backend services
 local function set_auth_headers(auth_data)
     -- SECURITY: Strip ALL client-supplied auth headers BEFORE setting validated ones.
@@ -414,9 +504,12 @@ function _M.authenticate()
         set_cached_auth_data(cache_key, auth_data, config)
     end
     
+    -- Enforce API-key least-privilege scopes (no-op for interactive/JWT auth)
+    enforce_scopes(auth_data)
+
     -- Apply rate limiting
     apply_rate_limiting(auth_data)
-    
+
     -- Set authentication headers for backend services
     set_auth_headers(auth_data)
     

--- a/open-security-identity/alembic/versions/e4f5a6b7c8d9_add_api_key_scopes.py
+++ b/open-security-identity/alembic/versions/e4f5a6b7c8d9_add_api_key_scopes.py
@@ -1,0 +1,30 @@
+"""add scopes column to api_keys (scoped API keys)
+
+Adds a nullable JSON `scopes` column to `api_keys`. NULL means a legacy key
+created before scoping existed and is treated as unrestricted (back-compat);
+a JSON list of scope strings is enforced at the gateway (path/method -> required
+scope). This makes the dashboard's per-key scope selector actually take effect.
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-06-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e4f5a6b7c8d9'
+down_revision: Union[str, None] = 'd3e4f5a6b7c8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('api_keys', sa.Column('scopes', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('api_keys', 'scopes')

--- a/open-security-identity/app/api_v1/endpoints/api_keys.py
+++ b/open-security-identity/app/api_v1/endpoints/api_keys.py
@@ -86,6 +86,7 @@ async def create_api_key(
         user_id=current_user.id,
         team_id=team.id,
         name=key_data.name,
+        scopes=key_data.scopes,
         expires_at=key_data.expires_at
     )
     
@@ -100,6 +101,7 @@ async def create_api_key(
         user_id=api_key.user_id,
         team_id=api_key.team_id,
         name=api_key.name,
+        scopes=api_key.scopes,
         is_active=api_key.is_active,
         expires_at=api_key.expires_at,
         last_used_at=api_key.last_used_at,

--- a/open-security-identity/app/api_v1/endpoints/user_api_keys.py
+++ b/open-security-identity/app/api_v1/endpoints/user_api_keys.py
@@ -84,6 +84,7 @@ async def create_user_api_key(
         user_id=current_user.id,
         team_id=team.id,
         name=key_data.name,
+        scopes=key_data.scopes,
         expires_at=key_data.expires_at
     )
 
@@ -98,6 +99,7 @@ async def create_user_api_key(
         user_id=api_key.user_id,
         team_id=api_key.team_id,
         name=api_key.name,
+        scopes=api_key.scopes,
         is_active=api_key.is_active,
         expires_at=api_key.expires_at,
         last_used_at=api_key.last_used_at,

--- a/open-security-identity/app/internal.py
+++ b/open-security-identity/app/internal.py
@@ -100,13 +100,15 @@ async def authorize_request(
 
             user, team, membership = row
 
-            # Build authorization response
+            # Build authorization response. Bearer (interactive) auth is not
+            # scope-limited — scopes=None means unrestricted at the gateway.
             return AuthorizationResponse(
                 is_authenticated=True,
                 user_id=str(user.id),
                 team_id=str(team.id),
                 role=membership.role,
-                permissions=_get_permissions_for_role(membership.role)
+                permissions=_get_permissions_for_role(membership.role),
+                scopes=None
             )
             
         elif request_data.token_type == "api_key":
@@ -156,12 +158,15 @@ async def authorize_request(
             api_key_obj.last_used_at = datetime.utcnow()
             await db.commit()
 
+            # API keys carry least-privilege scopes. NULL (legacy key created
+            # before scoping) => unrestricted; a list is enforced at the gateway.
             return AuthorizationResponse(
                 is_authenticated=True,
                 user_id=str(user.id),
                 team_id=str(team.id),
                 role=membership.role,
-                permissions=_get_permissions_for_role(membership.role)
+                permissions=_get_permissions_for_role(membership.role),
+                scopes=api_key_obj.scopes
             )
         else:
             raise HTTPException(

--- a/open-security-identity/app/models.py
+++ b/open-security-identity/app/models.py
@@ -11,8 +11,8 @@ from enum import Enum
 from typing import Optional
 
 from sqlalchemy import (
-    Boolean, Column, DateTime, ForeignKey, String, Text, 
-    UniqueConstraint, Index
+    Boolean, Column, DateTime, ForeignKey, String, Text,
+    UniqueConstraint, Index, JSON
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declarative_base
@@ -120,6 +120,11 @@ class ApiKey(Base):
     # Metadata
     name = Column(String(255), nullable=False)  # User-provided description
     is_active = Column(Boolean, default=True, nullable=False)
+    # Least-privilege scopes granted to this key (subset of the role's perms).
+    # NULL = legacy key created before scoping existed → unrestricted (back-compat);
+    # a list (incl. empty) = enforce: the gateway maps each request to a required
+    # scope and rejects keys that don't hold it.
+    scopes = Column(JSON, nullable=True)
     
     # Expiration and usage tracking
     expires_at = Column(DateTime(timezone=True), nullable=True)

--- a/open-security-identity/app/schemas.py
+++ b/open-security-identity/app/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from .models import TeamRole
 
@@ -19,7 +19,7 @@ import uuid
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from fastapi_users import schemas
 
 from .models import TeamRole
@@ -106,8 +106,36 @@ class TeamMembershipResponse(BaseModel):
 
 
 # API Key schemas
+
+# Canonical scope vocabulary (must match the dashboard's availableScopes).
+# A key may only be granted scopes from this set; the gateway maps each request
+# to a required scope and rejects keys that don't hold an equal-or-greater one.
+VALID_API_KEY_SCOPES = frozenset({
+    "read", "write", "admin",
+    "tools:read", "tools:execute", "tools:admin",
+    "data:read", "data:write", "data:delete",
+    "reports:read", "reports:write",
+    "team:read", "team:manage",
+})
+
+
 class ApiKeyCreate(ApiKeyBase):
     expires_at: Optional[datetime] = None
+    # Optional for back-compat: omitted/None => unrestricted (legacy behaviour).
+    # A list restricts the key to those scopes (enforced at the gateway).
+    scopes: Optional[List[str]] = None
+
+    @field_validator("scopes")
+    @classmethod
+    def _validate_scopes(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is None:
+            return v
+        unknown = sorted(set(v) - VALID_API_KEY_SCOPES)
+        if unknown:
+            raise ValueError(f"Unknown API key scope(s): {', '.join(unknown)}")
+        # De-duplicate while preserving order.
+        seen: set[str] = set()
+        return [s for s in v if not (s in seen or seen.add(s))]
 
 
 class ApiKeyResponse(ApiKeyBase):
@@ -116,10 +144,11 @@ class ApiKeyResponse(ApiKeyBase):
     user_id: UUID
     team_id: UUID
     is_active: bool
+    scopes: Optional[List[str]] = None
     expires_at: Optional[datetime] = None
     last_used_at: Optional[datetime] = None
     created_at: datetime
-    
+
     class Config:
         from_attributes = True
 
@@ -149,6 +178,9 @@ class AuthorizationResponse(BaseModel):
     team_id: Optional[str] = None
     role: Optional[str] = None
     permissions: List[str] = []
+    # API-key scopes for least-privilege enforcement at the gateway.
+    # None => unrestricted (interactive/JWT auth, or a legacy key with no scopes).
+    scopes: Optional[List[str]] = None
 
 
 # Update forward references


### PR DESCRIPTION
## Problem
The dashboard's API-key UI **requires** the user to pick scopes (`read`, `tools:read`, `data:write`, `tools:admin`, …) and sends them on create — but they were a **no-op**:
- `ApiKeyCreate` had no `scopes` field → Pydantic silently dropped them.
- The `api_keys` table had no `scopes` column.
- `/internal/authorize` always returned the creator's **full role permissions**.

So a "Read Only" key could still write, delete and execute — a least-privilege illusion.

## Fix — make scopes real, enforce centrally at the gateway

**identity**
- `ApiKey` gains a nullable JSON `scopes` column (alembic `e4f5a6b7c8d9`). `NULL` = legacy key created before scoping = **unrestricted** (back-compat); a list is enforced.
- `ApiKeyCreate` accepts + validates `scopes` against a canonical vocabulary (`VALID_API_KEY_SCOPES`, matching the dashboard); unknown scope → **422**.
- Both working create paths store scopes (`/api/v1/api-keys`, `/api/v1/teams/{team_id}/api-keys`); `ApiKeyResponse` returns them.
- `/internal/authorize` returns the key's scopes for `api_key` auth; bearer/JWT (interactive) returns `scopes=null` = unrestricted.

**gateway (`auth_handler.lua`)**
- Maps each request (path + method) → required scope: tools `:read`/`:execute`, guardian → `data:read`/`data:write`/`data:delete`, automations → `tools:admin`, default generic `read`/`write`.
- Enforces with a small hierarchy (`admin` > `write` > `read`; `<res>:admin` > `<res>:write|execute` > `<res>:read`; generic scopes satisfy lower resource scopes). Missing scope → **403 `insufficient_scope`**.
- No-op when scopes are null (interactive/JWT auth, or legacy keys).
- `enforce_scopes` exported and wired into the inline-Lua `/api/v1/agents/` location too (agents is API-key-only).

## Verification (live stack)
| request | result |
|---|---|
| read-only key → `GET /api/v1/guardian/vulnerabilities/` | **200** (allowed) |
| read-only key → `POST /api/tools/header_analyzer` | **403 `insufficient_scope`** (required `tools:execute`) |
| admin key → `POST /api/tools/header_analyzer` | 422 (passed scope gate, body invalid — **not** 403) |
| bearer JWT → `POST /api/tools/header_analyzer` | 422 (unrestricted — **not** 403) |
| create with invalid scope | **422** |
| scopes stored + returned on create | ✓ |

## Out of scope (pre-existing, tracked separately)
The dashboard's api-keys page posts to a non-existent `/api/v1/users/me/api-keys` (404) and a broken duplicate `create_my_api_key` lives in `users.py`. That UI-wiring bug predates this change; scoped-key creation here is exercised via the working `/api/v1/api-keys` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)