### PR TITLE
fix(cspm): report unimplemented checks as NOT_IMPLEMENTED, never PASSED

### DIFF
--- a/open-security-cspm/app/checks/aws/accessanalyzer/check_enabled.py
+++ b/open-security-cspm/app/checks/aws/accessanalyzer/check_enabled.py
@@ -56,8 +56,8 @@ class CheckAccessAnalyzerEnabled(BaseCheck):
                 resource_type="AWS::accessanalyzer::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'accessanalyzer',

--- a/open-security-cspm/app/checks/aws/amplify/check_branch_protection.py
+++ b/open-security-cspm/app/checks/aws/amplify/check_branch_protection.py
@@ -56,8 +56,8 @@ class CheckAmplifyBranchProtection(BaseCheck):
                 resource_type="AWS::amplify::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'amplify',

--- a/open-security-cspm/app/checks/aws/apigateway/check_logging_enabled.py
+++ b/open-security-cspm/app/checks/aws/apigateway/check_logging_enabled.py
@@ -56,7 +56,7 @@ class CheckAPIGatewayLogging(BaseCheck):
                 resource_type="AWS::apigateway::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/apigateway/check_ssl_certificate.py
+++ b/open-security-cspm/app/checks/aws/apigateway/check_ssl_certificate.py
@@ -56,7 +56,7 @@ class CheckAPIGatewaySSLCertificate(BaseCheck):
                 resource_type="AWS::apigateway::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/apigateway/check_waf_enabled.py
+++ b/open-security-cspm/app/checks/aws/apigateway/check_waf_enabled.py
@@ -56,7 +56,7 @@ class CheckAPIGatewayWAF(BaseCheck):
                 resource_type="AWS::apigateway::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/apprunner/check_auto_scaling.py
+++ b/open-security-cspm/app/checks/aws/apprunner/check_auto_scaling.py
@@ -56,8 +56,8 @@ class CheckAppRunnerAutoScaling(BaseCheck):
                 resource_type="AWS::apprunner::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'apprunner',

--- a/open-security-cspm/app/checks/aws/athena/check_result_encryption.py
+++ b/open-security-cspm/app/checks/aws/athena/check_result_encryption.py
@@ -55,7 +55,7 @@ class CheckAthenaResultEncryption(BaseCheck):
                 resource_type="AWS::athena::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/athena/check_workgroup_configuration.py
+++ b/open-security-cspm/app/checks/aws/athena/check_workgroup_configuration.py
@@ -55,7 +55,7 @@ class CheckAthenaWorkgroupConfig(BaseCheck):
                 resource_type="AWS::athena::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/backup/check_backup_plans.py
+++ b/open-security-cspm/app/checks/aws/backup/check_backup_plans.py
@@ -55,7 +55,7 @@ class CheckBackupPlansConfigured(BaseCheck):
                 resource_type="AWS::backup::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/backup/check_cross_region_backup.py
+++ b/open-security-cspm/app/checks/aws/backup/check_cross_region_backup.py
@@ -55,7 +55,7 @@ class CheckCrossRegionBackup(BaseCheck):
                 resource_type="AWS::backup::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/certificate/check_certificate_transparency.py
+++ b/open-security-cspm/app/checks/aws/certificate/check_certificate_transparency.py
@@ -56,8 +56,8 @@ class CheckACMCertificateTransparency(BaseCheck):
                 resource_type="AWS::certificate::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'certificate',

--- a/open-security-cspm/app/checks/aws/certificate/check_certificate_validation.py
+++ b/open-security-cspm/app/checks/aws/certificate/check_certificate_validation.py
@@ -56,8 +56,8 @@ class CheckACMCertificateValidation(BaseCheck):
                 resource_type="AWS::certificate::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'certificate',

--- a/open-security-cspm/app/checks/aws/cloudwatch/check_log_group_encryption.py
+++ b/open-security-cspm/app/checks/aws/cloudwatch/check_log_group_encryption.py
@@ -56,7 +56,7 @@ class CheckCloudWatchLogEncryption(BaseCheck):
                 resource_type="AWS::cloudwatch::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/cloudwatch/check_log_group_retention.py
+++ b/open-security-cspm/app/checks/aws/cloudwatch/check_log_group_retention.py
@@ -56,7 +56,7 @@ class CheckCloudWatchLogRetention(BaseCheck):
                 resource_type="AWS::cloudwatch::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/codebuild/check_environment_variables.py
+++ b/open-security-cspm/app/checks/aws/codebuild/check_environment_variables.py
@@ -55,7 +55,7 @@ class CheckCodeBuildEnvironmentVariables(BaseCheck):
                 resource_type="AWS::codebuild::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/codebuild/check_privileged_mode.py
+++ b/open-security-cspm/app/checks/aws/codebuild/check_privileged_mode.py
@@ -55,7 +55,7 @@ class CheckCodeBuildPrivilegedMode(BaseCheck):
                 resource_type="AWS::codebuild::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/codepipeline/check_encryption.py
+++ b/open-security-cspm/app/checks/aws/codepipeline/check_encryption.py
@@ -55,7 +55,7 @@ class CheckCodePipelineEncryption(BaseCheck):
                 resource_type="AWS::codepipeline::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/config/check_delivery_channel.py
+++ b/open-security-cspm/app/checks/aws/config/check_delivery_channel.py
@@ -56,7 +56,7 @@ class CheckConfigDeliveryChannel(BaseCheck):
                 resource_type="AWS::config::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/config/check_enabled.py
+++ b/open-security-cspm/app/checks/aws/config/check_enabled.py
@@ -56,7 +56,7 @@ class CheckAWSConfigEnabled(BaseCheck):
                 resource_type="AWS::config::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/config/check_recording_all_resources.py
+++ b/open-security-cspm/app/checks/aws/config/check_recording_all_resources.py
@@ -56,7 +56,7 @@ class CheckConfigRecordingAllResources(BaseCheck):
                 resource_type="AWS::config::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/datasync/check_encryption.py
+++ b/open-security-cspm/app/checks/aws/datasync/check_encryption.py
@@ -56,8 +56,8 @@ class CheckDataSyncEncryption(BaseCheck):
                 resource_type="AWS::datasync::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'datasync',

--- a/open-security-cspm/app/checks/aws/detective/check_enabled.py
+++ b/open-security-cspm/app/checks/aws/detective/check_enabled.py
@@ -56,8 +56,8 @@ class CheckDetectiveEnabled(BaseCheck):
                 resource_type="AWS::detective::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'detective',

--- a/open-security-cspm/app/checks/aws/directconnect/check_connection_encryption.py
+++ b/open-security-cspm/app/checks/aws/directconnect/check_connection_encryption.py
@@ -56,8 +56,8 @@ class CheckDirectConnectEncryption(BaseCheck):
                 resource_type="AWS::directconnect::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'directconnect',

--- a/open-security-cspm/app/checks/aws/ecr/check_image_scanning.py
+++ b/open-security-cspm/app/checks/aws/ecr/check_image_scanning.py
@@ -56,8 +56,8 @@ class CheckECRImageScanning(BaseCheck):
                 resource_type="AWS::ecr::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'ecr',

--- a/open-security-cspm/app/checks/aws/ecr/check_immutable_tags.py
+++ b/open-security-cspm/app/checks/aws/ecr/check_immutable_tags.py
@@ -56,8 +56,8 @@ class CheckECRImmutableTags(BaseCheck):
                 resource_type="AWS::ecr::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'ecr',

--- a/open-security-cspm/app/checks/aws/ecr/check_lifecycle_policy.py
+++ b/open-security-cspm/app/checks/aws/ecr/check_lifecycle_policy.py
@@ -56,8 +56,8 @@ class CheckECRLifecyclePolicy(BaseCheck):
                 resource_type="AWS::ecr::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'ecr',

--- a/open-security-cspm/app/checks/aws/ecs/check_container_insights.py
+++ b/open-security-cspm/app/checks/aws/ecs/check_container_insights.py
@@ -56,7 +56,7 @@ class CheckECSContainerInsights(BaseCheck):
                 resource_type="AWS::ecs::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/ecs/check_task_definition_secrets.py
+++ b/open-security-cspm/app/checks/aws/ecs/check_task_definition_secrets.py
@@ -56,7 +56,7 @@ class CheckECSTaskDefinitionSecrets(BaseCheck):
                 resource_type="AWS::ecs::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/ecs/check_task_role_assigned.py
+++ b/open-security-cspm/app/checks/aws/ecs/check_task_role_assigned.py
@@ -56,7 +56,7 @@ class CheckECSTaskRoleAssigned(BaseCheck):
                 resource_type="AWS::ecs::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/efs/check_backup_enabled.py
+++ b/open-security-cspm/app/checks/aws/efs/check_backup_enabled.py
@@ -56,7 +56,7 @@ class CheckEFSBackupEnabled(BaseCheck):
                 resource_type="AWS::efs::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/efs/check_encryption_at_rest.py
+++ b/open-security-cspm/app/checks/aws/efs/check_encryption_at_rest.py
@@ -56,7 +56,7 @@ class CheckEFSEncryptionatRest(BaseCheck):
                 resource_type="AWS::efs::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/efs/check_encryption_in_transit.py
+++ b/open-security-cspm/app/checks/aws/efs/check_encryption_in_transit.py
@@ -56,7 +56,7 @@ class CheckEFSEncryptioninTransit(BaseCheck):
                 resource_type="AWS::efs::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/eks/check_endpoint_private.py
+++ b/open-security-cspm/app/checks/aws/eks/check_endpoint_private.py
@@ -56,7 +56,7 @@ class CheckEKSPrivateEndpoint(BaseCheck):
                 resource_type="AWS::eks::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/eks/check_logging_enabled.py
+++ b/open-security-cspm/app/checks/aws/eks/check_logging_enabled.py
@@ -56,7 +56,7 @@ class CheckEKSLoggingEnabled(BaseCheck):
                 resource_type="AWS::eks::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/eks/check_secrets_encryption.py
+++ b/open-security-cspm/app/checks/aws/eks/check_secrets_encryption.py
@@ -56,7 +56,7 @@ class CheckEKSSecretsEncryption(BaseCheck):
                 resource_type="AWS::eks::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/elasticache/check_backup_retention.py
+++ b/open-security-cspm/app/checks/aws/elasticache/check_backup_retention.py
@@ -56,7 +56,7 @@ class CheckElastiCacheBackupRetention(BaseCheck):
                 resource_type="AWS::elasticache::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/elasticache/check_encryption_at_rest.py
+++ b/open-security-cspm/app/checks/aws/elasticache/check_encryption_at_rest.py
@@ -56,7 +56,7 @@ class CheckElastiCacheEncryptionatRest(BaseCheck):
                 resource_type="AWS::elasticache::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/elasticache/check_encryption_in_transit.py
+++ b/open-security-cspm/app/checks/aws/elasticache/check_encryption_in_transit.py
@@ -56,7 +56,7 @@ class CheckElastiCacheEncryptioninTransit(BaseCheck):
                 resource_type="AWS::elasticache::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/elb/check_access_logging.py
+++ b/open-security-cspm/app/checks/aws/elb/check_access_logging.py
@@ -56,7 +56,7 @@ class CheckELBAccessLogging(BaseCheck):
                 resource_type="AWS::elb::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/elb/check_connection_draining.py
+++ b/open-security-cspm/app/checks/aws/elb/check_connection_draining.py
@@ -56,7 +56,7 @@ class CheckELBConnectionDraining(BaseCheck):
                 resource_type="AWS::elb::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/elb/check_https_only.py
+++ b/open-security-cspm/app/checks/aws/elb/check_https_only.py
@@ -56,7 +56,7 @@ class CheckELBHTTPSOnly(BaseCheck):
                 resource_type="AWS::elb::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/eventbridge/check_dead_letter_queue.py
+++ b/open-security-cspm/app/checks/aws/eventbridge/check_dead_letter_queue.py
@@ -55,7 +55,7 @@ class CheckEventBridgeDLQ(BaseCheck):
                 resource_type="AWS::eventbridge::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/eventbridge/check_encryption.py
+++ b/open-security-cspm/app/checks/aws/eventbridge/check_encryption.py
@@ -55,7 +55,7 @@ class CheckEventBridgeEncryption(BaseCheck):
                 resource_type="AWS::eventbridge::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/globalaccelerator/check_flow_logs.py
+++ b/open-security-cspm/app/checks/aws/globalaccelerator/check_flow_logs.py
@@ -56,8 +56,8 @@ class CheckGlobalAcceleratorFlowLogs(BaseCheck):
                 resource_type="AWS::globalaccelerator::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'globalaccelerator',

--- a/open-security-cspm/app/checks/aws/guardduty/check_enabled.py
+++ b/open-security-cspm/app/checks/aws/guardduty/check_enabled.py
@@ -56,7 +56,7 @@ class CheckGuardDutyEnabled(BaseCheck):
                 resource_type="AWS::guardduty::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/guardduty/check_malware_protection.py
+++ b/open-security-cspm/app/checks/aws/guardduty/check_malware_protection.py
@@ -56,7 +56,7 @@ class CheckGuardDutyMalwareProtection(BaseCheck):
                 resource_type="AWS::guardduty::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/guardduty/check_s3_protection.py
+++ b/open-security-cspm/app/checks/aws/guardduty/check_s3_protection.py
@@ -56,7 +56,7 @@ class CheckGuardDutyS3Protection(BaseCheck):
                 resource_type="AWS::guardduty::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/inspector/check_assessment_targets.py
+++ b/open-security-cspm/app/checks/aws/inspector/check_assessment_targets.py
@@ -56,8 +56,8 @@ class CheckInspectorAssessmentTargets(BaseCheck):
                 resource_type="AWS::inspector::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'inspector',

--- a/open-security-cspm/app/checks/aws/inspector/check_assessment_templates.py
+++ b/open-security-cspm/app/checks/aws/inspector/check_assessment_templates.py
@@ -56,8 +56,8 @@ class CheckInspectorAssessmentTemplates(BaseCheck):
                 resource_type="AWS::inspector::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'inspector',

--- a/open-security-cspm/app/checks/aws/kinesis/check_encryption.py
+++ b/open-security-cspm/app/checks/aws/kinesis/check_encryption.py
@@ -55,7 +55,7 @@ class CheckKinesisEncryption(BaseCheck):
                 resource_type="AWS::kinesis::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/kinesis/check_retention_period.py
+++ b/open-security-cspm/app/checks/aws/kinesis/check_retention_period.py
@@ -55,7 +55,7 @@ class CheckKinesisRetention(BaseCheck):
                 resource_type="AWS::kinesis::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/macie/check_enabled.py
+++ b/open-security-cspm/app/checks/aws/macie/check_enabled.py
@@ -56,8 +56,8 @@ class CheckMacieEnabled(BaseCheck):
                 resource_type="AWS::macie::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'macie',

--- a/open-security-cspm/app/checks/aws/macie/check_s3_bucket_jobs.py
+++ b/open-security-cspm/app/checks/aws/macie/check_s3_bucket_jobs.py
@@ -56,8 +56,8 @@ class CheckMacieS3BucketJobs(BaseCheck):
                 resource_type="AWS::macie::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'macie',

--- a/open-security-cspm/app/checks/aws/organizations/check_cloudtrail_org.py
+++ b/open-security-cspm/app/checks/aws/organizations/check_cloudtrail_org.py
@@ -56,8 +56,8 @@ class CheckOrganizationsCloudTrail(BaseCheck):
                 resource_type="AWS::organizations::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'organizations',

--- a/open-security-cspm/app/checks/aws/organizations/check_scp_enabled.py
+++ b/open-security-cspm/app/checks/aws/organizations/check_scp_enabled.py
@@ -56,8 +56,8 @@ class CheckOrganizationsSCPEnabled(BaseCheck):
                 resource_type="AWS::organizations::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'organizations',

--- a/open-security-cspm/app/checks/aws/redshift/check_audit_logging.py
+++ b/open-security-cspm/app/checks/aws/redshift/check_audit_logging.py
@@ -56,7 +56,7 @@ class CheckRedshiftAuditLogging(BaseCheck):
                 resource_type="AWS::redshift::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/redshift/check_encryption_at_rest.py
+++ b/open-security-cspm/app/checks/aws/redshift/check_encryption_at_rest.py
@@ -56,7 +56,7 @@ class CheckRedshiftEncryptionatRest(BaseCheck):
                 resource_type="AWS::redshift::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/redshift/check_public_access.py
+++ b/open-security-cspm/app/checks/aws/redshift/check_public_access.py
@@ -56,7 +56,7 @@ class CheckRedshiftPublicAccess(BaseCheck):
                 resource_type="AWS::redshift::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/secretsmanager/check_cross_region_replica.py
+++ b/open-security-cspm/app/checks/aws/secretsmanager/check_cross_region_replica.py
@@ -55,7 +55,7 @@ class CheckSecretsCrossRegionReplica(BaseCheck):
                 resource_type="AWS::secretsmanager::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/secretsmanager/check_rotation_enabled.py
+++ b/open-security-cspm/app/checks/aws/secretsmanager/check_rotation_enabled.py
@@ -55,7 +55,7 @@ class CheckSecretsRotation(BaseCheck):
                 resource_type="AWS::secretsmanager::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/securityhub/check_enabled.py
+++ b/open-security-cspm/app/checks/aws/securityhub/check_enabled.py
@@ -56,7 +56,7 @@ class CheckSecurityHubEnabled(BaseCheck):
                 resource_type="AWS::securityhub::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/securityhub/check_standards_enabled.py
+++ b/open-security-cspm/app/checks/aws/securityhub/check_standards_enabled.py
@@ -56,7 +56,7 @@ class CheckSecurityHubStandards(BaseCheck):
                 resource_type="AWS::securityhub::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/shield/check_advanced_protection.py
+++ b/open-security-cspm/app/checks/aws/shield/check_advanced_protection.py
@@ -56,8 +56,8 @@ class CheckShieldAdvancedProtection(BaseCheck):
                 resource_type="AWS::shield::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'shield',

--- a/open-security-cspm/app/checks/aws/ssm/check_parameter_store_encryption.py
+++ b/open-security-cspm/app/checks/aws/ssm/check_parameter_store_encryption.py
@@ -55,7 +55,7 @@ class CheckParameterStoreEncryption(BaseCheck):
                 resource_type="AWS::ssm::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/ssm/check_patch_compliance.py
+++ b/open-security-cspm/app/checks/aws/ssm/check_patch_compliance.py
@@ -55,7 +55,7 @@ class CheckSSMPatchCompliance(BaseCheck):
                 resource_type="AWS::ssm::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/ssm/check_session_manager.py
+++ b/open-security-cspm/app/checks/aws/ssm/check_session_manager.py
@@ -55,7 +55,7 @@ class CheckSSMSessionManager(BaseCheck):
                 resource_type="AWS::ssm::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/stepfunctions/check_logging_enabled.py
+++ b/open-security-cspm/app/checks/aws/stepfunctions/check_logging_enabled.py
@@ -55,7 +55,7 @@ class CheckStepFunctionsLogging(BaseCheck):
                 resource_type="AWS::stepfunctions::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/stepfunctions/check_xray_tracing.py
+++ b/open-security-cspm/app/checks/aws/stepfunctions/check_xray_tracing.py
@@ -55,7 +55,7 @@ class CheckStepFunctionsXRay(BaseCheck):
                 resource_type="AWS::stepfunctions::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/transit-gateway/check_route_table_association.py
+++ b/open-security-cspm/app/checks/aws/transit-gateway/check_route_table_association.py
@@ -56,8 +56,8 @@ class CheckTransitGatewayRouteTables(BaseCheck):
                 resource_type="AWS::transit_gateway::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AWS API calls',
                     'service': 'transit-gateway',

--- a/open-security-cspm/app/checks/aws/waf/check_rate_limiting.py
+++ b/open-security-cspm/app/checks/aws/waf/check_rate_limiting.py
@@ -55,7 +55,7 @@ class CheckWAFRateLimiting(BaseCheck):
                 resource_type="AWS::waf::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/waf/check_sql_injection_protection.py
+++ b/open-security-cspm/app/checks/aws/waf/check_sql_injection_protection.py
@@ -55,7 +55,7 @@ class CheckWAFSQLInjectionProtection(BaseCheck):
                 resource_type="AWS::waf::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/waf/check_waf_enabled.py
+++ b/open-security-cspm/app/checks/aws/waf/check_waf_enabled.py
@@ -55,7 +55,7 @@ class CheckWAFEnabled(BaseCheck):
                 resource_type="AWS::waf::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/workspaces/check_access_control.py
+++ b/open-security-cspm/app/checks/aws/workspaces/check_access_control.py
@@ -56,7 +56,7 @@ class CheckWorkSpacesAccessControl(BaseCheck):
                 resource_type="AWS::workspaces::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/aws/workspaces/check_encryption.py
+++ b/open-security-cspm/app/checks/aws/workspaces/check_encryption.py
@@ -56,7 +56,7 @@ class CheckWorkSpacesEncryption(BaseCheck):
                 resource_type="AWS::workspaces::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/acr/check_admin_user_disabled.py
+++ b/open-security-cspm/app/checks/azure/acr/check_admin_user_disabled.py
@@ -55,7 +55,7 @@ class CheckACRAdminUserDisabled(BaseCheck):
                 resource_type="AZURE::acr::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/acr/check_vulnerability_scanning.py
+++ b/open-security-cspm/app/checks/azure/acr/check_vulnerability_scanning.py
@@ -55,7 +55,7 @@ class CheckACRVulnerabilityScanning(BaseCheck):
                 resource_type="AZURE::acr::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/appgateway/check_ssl_policy.py
+++ b/open-security-cspm/app/checks/azure/appgateway/check_ssl_policy.py
@@ -55,7 +55,7 @@ class CheckApplicationGatewaySSLPolicy(BaseCheck):
                 resource_type="AZURE::appgateway::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/appgateway/check_waf_enabled.py
+++ b/open-security-cspm/app/checks/azure/appgateway/check_waf_enabled.py
@@ -55,7 +55,7 @@ class CheckApplicationGatewayWAF(BaseCheck):
                 resource_type="AZURE::appgateway::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/appservice/check_https_only.py
+++ b/open-security-cspm/app/checks/azure/appservice/check_https_only.py
@@ -56,7 +56,7 @@ class CheckAppServiceHTTPSOnly(BaseCheck):
                 resource_type="Azure::appservice::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/appservice/check_identity_enabled.py
+++ b/open-security-cspm/app/checks/azure/appservice/check_identity_enabled.py
@@ -56,7 +56,7 @@ class CheckAppServiceManagedIdentity(BaseCheck):
                 resource_type="Azure::appservice::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/automation/check_update_management.py
+++ b/open-security-cspm/app/checks/azure/automation/check_update_management.py
@@ -56,8 +56,8 @@ class CheckAutomationUpdateManagement(BaseCheck):
                 resource_type="AZURE::automation::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'automation',

--- a/open-security-cspm/app/checks/azure/backup/check_retention_policy.py
+++ b/open-security-cspm/app/checks/azure/backup/check_retention_policy.py
@@ -56,8 +56,8 @@ class CheckBackupRetentionPolicy(BaseCheck):
                 resource_type="AZURE::backup::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'backup',

--- a/open-security-cspm/app/checks/azure/backup/check_vm_backup.py
+++ b/open-security-cspm/app/checks/azure/backup/check_vm_backup.py
@@ -56,8 +56,8 @@ class CheckVMBackupConfigured(BaseCheck):
                 resource_type="AZURE::backup::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'backup',

--- a/open-security-cspm/app/checks/azure/batch/check_certificate_encryption.py
+++ b/open-security-cspm/app/checks/azure/batch/check_certificate_encryption.py
@@ -56,8 +56,8 @@ class CheckBatchCertificateEncryption(BaseCheck):
                 resource_type="AZURE::batch::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'batch',

--- a/open-security-cspm/app/checks/azure/cdn/check_compression.py
+++ b/open-security-cspm/app/checks/azure/cdn/check_compression.py
@@ -56,8 +56,8 @@ class CheckCDNCompression(BaseCheck):
                 resource_type="AZURE::cdn::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'cdn',

--- a/open-security-cspm/app/checks/azure/cdn/check_https_redirect.py
+++ b/open-security-cspm/app/checks/azure/cdn/check_https_redirect.py
@@ -56,8 +56,8 @@ class CheckCDNHTTPSRedirect(BaseCheck):
                 resource_type="AZURE::cdn::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'cdn',

--- a/open-security-cspm/app/checks/azure/compute/check_disk_encryption.py
+++ b/open-security-cspm/app/checks/azure/compute/check_disk_encryption.py
@@ -56,7 +56,7 @@ class CheckVMDiskEncryption(BaseCheck):
                 resource_type="Azure::compute::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/compute/check_endpoint_protection.py
+++ b/open-security-cspm/app/checks/azure/compute/check_endpoint_protection.py
@@ -56,7 +56,7 @@ class CheckVMEndpointProtection(BaseCheck):
                 resource_type="Azure::compute::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/compute/check_os_updates.py
+++ b/open-security-cspm/app/checks/azure/compute/check_os_updates.py
@@ -56,7 +56,7 @@ class CheckVMOSUpdates(BaseCheck):
                 resource_type="Azure::compute::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/cosmosdb/check_backup_policy.py
+++ b/open-security-cspm/app/checks/azure/cosmosdb/check_backup_policy.py
@@ -55,7 +55,7 @@ class CheckCosmosDBBackupPolicy(BaseCheck):
                 resource_type="AZURE::cosmosdb::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/cosmosdb/check_firewall_rules.py
+++ b/open-security-cspm/app/checks/azure/cosmosdb/check_firewall_rules.py
@@ -55,7 +55,7 @@ class CheckCosmosDBFirewall(BaseCheck):
                 resource_type="AZURE::cosmosdb::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/datafactory/check_git_configuration.py
+++ b/open-security-cspm/app/checks/azure/datafactory/check_git_configuration.py
@@ -55,7 +55,7 @@ class CheckDataFactoryGitConfig(BaseCheck):
                 resource_type="AZURE::datafactory::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/datafactory/check_managed_identity.py
+++ b/open-security-cspm/app/checks/azure/datafactory/check_managed_identity.py
@@ -55,7 +55,7 @@ class CheckDataFactoryManagedIdentity(BaseCheck):
                 resource_type="AZURE::datafactory::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/defender/check_enabled_all_resources.py
+++ b/open-security-cspm/app/checks/azure/defender/check_enabled_all_resources.py
@@ -56,8 +56,8 @@ class CheckDefenderforAllResources(BaseCheck):
                 resource_type="AZURE::defender::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'defender',

--- a/open-security-cspm/app/checks/azure/defender/check_threat_intelligence.py
+++ b/open-security-cspm/app/checks/azure/defender/check_threat_intelligence.py
@@ -56,8 +56,8 @@ class CheckDefenderThreatIntelligence(BaseCheck):
                 resource_type="AZURE::defender::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'defender',

--- a/open-security-cspm/app/checks/azure/devtest-labs/check_auto_shutdown.py
+++ b/open-security-cspm/app/checks/azure/devtest-labs/check_auto_shutdown.py
@@ -56,8 +56,8 @@ class CheckDevTestLabsAutoShutdown(BaseCheck):
                 resource_type="AZURE::devtest_labs::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'devtest-labs',

--- a/open-security-cspm/app/checks/azure/eventhub/check_capture_enabled.py
+++ b/open-security-cspm/app/checks/azure/eventhub/check_capture_enabled.py
@@ -55,7 +55,7 @@ class CheckEventHubCapture(BaseCheck):
                 resource_type="AZURE::eventhub::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/eventhub/check_encryption.py
+++ b/open-security-cspm/app/checks/azure/eventhub/check_encryption.py
@@ -55,7 +55,7 @@ class CheckEventHubEncryption(BaseCheck):
                 resource_type="AZURE::eventhub::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/keyvault/check_access_policies.py
+++ b/open-security-cspm/app/checks/azure/keyvault/check_access_policies.py
@@ -56,7 +56,7 @@ class CheckKeyVaultAccessPolicies(BaseCheck):
                 resource_type="Azure::keyvault::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/keyvault/check_purge_protection.py
+++ b/open-security-cspm/app/checks/azure/keyvault/check_purge_protection.py
@@ -56,7 +56,7 @@ class CheckKeyVaultPurgeProtection(BaseCheck):
                 resource_type="Azure::keyvault::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/keyvault/check_soft_delete.py
+++ b/open-security-cspm/app/checks/azure/keyvault/check_soft_delete.py
@@ -56,7 +56,7 @@ class CheckKeyVaultSoftDelete(BaseCheck):
                 resource_type="Azure::keyvault::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/logicapps/check_access_control.py
+++ b/open-security-cspm/app/checks/azure/logicapps/check_access_control.py
@@ -55,7 +55,7 @@ class CheckLogicAppsAccessControl(BaseCheck):
                 resource_type="AZURE::logicapps::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/logicapps/check_diagnostic_logs.py
+++ b/open-security-cspm/app/checks/azure/logicapps/check_diagnostic_logs.py
@@ -55,7 +55,7 @@ class CheckLogicAppsDiagnosticLogs(BaseCheck):
                 resource_type="AZURE::logicapps::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/monitor/check_activity_log_alerts.py
+++ b/open-security-cspm/app/checks/azure/monitor/check_activity_log_alerts.py
@@ -56,7 +56,7 @@ class CheckActivityLogAlerts(BaseCheck):
                 resource_type="Azure::monitor::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/monitor/check_diagnostic_settings.py
+++ b/open-security-cspm/app/checks/azure/monitor/check_diagnostic_settings.py
@@ -56,7 +56,7 @@ class CheckDiagnosticSettings(BaseCheck):
                 resource_type="Azure::monitor::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/network/check_ddos_protection.py
+++ b/open-security-cspm/app/checks/azure/network/check_ddos_protection.py
@@ -56,7 +56,7 @@ class CheckDDoSProtection(BaseCheck):
                 resource_type="Azure::network::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/network/check_network_watcher.py
+++ b/open-security-cspm/app/checks/azure/network/check_network_watcher.py
@@ -56,7 +56,7 @@ class CheckNetworkWatcher(BaseCheck):
                 resource_type="Azure::network::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/network/check_nsg_rules.py
+++ b/open-security-cspm/app/checks/azure/network/check_nsg_rules.py
@@ -56,7 +56,7 @@ class CheckNSGSecurityRules(BaseCheck):
                 resource_type="Azure::network::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/purview/check_data_catalog.py
+++ b/open-security-cspm/app/checks/azure/purview/check_data_catalog.py
@@ -56,8 +56,8 @@ class CheckPurviewDataCatalog(BaseCheck):
                 resource_type="AZURE::purview::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'purview',

--- a/open-security-cspm/app/checks/azure/recovery-services/check_vault_encryption.py
+++ b/open-security-cspm/app/checks/azure/recovery-services/check_vault_encryption.py
@@ -56,8 +56,8 @@ class CheckRecoveryServicesVaultEncryption(BaseCheck):
                 resource_type="AZURE::recovery_services::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'recovery-services',

--- a/open-security-cspm/app/checks/azure/securitycenter/check_auto_provisioning.py
+++ b/open-security-cspm/app/checks/azure/securitycenter/check_auto_provisioning.py
@@ -55,7 +55,7 @@ class CheckSecurityCenterAutoProvisioning(BaseCheck):
                 resource_type="AZURE::securitycenter::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/securitycenter/check_enabled.py
+++ b/open-security-cspm/app/checks/azure/securitycenter/check_enabled.py
@@ -55,7 +55,7 @@ class CheckSecurityCenterEnabled(BaseCheck):
                 resource_type="AZURE::securitycenter::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/securitycenter/check_standard_tier.py
+++ b/open-security-cspm/app/checks/azure/securitycenter/check_standard_tier.py
@@ -55,7 +55,7 @@ class CheckSecurityCenterStandardTier(BaseCheck):
                 resource_type="AZURE::securitycenter::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/sentinel/check_data_connectors.py
+++ b/open-security-cspm/app/checks/azure/sentinel/check_data_connectors.py
@@ -55,7 +55,7 @@ class CheckSentinelDataConnectors(BaseCheck):
                 resource_type="AZURE::sentinel::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/sentinel/check_workspace_configured.py
+++ b/open-security-cspm/app/checks/azure/sentinel/check_workspace_configured.py
@@ -55,7 +55,7 @@ class CheckSentinelWorkspace(BaseCheck):
                 resource_type="AZURE::sentinel::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/servicebus/check_duplicate_detection.py
+++ b/open-security-cspm/app/checks/azure/servicebus/check_duplicate_detection.py
@@ -56,8 +56,8 @@ class CheckServiceBusDuplicateDetection(BaseCheck):
                 resource_type="AZURE::servicebus::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'servicebus',

--- a/open-security-cspm/app/checks/azure/signalr/check_service_mode.py
+++ b/open-security-cspm/app/checks/azure/signalr/check_service_mode.py
@@ -56,8 +56,8 @@ class CheckSignalRServiceMode(BaseCheck):
                 resource_type="AZURE::signalr::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'signalr',

--- a/open-security-cspm/app/checks/azure/spring-cloud/check_config_server.py
+++ b/open-security-cspm/app/checks/azure/spring-cloud/check_config_server.py
@@ -56,8 +56,8 @@ class CheckSpringCloudConfigServer(BaseCheck):
                 resource_type="AZURE::spring_cloud::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual AZURE API calls',
                     'service': 'spring-cloud',

--- a/open-security-cspm/app/checks/azure/sql/check_auditing_enabled.py
+++ b/open-security-cspm/app/checks/azure/sql/check_auditing_enabled.py
@@ -56,7 +56,7 @@ class CheckSQLAuditingEnabled(BaseCheck):
                 resource_type="Azure::sql::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/sql/check_threat_detection.py
+++ b/open-security-cspm/app/checks/azure/sql/check_threat_detection.py
@@ -56,7 +56,7 @@ class CheckSQLThreatDetection(BaseCheck):
                 resource_type="Azure::sql::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/sql/check_transparent_encryption.py
+++ b/open-security-cspm/app/checks/azure/sql/check_transparent_encryption.py
@@ -56,7 +56,7 @@ class CheckSQLTransparentEncryption(BaseCheck):
                 resource_type="Azure::sql::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/storage/check_access_tier.py
+++ b/open-security-cspm/app/checks/azure/storage/check_access_tier.py
@@ -56,7 +56,7 @@ class CheckStorageAccessTier(BaseCheck):
                 resource_type="Azure::storage::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/storage/check_private_endpoints.py
+++ b/open-security-cspm/app/checks/azure/storage/check_private_endpoints.py
@@ -56,7 +56,7 @@ class CheckStoragePrivateEndpoints(BaseCheck):
                 resource_type="Azure::storage::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/azure/storage/check_storage_encryption.py
+++ b/open-security-cspm/app/checks/azure/storage/check_storage_encryption.py
@@ -56,7 +56,7 @@ class CheckStorageAccountEncryption(BaseCheck):
                 resource_type="Azure::storage::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/framework.py
+++ b/open-security-cspm/app/checks/framework.py
@@ -25,6 +25,9 @@ class CheckStatus(str, Enum):
     FAILED = "failed"
     ERROR = "error"
     SKIPPED = "skipped"
+    # A check that has no real implementation yet. Never report these as PASSED:
+    # an unimplemented check that "passes" is a false compliance signal.
+    NOT_IMPLEMENTED = "not_implemented"
 
 
 class CloudProvider(str, Enum):
@@ -158,6 +161,7 @@ class ScanReport(BaseModel):
     failed_checks: int = 0
     error_checks: int = 0
     skipped_checks: int = 0
+    not_implemented_checks: int = 0
     critical_findings: int = 0
     high_findings: int = 0
     medium_findings: int = 0
@@ -195,6 +199,8 @@ class ScanReport(BaseModel):
             self.error_checks += 1
         elif result.status == CheckStatus.SKIPPED:
             self.skipped_checks += 1
+        elif result.status == CheckStatus.NOT_IMPLEMENTED:
+            self.not_implemented_checks += 1
     
     def _get_check_severity(self, check_id: str) -> CheckSeverity:
         """Get severity for a check ID. This would be enhanced with check registry."""
@@ -206,15 +212,26 @@ class ScanReport(BaseModel):
         self.completed_at = datetime.utcnow()
         self.status = "completed"
         
-        # Calculate compliance score (percentage of passed checks)
-        if self.total_checks > 0:
-            self.compliance_score = (self.passed_checks / self.total_checks) * 100
+        # Calculate compliance score over checks that actually produced a verdict.
+        # Not-implemented / skipped / errored checks are excluded from the
+        # denominator so they neither inflate nor deflate the score — only real
+        # pass/fail results count.
+        evaluated_checks = self.passed_checks + self.failed_checks
+        if evaluated_checks > 0:
+            self.compliance_score = (self.passed_checks / evaluated_checks) * 100
         else:
             self.compliance_score = 0.0
         
         # Generate summary
         self.summary = {
             "duration_seconds": (self.completed_at - self.started_at).total_seconds(),
+            "checks_by_status": {
+                "passed": self.passed_checks,
+                "failed": self.failed_checks,
+                "error": self.error_checks,
+                "skipped": self.skipped_checks,
+                "not_implemented": self.not_implemented_checks,
+            },
             "findings_by_severity": {
                 "critical": self.critical_findings,
                 "high": self.high_findings,

--- a/open-security-cspm/app/checks/gcp/asset/check_inventory_enabled.py
+++ b/open-security-cspm/app/checks/gcp/asset/check_inventory_enabled.py
@@ -55,7 +55,7 @@ class CheckAssetInventoryEnabled(BaseCheck):
                 resource_type="GCP::asset::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/bigquery/check_dataset_encryption.py
+++ b/open-security-cspm/app/checks/gcp/bigquery/check_dataset_encryption.py
@@ -56,7 +56,7 @@ class CheckBigQueryDatasetEncryption(BaseCheck):
                 resource_type="GCP::bigquery::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/bigquery/check_table_access.py
+++ b/open-security-cspm/app/checks/gcp/bigquery/check_table_access.py
@@ -56,7 +56,7 @@ class CheckBigQueryTableAccess(BaseCheck):
                 resource_type="GCP::bigquery::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/binaryauth/check_policy_enabled.py
+++ b/open-security-cspm/app/checks/gcp/binaryauth/check_policy_enabled.py
@@ -55,7 +55,7 @@ class CheckBinaryAuthorizationPolicy(BaseCheck):
                 resource_type="GCP::binaryauth::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/cloudarmor/check_security_policy.py
+++ b/open-security-cspm/app/checks/gcp/cloudarmor/check_security_policy.py
@@ -55,7 +55,7 @@ class CheckCloudArmorSecurityPolicy(BaseCheck):
                 resource_type="GCP::cloudarmor::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/cloudshell/check_disabled.py
+++ b/open-security-cspm/app/checks/gcp/cloudshell/check_disabled.py
@@ -56,8 +56,8 @@ class CheckCloudShellDisabled(BaseCheck):
                 resource_type="GCP::cloudshell::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'cloudshell',

--- a/open-security-cspm/app/checks/gcp/cloudsql/check_authorized_networks.py
+++ b/open-security-cspm/app/checks/gcp/cloudsql/check_authorized_networks.py
@@ -56,7 +56,7 @@ class CheckCloudSQLAuthorizedNetworks(BaseCheck):
                 resource_type="GCP::cloudsql::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/cloudsql/check_backup_enabled.py
+++ b/open-security-cspm/app/checks/gcp/cloudsql/check_backup_enabled.py
@@ -56,7 +56,7 @@ class CheckCloudSQLBackupEnabled(BaseCheck):
                 resource_type="GCP::cloudsql::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/cloudsql/check_ssl_required.py
+++ b/open-security-cspm/app/checks/gcp/cloudsql/check_ssl_required.py
@@ -56,7 +56,7 @@ class CheckCloudSQLSSLRequired(BaseCheck):
                 resource_type="GCP::cloudsql::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/compute/check_ip_forwarding_disabled.py
+++ b/open-security-cspm/app/checks/gcp/compute/check_ip_forwarding_disabled.py
@@ -56,7 +56,7 @@ class CheckIPForwardingDisabled(BaseCheck):
                 resource_type="GCP::compute::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/compute/check_oslogin_enabled.py
+++ b/open-security-cspm/app/checks/gcp/compute/check_oslogin_enabled.py
@@ -56,7 +56,7 @@ class CheckComputeOSLoginEnabled(BaseCheck):
                 resource_type="GCP::compute::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/compute/check_secure_boot_enabled.py
+++ b/open-security-cspm/app/checks/gcp/compute/check_secure_boot_enabled.py
@@ -56,7 +56,7 @@ class CheckSecureBootEnabled(BaseCheck):
                 resource_type="GCP::compute::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/compute/check_serial_port_disabled.py
+++ b/open-security-cspm/app/checks/gcp/compute/check_serial_port_disabled.py
@@ -56,7 +56,7 @@ class CheckComputeSerialPortDisabled(BaseCheck):
                 resource_type="GCP::compute::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/dataflow/check_private_ips.py
+++ b/open-security-cspm/app/checks/gcp/dataflow/check_private_ips.py
@@ -56,8 +56,8 @@ class CheckDataflowPrivateIPs(BaseCheck):
                 resource_type="GCP::dataflow::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'dataflow',

--- a/open-security-cspm/app/checks/gcp/dns/check_dnssec_enabled.py
+++ b/open-security-cspm/app/checks/gcp/dns/check_dnssec_enabled.py
@@ -55,7 +55,7 @@ class CheckDNSDNSSECEnabled(BaseCheck):
                 resource_type="GCP::dns::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/dns/check_private_zones.py
+++ b/open-security-cspm/app/checks/gcp/dns/check_private_zones.py
@@ -55,7 +55,7 @@ class CheckDNSPrivateZones(BaseCheck):
                 resource_type="GCP::dns::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/firestore/check_security_rules.py
+++ b/open-security-cspm/app/checks/gcp/firestore/check_security_rules.py
@@ -56,8 +56,8 @@ class CheckFirestoreSecurityRules(BaseCheck):
                 resource_type="GCP::firestore::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'firestore',

--- a/open-security-cspm/app/checks/gcp/functions/check_environment_variables.py
+++ b/open-security-cspm/app/checks/gcp/functions/check_environment_variables.py
@@ -56,7 +56,7 @@ class CheckFunctionsEnvironmentVariables(BaseCheck):
                 resource_type="GCP::functions::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/functions/check_ingress_settings.py
+++ b/open-security-cspm/app/checks/gcp/functions/check_ingress_settings.py
@@ -56,7 +56,7 @@ class CheckCloudFunctionsIngress(BaseCheck):
                 resource_type="GCP::functions::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/gke/check_network_policy.py
+++ b/open-security-cspm/app/checks/gcp/gke/check_network_policy.py
@@ -56,7 +56,7 @@ class CheckGKENetworkPolicy(BaseCheck):
                 resource_type="GCP::gke::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/gke/check_pod_security_policy.py
+++ b/open-security-cspm/app/checks/gcp/gke/check_pod_security_policy.py
@@ -56,7 +56,7 @@ class CheckGKEPodSecurityPolicy(BaseCheck):
                 resource_type="GCP::gke::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/gke/check_private_cluster.py
+++ b/open-security-cspm/app/checks/gcp/gke/check_private_cluster.py
@@ -56,7 +56,7 @@ class CheckGKEPrivateCluster(BaseCheck):
                 resource_type="GCP::gke::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/kms/check_key_access.py
+++ b/open-security-cspm/app/checks/gcp/kms/check_key_access.py
@@ -56,8 +56,8 @@ class CheckKMSKeyAccess(BaseCheck):
                 resource_type="GCP::kms::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'kms',

--- a/open-security-cspm/app/checks/gcp/kms/check_key_rotation.py
+++ b/open-security-cspm/app/checks/gcp/kms/check_key_rotation.py
@@ -56,8 +56,8 @@ class CheckKMSKeyRotation(BaseCheck):
                 resource_type="GCP::kms::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'kms',

--- a/open-security-cspm/app/checks/gcp/logging/check_audit_logs_enabled.py
+++ b/open-security-cspm/app/checks/gcp/logging/check_audit_logs_enabled.py
@@ -56,7 +56,7 @@ class CheckAuditLogsEnabled(BaseCheck):
                 resource_type="GCP::logging::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/logging/check_retention_policy.py
+++ b/open-security-cspm/app/checks/gcp/logging/check_retention_policy.py
@@ -56,7 +56,7 @@ class CheckLogRetentionPolicy(BaseCheck):
                 resource_type="GCP::logging::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/memorystore/check_auth_enabled.py
+++ b/open-security-cspm/app/checks/gcp/memorystore/check_auth_enabled.py
@@ -56,8 +56,8 @@ class CheckMemorystoreAuthEnabled(BaseCheck):
                 resource_type="GCP::memorystore::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'memorystore',

--- a/open-security-cspm/app/checks/gcp/monitoring/check_alerting_policy.py
+++ b/open-security-cspm/app/checks/gcp/monitoring/check_alerting_policy.py
@@ -56,8 +56,8 @@ class CheckMonitoringAlertingPolicy(BaseCheck):
                 resource_type="GCP::monitoring::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'monitoring',

--- a/open-security-cspm/app/checks/gcp/monitoring/check_uptime_checks.py
+++ b/open-security-cspm/app/checks/gcp/monitoring/check_uptime_checks.py
@@ -56,8 +56,8 @@ class CheckMonitoringUptimeChecks(BaseCheck):
                 resource_type="GCP::monitoring::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'monitoring',

--- a/open-security-cspm/app/checks/gcp/pubsub/check_dead_letter_topic.py
+++ b/open-security-cspm/app/checks/gcp/pubsub/check_dead_letter_topic.py
@@ -55,7 +55,7 @@ class CheckPubSubDeadLetterTopic(BaseCheck):
                 resource_type="GCP::pubsub::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/pubsub/check_topic_encryption.py
+++ b/open-security-cspm/app/checks/gcp/pubsub/check_topic_encryption.py
@@ -55,7 +55,7 @@ class CheckPubSubTopicEncryption(BaseCheck):
                 resource_type="GCP::pubsub::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/scc/check_enabled.py
+++ b/open-security-cspm/app/checks/gcp/scc/check_enabled.py
@@ -55,7 +55,7 @@ class CheckSecurityCommandCenterEnabled(BaseCheck):
                 resource_type="GCP::scc::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/scc/check_notification_config.py
+++ b/open-security-cspm/app/checks/gcp/scc/check_notification_config.py
@@ -55,7 +55,7 @@ class CheckSCCNotificationConfig(BaseCheck):
                 resource_type="GCP::scc::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/scheduler/check_job_authentication.py
+++ b/open-security-cspm/app/checks/gcp/scheduler/check_job_authentication.py
@@ -55,7 +55,7 @@ class CheckSchedulerJobAuthentication(BaseCheck):
                 resource_type="GCP::scheduler::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/secretmanager/check_secret_access.py
+++ b/open-security-cspm/app/checks/gcp/secretmanager/check_secret_access.py
@@ -56,8 +56,8 @@ class CheckSecretManagerAccess(BaseCheck):
                 resource_type="GCP::secretmanager::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'secretmanager',

--- a/open-security-cspm/app/checks/gcp/secretmanager/check_secret_rotation.py
+++ b/open-security-cspm/app/checks/gcp/secretmanager/check_secret_rotation.py
@@ -56,8 +56,8 @@ class CheckSecretManagerRotation(BaseCheck):
                 resource_type="GCP::secretmanager::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'secretmanager',

--- a/open-security-cspm/app/checks/gcp/service-usage/check_api_restrictions.py
+++ b/open-security-cspm/app/checks/gcp/service-usage/check_api_restrictions.py
@@ -56,8 +56,8 @@ class CheckServiceUsageAPIRestrictions(BaseCheck):
                 resource_type="GCP::service_usage::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
-                message="Check implementation needed - placeholder",
+                status=CheckStatus.NOT_IMPLEMENTED,
+                message="Check not implemented yet — no assessment performed",
                 details={
                     'note': 'This check needs to be implemented with actual GCP API calls',
                     'service': 'service-usage',

--- a/open-security-cspm/app/checks/gcp/storage/check_bucket_encryption.py
+++ b/open-security-cspm/app/checks/gcp/storage/check_bucket_encryption.py
@@ -56,7 +56,7 @@ class CheckStorageBucketEncryption(BaseCheck):
                 resource_type="GCP::storage::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/storage/check_bucket_logging.py
+++ b/open-security-cspm/app/checks/gcp/storage/check_bucket_logging.py
@@ -56,7 +56,7 @@ class CheckStorageBucketLogging(BaseCheck):
                 resource_type="GCP::storage::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/storage/check_uniform_bucket_access.py
+++ b/open-security-cspm/app/checks/gcp/storage/check_uniform_bucket_access.py
@@ -56,7 +56,7 @@ class CheckUniformBucketAccess(BaseCheck):
                 resource_type="GCP::storage::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/vpc/check_flow_logs.py
+++ b/open-security-cspm/app/checks/gcp/vpc/check_flow_logs.py
@@ -55,7 +55,7 @@ class CheckVPCFlowLogs(BaseCheck):
                 resource_type="GCP::vpc::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/checks/gcp/vpc/check_private_google_access.py
+++ b/open-security-cspm/app/checks/gcp/vpc/check_private_google_access.py
@@ -55,7 +55,7 @@ class CheckPrivateGoogleAccess(BaseCheck):
                 resource_type="GCP::vpc::Resource",
                 resource_name="placeholder",
                 region=region,
-                status=CheckStatus.PASSED,
+                status=CheckStatus.NOT_IMPLEMENTED,
                 message="Check implementation needed",
                 details={'note': 'This check needs to be implemented'}
             ))

--- a/open-security-cspm/app/schemas.py
+++ b/open-security-cspm/app/schemas.py
@@ -199,7 +199,8 @@ class ScanReportSchema(BaseModel):
     failed_checks: int = Field(..., description="Number of failed checks")
     error_checks: int = Field(..., description="Number of checks with errors")
     skipped_checks: int = Field(..., description="Number of skipped checks")
-    
+    not_implemented_checks: int = Field(0, description="Number of checks not yet implemented (never counted as passed)")
+
     # Findings by severity
     critical_findings: int = Field(..., description="Critical severity findings")
     high_findings: int = Field(..., description="High severity findings")

--- a/open-security-cspm/app/utils.py
+++ b/open-security-cspm/app/utils.py
@@ -49,15 +49,19 @@ def _calculate_compliance_score(scan_results: Dict[str, Any]) -> float:
     """
     if not scan_results.get('results'):
         return 0.0
-    
+
     results = scan_results['results']
-    total_checks = len(results)
+    # Score over checks that produced a real verdict only. Not-implemented /
+    # skipped / errored checks are excluded so an unrun check never counts as
+    # (or against) compliance.
     passed_checks = sum(1 for result in results if result.get('status') == 'passed')
-    
-    if total_checks == 0:
+    failed_checks = sum(1 for result in results if result.get('status') == 'failed')
+    evaluated_checks = passed_checks + failed_checks
+
+    if evaluated_checks == 0:
         return 0.0
-    
-    return round((passed_checks / total_checks) * 100, 2)
+
+    return round((passed_checks / evaluated_checks) * 100, 2)
 
 
 def _generate_executive_summary(scan_results: Dict[str, Any]) -> Dict[str, Any]:

--- a/open-security-dashboard/src/types/index.ts
+++ b/open-security-dashboard/src/types/index.ts
@@ -225,7 +225,9 @@ export interface ComplianceFinding {
   title: string
   description: string
   severity: 'critical' | 'high' | 'medium' | 'low' | 'info'
-  status: 'passed' | 'failed' | 'warning'
+  // Backend (open-security-cspm) statuses. `not_implemented` means the check
+  // has no real implementation yet and must never be shown as passed.
+  status: 'passed' | 'failed' | 'warning' | 'error' | 'skipped' | 'not_implemented'
   resource: string
   region: string
   category: string


### PR DESCRIPTION
Closes #158 — Sprint 0 (honesty & first-run).

In a CSPM product, **an unimplemented check that returns `PASSED` is a false compliance signal.** 166 of ~204 checks under `open-security-cspm/app/checks/{aws,azure,gcp}/**` were `# TODO` placeholders that returned `CheckStatus.PASSED` — so every scan reported near-100% compliance for checks that never ran.

## Changes
- **`framework.py`**: add `CheckStatus.NOT_IMPLEMENTED`; count it separately on `ScanReport` (`not_implemented_checks`); add a `checks_by_status` breakdown to the summary.
- **Scoring** (`framework.finalize()` + `utils._calculate_compliance_score()`): compliance score is now `passed / (passed + failed)`. Not-implemented / skipped / errored checks are **excluded from the denominator**, so an unrun check neither inflates nor deflates compliance.
- **Sweep**: the 166 placeholder bodies now return `NOT_IMPLEMENTED` with an honest message; the **32 real checks** that legitimately return `PASSED` are untouched (verified each placeholder file had exactly one `PASSED`).
- **`schemas.py` / dashboard `types`**: surface `not_implemented_checks` and extend the `ComplianceFinding` status union so the new status renders instead of the old PASSED.

Decoupled from actually implementing the checks (Sprint 5) — this only stops the platform from claiming compliance for checks that never executed.

## Verification
- `py_compile` on all 166 swept files + framework/utils/schemas: clean.
- Logic test: `2 passed, 1 failed, 10 not_implemented` → score **66.67%** (`2/3`), not the old inflated `12/13 = 92%`; `not_implemented` never counts as passed; `checks_by_status` populated.
- 0 placeholder `PASSED` remain; 32 real `PASSED` preserved.

Follow-up (separate): dashboard could add a dedicated badge/filter for `not_implemented`; real check implementations are Sprint 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)