### PR TITLE
docs: fix broken Next Steps link (environment.md -> credentials.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ curl http://localhost:8001/health
 
 ### Next Steps
 1. Review **[Security Best Practices](SECURITY.md)**
-2. Configure **[Environment Variables](docs/guides/environment.md)**
+2. Configure **[Environment Variables](docs/guides/credentials.md)**
 3. Read **[Deployment Guide](docs/guides/deployment.md)** for production setup
 4. Explore **[API Documentation](docs/api/)**
 


### PR DESCRIPTION
## What
In the README's **Next Steps**, the *Environment Variables* link pointed to `docs/guides/environment.md` — which does not exist (**404**).

## Fix
Repoint it to **`docs/guides/credentials.md`**, which is the guide that actually documents environment-variable setup (it contains the "Environment Variable Template" / `.env` section). All other `docs/guides/*` links in Next Steps already resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)