### PR TITLE
chore(env): standardize on ANTHROPIC_*, drop leftover OpenAI/Stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,6 @@ INITIAL_ADMIN_PASSWORD=Change-This-To-A-Secure-Password!
 # Example: openssl rand -hex 32
 API_KEY=replace-this-with-a-secure-random-string-32-chars-long
 
-# Stripe Configuration (Development/Test keys)
-STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
-STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
-STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key
-
 # Application Configuration
 DEBUG=false
 LOG_LEVEL=INFO

--- a/.env.template
+++ b/.env.template
@@ -55,15 +55,6 @@ N8N_BASIC_AUTH_USER=admin
 N8N_BASIC_AUTH_PASSWORD=
 
 # ═══════════════════════════════════════════════════════════════════════════
-# SECTION 2: STRIPE INTEGRATION (Required for subscription features)
-# ═══════════════════════════════════════════════════════════════════════════
-# Get these from: https://dashboard.stripe.com/apikeys
-
-STRIPE_SECRET_KEY=
-STRIPE_PUBLISHABLE_KEY=
-STRIPE_WEBHOOK_SECRET=
-
-# ═══════════════════════════════════════════════════════════════════════════
 # SECTION 3: INITIAL ADMIN ACCOUNT
 # ═══════════════════════════════════════════════════════════════════════════
 
@@ -145,11 +136,13 @@ RATE_LIMIT_WINDOW=60
 # SECTION 11: AI/LLM CONFIGURATION (Optional)
 # ═══════════════════════════════════════════════════════════════════════════
 
-# OpenAI API key (for AI agents service)
-OPENAI_API_KEY=
+# Claude (Anthropic) API key for the AI agents service.
+# Leave blank to disable AI threat analysis — the service starts without it.
+# Get a key from: https://console.anthropic.com/
+ANTHROPIC_API_KEY=
 
-# LLM model to use
-LLM_MODEL=gpt-4o
+# Claude model to use for analysis.
+# ANTHROPIC_MODEL=claude-opus-4-8
 
 # ═══════════════════════════════════════════════════════════════════════════
 # VALIDATION CHECKLIST

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -235,7 +235,7 @@ services:
     environment:
       REDIS_URL: redis://redis-test:6379/6
       API_KEY: test-api-key-for-ci-only
-      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
       DEBUG: "true"
     depends_on:
       redis-test:


### PR DESCRIPTION
Closes #169 — Sprint 0 (honesty & first-run).

Env templates still carried `OPENAI_API_KEY`/`LLM_MODEL=gpt-4o` and Stripe keys, but the agents service reads `ANTHROPIC_API_KEY`/`ANTHROPIC_MODEL` (`open-security-agents/app/config.py`, default `claude-opus-4-8`) and billing/Stripe was removed (#129). A self-hoster following the templates sets the wrong key and AI analysis silently no-ops.

## Changes
- **`.env.example`**: remove the Stripe block (`ANTHROPIC_*` was already present).
- **`.env.template`**: remove the Stripe section; replace the OpenAI / `LLM_MODEL=gpt-4o` section with `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL`.
- **`docker-compose.test.yml`**: `agents-test` now passes `ANTHROPIC_API_KEY` (the var the service actually reads) instead of `OPENAI_API_KEY`.

## Scope notes
- `.env` is gitignored and untouched (may hold real local secrets).
- `open-security-agents/docker-compose.yml` deliberately uses the **OpenAI-compatible protocol against a local vLLM** (`llm` service, `qwen3-0.6b`) — that's a self-hosted-LLM setup, not leftover OpenAI config, so it's left as-is. The mismatch between that standalone compose and the Anthropic code path is a real but separate follow-up.

Surfaced while analyzing `docs.html#quickstart`, which also still lists Stripe + `OPENAI_API_KEY` as "essential" — that doc fix lands in #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)