### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.6] - 2026-06-28
+## [0.6.2] - 2026-06-28
 
 ### Changed
 - Documentation-quality CI: run link checking on Node 22 (Node 18 broke on the now-ESM `marked`), expand the cspell dictionary, and fix the empty-alt examples so the Spell Check, Link Validation, and Image Alt Text gates pass.

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Next.js, TypeScript, Tailwind CSS, TanStack Query.
 
 ## Roadmap
 
-**Current version: v0.5.6 (Security-Hardened)**
+**Current version: v0.6.2 (Security-Hardened)**
 
 **Phase 1: Stabilization** - Done
 - Core security controls, documentation, CI/CD


### PR DESCRIPTION
Corrects the version line. The published git tags were already at **v0.6.1**, but `README`/`CHANGELOG` had drifted to `0.5.x`. This bumps to **v0.6.2** (the real next patch); the erroneous `v0.5.6` tag/release (which sorted *below* v0.6.1) has been removed.

Same patch content as before — repo hygiene + documentation-quality CI (PRs #184/#185/#186/#188), just under the correct version.

> Note: `CHANGELOG.md` still lacks `[0.6.0]`/`[0.6.1]` entries (those were tagged without changelog updates) — a pre-existing gap, flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)