### PR TITLE
chore(gateway): remove dead X-Wildbox-Plan header (billing removed)

### DIFF
--- a/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
+++ b/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
@@ -453,7 +453,6 @@ server {
             -- SECURITY: Strip ALL client-supplied auth headers to prevent spoofing
             ngx.req.clear_header("X-Wildbox-User-ID")
             ngx.req.clear_header("X-Wildbox-Team-ID")
-            ngx.req.clear_header("X-Wildbox-Plan")
             ngx.req.clear_header("X-Wildbox-Role")
             ngx.req.clear_header("Authorization")
             ngx.req.clear_header("X-API-Key")
@@ -461,7 +460,6 @@ server {
             -- Set headers from validated auth data only
             ngx.req.set_header("X-Wildbox-User-ID", auth_data.user_id)
             ngx.req.set_header("X-Wildbox-Team-ID", auth_data.team_id)
-            ngx.req.set_header("X-Wildbox-Plan", auth_data.plan or "free")
             ngx.req.set_header("X-Wildbox-Role", auth_data.role or "member")
         }
         

--- a/open-security-gateway/nginx/lua/auth_apikey_simple.lua
+++ b/open-security-gateway/nginx/lua/auth_apikey_simple.lua
@@ -83,7 +83,6 @@ local auth_data = cjson.decode(res.body)
 
 ngx.req.set_header("X-Wildbox-User-ID", auth_data.user_id)
 ngx.req.set_header("X-Wildbox-Team-ID", auth_data.team_id)
-ngx.req.set_header("X-Wildbox-Plan", auth_data.plan or "free")
 ngx.req.set_header("X-Wildbox-Role", auth_data.role or "user")
 
 ngx.log(ngx.INFO, "API key authenticated for user: ", auth_data.user_id, " team: ", auth_data.team_id)

--- a/open-security-gateway/nginx/nginx.conf
+++ b/open-security-gateway/nginx/nginx.conf
@@ -134,12 +134,12 @@ http {
 
     map $request_method $cors_headers {
         default "";
-        OPTIONS "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-Wildbox-Plan,X-API-Key";
-        GET "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-Wildbox-Plan,X-API-Key";
-        POST "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-Wildbox-Plan,X-API-Key";
-        PUT "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-Wildbox-Plan,X-API-Key";
-        DELETE "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-Wildbox-Plan,X-API-Key";
-        PATCH "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-Wildbox-Plan,X-API-Key";
+        OPTIONS "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
+        GET "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
+        POST "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
+        PUT "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
+        DELETE "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
+        PATCH "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
     }
 
     # Initialize Lua modules


### PR DESCRIPTION
Billing/subscriptions were removed in #129, so identity's `/internal/authorize` no longer returns a `plan` and **no backend reads `X-Wildbox-Plan`**. The gateway still stamped it (always `auth_data.plan or "free"` → `"free"`) and advertised it in CORS — dead code.

Removes it:
- agents inline-Lua location (`wildbox_gateway.conf`): stop clearing/setting `X-Wildbox-Plan`.
- `auth_apikey_simple.lua`: stop setting it.
- `nginx.conf`: remove `X-Wildbox-Plan` from the CORS allowed-headers map.

(The only remaining reference is a commented-out `proxy_cache_key` line, left as-is.)

**Verified**: gateway healthy after reload; JWT auth (`guardian` → 200) and API-key auth (`agents` request proxied past auth+scope) both still work. Confirmed no backend service reads the header (`grep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)