### PR TITLE
chore: release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-06-28
+
+### Changed
+- Documentation-quality CI: run link checking on Node 22 (Node 18 broke on the now-ESM `marked`), expand the cspell dictionary, and fix the empty-alt examples so the Spell Check, Link Validation, and Image Alt Text gates pass.
+
+### Removed
+- Stopped tracking generated artifacts (`.coverage`, `tests/reports/junit.xml`, Playwright `test-results/`).
+- Removed committed status-report docs (`*_COMPLETE.md`, `*_IN_PROGRESS.md`, …) and one-off migration scripts.
+
+### Fixed
+- Removed a hardcoded developer path from the tool audit/integration scripts so they run on any checkout.
+- Fixed the dead YouTube thumbnail link in the README (`maxresdefault` → `hqdefault`).
+
 ## [0.5.5] - 2026-02-22
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Next.js, TypeScript, Tailwind CSS, TanStack Query.
 
 ## Roadmap
 
-**Current version: v0.5.5 (Security-Hardened)**
+**Current version: v0.5.6 (Security-Hardened)**
 
 **Phase 1: Stabilization** - Done
 - Core security controls, documentation, CI/CD


### PR DESCRIPTION
Patch release **v0.5.6** — repo hygiene + documentation-quality CI. Bumps the README version line and adds the CHANGELOG entry.

Aggregates the four PRs merged this session:
- #184 stop tracking generated coverage/test artifacts
- #185 remove committed status-report docs and one-off scripts
- #186 remove hardcoded developer path from audit/test scripts
- #188 green 3/4 documentation-quality checks (Link Validation on Node 22, Spell Check, Image Alt Text)

No code or behavior changes; docs/CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)