### PR TITLE
sec(tools): central SSRF guard for all tool targets

### DIFF
--- a/open-security-tools/app/api/router.py
+++ b/open-security-tools/app/api/router.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Request
 from typing import Dict, Any, List
 from app.auth import verify_api_key
 from app.execution_manager import ToolExecutionManager
+from app.input_validation import InputSanitizer
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -163,7 +164,18 @@ def register_tool_endpoint(app, tool_name: str, tool_module: Any):
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="Input validation failed"
             )
-        
+
+        # SSRF guard: refuse to let a tool connect to private/internal/cloud-metadata
+        # targets, regardless of whether the individual tool validates its own input.
+        try:
+            InputSanitizer.validate_request_urls(validated_input)
+        except ValueError as e:
+            logger.warning(f"Blocked SSRF target for {tool_name}: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e)
+            )
+
         logger.info(f"Executing tool: {tool_name}", extra={
             "tool": tool_name,
             "input": validated_input.model_dump(),

--- a/open-security-tools/app/input_validation.py
+++ b/open-security-tools/app/input_validation.py
@@ -160,6 +160,23 @@ class InputSanitizer:
 
         return url
 
+    # Tool-input fields that carry a URL the tool will connect to (SSRF surface).
+    URL_REQUEST_FIELDS = ("target_url", "url")
+
+    @classmethod
+    def validate_request_urls(cls, input_obj) -> None:
+        """SSRF guard for tool inputs.
+
+        Validate any URL-bearing field on a validated tool-input object so a tool
+        cannot be pointed at private/internal/cloud-metadata hosts. Only http(s)
+        values are checked (non-URL fields are left untouched for the tool to
+        handle). Raises ValueError if a target resolves to a blocked host.
+        """
+        for field in cls.URL_REQUEST_FIELDS:
+            value = getattr(input_obj, field, None)
+            if isinstance(value, str) and re.match(r'^https?://', value.strip(), re.IGNORECASE):
+                cls.validate_url(value)
+
     @classmethod
     def validate_ip(cls, ip_str: str) -> str:
         """Validate an IP address. Blocks private/internal ranges."""

--- a/open-security-tools/app/tasks.py
+++ b/open-security-tools/app/tasks.py
@@ -97,7 +97,12 @@ def execute_tool_async(
         
         # Validate and convert input
         validated_input = input_schema_class(**input_data)
-        
+
+        # SSRF guard (same policy as the synchronous API path): block tool
+        # targets that resolve to private/internal/cloud-metadata hosts.
+        from app.input_validation import InputSanitizer
+        InputSanitizer.validate_request_urls(validated_input)
+
         # Execute the tool (handle both sync and async)
         import inspect
         if inspect.iscoroutinefunction(execute_func):


### PR DESCRIPTION
## Problem
Only a couple of HTTP-fetching tools (`url_security_scanner`, `header_analyzer`) guarded their target against private/internal IPs. Others — `web_vuln_scanner`, `xss_scanner`, `http_security_scanner`, `cookie_scanner`, … — fetched user-supplied URLs with **no SSRF check**, so an authenticated user could point them at `127.0.0.1`, RFC1918 ranges, or the cloud-metadata endpoint (`169.254.169.254` → IAM credential theft).

## Fix — guard at the choke points, not per-tool
Both execution paths funnel validated input through one place each; add the guard there so it covers **all** tools:

- `InputSanitizer.validate_request_urls()` validates the URL-bearing input fields (`target_url`, `url`) with the existing SSRF-aware `validate_url` (blocks private, loopback, link-local, reserved, multicast, and cloud-metadata IPs). Only `http(s)` values are checked; non-URL fields are left untouched.
- **Sync path** (`api/router.py`): runs it right after schema validation → **400** with the block reason.
- **Async path** (`tasks.py`, Celery): runs it before dispatch → surfaced as task failure.

Reuses the same `validate_url` the already-guarded tools rely on, so the policy is consistent.

## Verified (live stack, via the gateway)
| request | result |
|---|---|
| `web_vuln_scanner` `target_url=http://169.254.169.254/` | **400** blocked |
| `web_vuln_scanner` `target_url=http://127.0.0.1/` / `http://10.0.0.1/` | **400** blocked |
| `http_security_scanner` `url=http://169.254.169.254/` | **400** blocked (the `url` field is covered too) |
| `web_vuln_scanner` `target_url=http://example.com/` | passes the guard, proceeds to execution (not 400) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)