### PR TITLE
sec(automations): bind n8n to localhost so webhooks aren't network-exposed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -545,7 +545,13 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "5678:5678"
+      # Bind to localhost only. N8N_BASIC_AUTH protects the editor/REST API but
+      # NOT webhook endpoints (/webhook/*), which are unauthenticated by design —
+      # exposing 0.0.0.0:5678 would let anyone on the network trigger workflows.
+      # 127.0.0.1 keeps it reachable for local admin (e.g. via an SSH tunnel)
+      # without exposing it to the network; containers still reach it over the
+      # docker network by service name. Matches tools-flower (also 127.0.0.1).
+      - "127.0.0.1:5678:5678"
     environment:
       - N8N_BASIC_AUTH_ACTIVE=true
       - N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER}


### PR DESCRIPTION
## Problem
n8n's port was published on `0.0.0.0:5678`. `N8N_BASIC_AUTH` guards the editor/REST API but **not** webhook endpoints (`/webhook/*`) — those are unauthenticated by design. So anyone able to reach the host on `:5678` could trigger n8n workflows with **no Wildbox authentication**, entirely bypassing the gateway.

## Fix
Bind to `127.0.0.1:5678` — reachable for local admin (e.g. via SSH tunnel) but not from the network. Containers still reach n8n over the docker network by service name, so nothing internal changes. Matches the `tools-flower` admin UI (also `127.0.0.1`-bound).

## Verified
- Port now publishes as `127.0.0.1:5678->5678/tcp` (was `0.0.0.0:5678`).
- n8n still healthy after recreate; `docker compose config` valid.

## Note — pre-existing, out of scope
While verifying, found the gateway's `automations_service` upstream is `server 127.0.0.1:5678 down` — both the **wrong host** (the gateway container's own loopback, not the n8n container — should be `open-security-automations:5678`) **and** marked `down`. So the authenticated `/api/v1/automations/` route already returns 502 (and n8n's own basic-auth would challenge gateway-proxied requests anyway). Enabling that route is a separate functional task, tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)