### PR TITLE
chore: remove hardcoded developer path from audit/test scripts

### DIFF
--- a/open-security-tools/audit_tools.py
+++ b/open-security-tools/audit_tools.py
@@ -12,8 +12,12 @@ from pathlib import Path
 from typing import Dict, Any, List
 import logging
 
+# Resolve paths relative to this file so the script is portable
+BASE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BASE_DIR.parent
+
 # Add the app directory to Python path
-sys.path.insert(0, '/Users/fab/GitHub/wildbox/open-security-tools')
+sys.path.insert(0, str(BASE_DIR))
 
 from app.standardized_schemas import tool_validator, BaseToolInput, BaseToolOutput
 
@@ -23,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def discover_tools() -> List[str]:
     """Discover all available tools."""
-    tools_dir = Path('/Users/fab/GitHub/wildbox/open-security-tools/app/tools')
+    tools_dir = BASE_DIR / 'app' / 'tools'
     tools = []
     
     for tool_dir in tools_dir.iterdir():
@@ -51,7 +55,7 @@ def audit_tool_schemas(tool_name: str) -> Dict[str, Any]:
     
     try:
         # Check if files exist
-        tool_path = Path(f'/Users/fab/GitHub/wildbox/open-security-tools/app/tools/{tool_name}')
+        tool_path = BASE_DIR / 'app' / 'tools' / tool_name
         schemas_file = tool_path / 'schemas.py'
         main_file = tool_path / 'main.py'
         
@@ -223,7 +227,7 @@ def main():
     report = generate_audit_report(audit_results)
     
     # Save detailed report
-    with open('/Users/fab/GitHub/wildbox/TOOL_COMPLIANCE_AUDIT.json', 'w') as f:
+    with open(REPO_ROOT / 'TOOL_COMPLIANCE_AUDIT.json', 'w') as f:
         json.dump(report, f, indent=2)
     
     # Print summary

--- a/open-security-tools/integration_test.py
+++ b/open-security-tools/integration_test.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 
 # Add the app directory to Python path
-sys.path.insert(0, '/Users/fab/GitHub/wildbox/open-security-tools')
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from app.secure_execution_manager import SecureToolExecutionManager
 from app.standardized_schemas import BaseToolInput, BaseToolOutput

--- a/tests/test_inventory_mapper.py
+++ b/tests/test_inventory_mapper.py
@@ -13,8 +13,9 @@ from collections import defaultdict
 class TestInventoryMapper:
     """Mappa tutti i test nel repository Wildbox"""
     
-    def __init__(self, repo_path: str = "/Users/fab/GitHub/wildbox"):
-        self.repo_path = Path(repo_path)
+    def __init__(self, repo_path: str | None = None):
+        # Default to the repo root (the parent of tests/, where this file lives)
+        self.repo_path = Path(repo_path) if repo_path else Path(__file__).resolve().parents[1]
         self.inventory = {
             "python_tests": [],
             "typescript_tests": [],


### PR DESCRIPTION
## What
Replace the hardcoded absolute path `/Users/fab/GitHub/wildbox` (6 occurrences across 3 files) with paths resolved relative to `__file__`:
- `open-security-tools/audit_tools.py` — `BASE_DIR`/`REPO_ROOT` from `__file__`
- `open-security-tools/integration_test.py` — `sys.path` from `__file__`
- `tests/test_inventory_mapper.py` — default `repo_path` derived from the file location

## Why
These scripts only worked on one machine and leaked a personal filesystem path in a public repo.

## Verified
- `grep "/Users/"` over the three files: none remain
- `python -m py_compile` passes on all three

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)