### PR TITLE
chore: add Dependabot for automated dependency & Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot configuration — https://docs.github.com/code-security/dependabot
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directories:
+      - "/open-security-*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      pip:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/open-security-dashboard"
+      - "/website"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/open-security-*"
+      - "/tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable **weekly automated dependency updates**.

- Minor/patch updates are **grouped** into one PR per ecosystem to minimise noise; majors come individually.
- Ecosystems are scoped to the manifests actually present in this repo (GitHub Actions + the relevant package managers / Dockerfiles).
- Config-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)