### PR TITLE
docs: reconcile README/SETUP_GUIDE/quickstart to one source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,12 @@ curl http://localhost:8001/health
 
 ### Default Credentials
 
-- **Email**: `admin@wildbox.security`
-- **Password**: `CHANGE-THIS-PASSWORD`
+The first admin account is created from the values you set in `.env`:
 
-**Change default credentials immediately after first login.**
+- **Email**: `INITIAL_ADMIN_EMAIL`
+- **Password**: `INITIAL_ADMIN_PASSWORD`
+
+Set both to strong values before the first start, and change the password after first login.
 
 ### Next Steps
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -36,13 +36,13 @@ git clone <your-repo-url>
 cd wildbox
 
 # Start all services
-docker-compose up -d
+docker compose up -d
 
 # Wait for services to initialize (2-3 minutes)
 sleep 180
 
 # Run health check
-./comprehensive_health_check.sh
+make health
 ```
 
 ### 2. Access the Platform
@@ -77,7 +77,7 @@ curl "http://localhost:8002/api/v1/stats"
 | **Guardian** | 8013 | Vulnerability Management | ✅ Running |
 | **Sensor** | 8004 | Endpoint Monitoring | ✅ Running |
 | **Responder** | 8018 | Incident Response | ✅ Running |
-| **AI Agents** | 8006 | GPT-4 Analysis | ✅ Running |
+| **AI Agents** | 8006 | Claude (Anthropic) Analysis | ✅ Running |
 | **CSPM** | 8019 | Cloud Security | ✅ Running |
 | **Automations** | 5678 | n8n Workflows | ✅ Running |
 | **Gateway** | 80/443 | API Gateway | ✅ Running |
@@ -119,15 +119,15 @@ curl "http://localhost:8002/api/v1/stats"
 
 ```bash
 # Comprehensive health check
-./comprehensive_health_check.sh
+make health
 
 # Enhanced system monitor
-./system_monitor.sh
+docker compose ps
 
 # Check specific components
-./system_monitor.sh performance
-./system_monitor.sh security
-./system_monitor.sh resources
+docker stats
+make health
+docker stats
 ```
 
 ### Real-time Monitoring
@@ -137,10 +137,10 @@ curl "http://localhost:8002/api/v1/stats"
 docker stats
 
 # Service logs
-docker-compose logs -f [service-name]
+docker compose logs -f [service-name]
 
 # Live system health
-watch -n 5 ./comprehensive_health_check.sh services
+watch -n 5 docker compose ps
 ```
 
 ---
@@ -149,8 +149,8 @@ watch -n 5 ./comprehensive_health_check.sh services
 
 ### Default Credentials (⚠️ Change in Production!)
 
-- **Admin Email:** admin@wildbox.security
-- **Admin Password:** ChangeMeInProduction123!
+- **Admin Email:** the `INITIAL_ADMIN_EMAIL` you set in `.env`
+- **Admin Password:** the `INITIAL_ADMIN_PASSWORD` you set in `.env`
 - **n8n Admin:** admin / wildbox_n8n_2025
 
 ### API Authentication
@@ -159,7 +159,7 @@ watch -n 5 ./comprehensive_health_check.sh services
 # Get JWT token
 curl -X POST http://localhost:8001/auth/jwt/login \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=admin@wildbox.security&password=ChangeMeInProduction123!"
+  -d "username=$INITIAL_ADMIN_EMAIL&password=$INITIAL_ADMIN_PASSWORD"
 
 # Use API key for tools
 curl -H "Authorization: Bearer <your-jwt-token>" \
@@ -176,27 +176,27 @@ curl -H "Authorization: Bearer <your-jwt-token>" \
 
 ```bash
 # Check logs
-docker-compose logs [service-name]
+docker compose logs [service-name]
 
 # Restart specific service
-docker-compose restart [service-name]
+docker compose restart [service-name]
 
 # Rebuild if needed
-docker-compose up -d --build [service-name]
+docker compose up -d --build [service-name]
 ```
 
 #### Database Issues
 
 ```bash
 # Check PostgreSQL
-docker-compose exec postgres pg_isready -U postgres
+docker compose exec postgres pg_isready -U postgres
 
 # Check Redis
-docker-compose exec wildbox-redis redis-cli ping
+docker compose exec wildbox-redis redis-cli ping
 
 # Reset databases (⚠️ Destructive)
-docker-compose down -v
-docker-compose up -d postgres wildbox-redis
+docker compose down -v
+docker compose up -d postgres wildbox-redis
 ```
 
 #### Performance Issues
@@ -206,10 +206,10 @@ docker-compose up -d postgres wildbox-redis
 docker stats
 
 # Monitor system health
-./system_monitor.sh resources
+docker stats
 
 # Optimize containers
-./system_monitor.sh optimize
+docker system prune
 ```
 
 ---
@@ -239,10 +239,10 @@ nano .env
 
 ```bash
 # Generate SSL certificates
-./scripts/setup-ssl.sh --domain your-domain.com
+# Configure TLS on the gateway (see docker-compose.prod.yml and haproxy/)
 
 # Enable HTTPS in gateway
-docker-compose restart gateway
+docker compose restart gateway
 ```
 
 ---
@@ -269,8 +269,8 @@ docker-compose restart gateway
 
 ### Getting Help
 
-1. Check logs: `docker-compose logs [service]`
-2. Run diagnostics: `./system_monitor.sh`
+1. Check logs: `docker compose logs [service]`
+2. Run diagnostics: `make health` and `docker compose ps`
 3. Review documentation in `/docs`
 4. Check GitHub issues
 
@@ -290,7 +290,7 @@ docker-compose restart gateway
 1. **Explore the Dashboard** - http://localhost:3000
 2. **Test Security Tools** - http://localhost:8000/docs
 3. **Configure Automations** - http://localhost:5678
-4. **Set up Monitoring** - Run `./system_monitor.sh`
+4. **Set up Monitoring** - Configure Prometheus/Grafana (see docker-compose.prod.yml)
 
 ### Advanced Usage
 

--- a/docs/guides/credentials.md
+++ b/docs/guides/credentials.md
@@ -69,20 +69,11 @@ AGENTS_API_KEY=dev-agents-key
 SENSOR_API_KEY=dev-sensor-key
 
 # ============================================
-# OPENAI CONFIGURATION (OPTIONAL)
+# AI / LLM CONFIGURATION (OPTIONAL)
 # ============================================
-# Set to enable AI-powered features
-OPENAI_API_KEY=sk-your-actual-openai-key-or-leave-empty
-OPENAI_MODEL=gpt-4o-mini
-OPENAI_TEMPERATURE=0.7
-
-# ============================================
-# STRIPE INTEGRATION (OPTIONAL)
-# ============================================
-# Leave empty or set to test keys for development
-STRIPE_SECRET_KEY=sk_test_your_stripe_test_key
-STRIPE_PUBLIC_KEY=pk_test_your_stripe_test_key
-STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
+# Claude (Anthropic). Leave empty to disable AI analysis.
+ANTHROPIC_API_KEY=
+# ANTHROPIC_MODEL=claude-opus-4-8
 
 # ============================================
 # APPLICATION SETTINGS
@@ -114,8 +105,8 @@ CELERY_WORKER_CONCURRENCY=4
 ### Admin User (Initial Setup)
 
 ```yaml
-Email: admin@wildbox.local
-Password: (generated during first run)
+Email: ${INITIAL_ADMIN_EMAIL}      # set in your .env before first start
+Password: ${INITIAL_ADMIN_PASSWORD}  # set in your .env before first start
 Role: Administrator
 ```
 
@@ -135,9 +126,9 @@ Role: Analyst
 
 ```bash
 # Request authentication token
-curl -X POST http://localhost:8001/token \
+curl -X POST http://localhost:8001/auth/jwt/login \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=admin@wildbox.local&password=your-password"
+  -d "username=$INITIAL_ADMIN_EMAIL&password=$INITIAL_ADMIN_PASSWORD"
 
 # Response:
 {
@@ -185,14 +176,14 @@ curl -X GET http://localhost:8000/v1/tools \
 
 ```bash
 # Change PostgreSQL password
-docker-compose exec postgres \
+docker compose exec postgres \
   psql -U postgres -c "ALTER USER postgres WITH PASSWORD 'new-secure-password';"
 
 # Update .env
 sed -i 's/DATABASE_PASSWORD=postgres/DATABASE_PASSWORD=new-secure-password/' .env
 
 # Restart services
-docker-compose restart
+docker compose restart
 ```
 
 ### 2. Generate Secure JWT Secret
@@ -224,7 +215,7 @@ CORS_ORIGINS=https://yourdomain.com,https://app.yourdomain.com
 
 ### 5. Enable HTTPS/TLS
 
-See `nginx-config.conf` for SSL certificate configuration.
+Configure TLS on the gateway service (see `haproxy/` and `docker-compose.prod.yml`).
 
 ---
 
@@ -234,7 +225,7 @@ See `nginx-config.conf` for SSL certificate configuration.
 
 ```bash
 # Access identity service
-docker-compose exec open-security-identity bash
+docker compose exec identity bash
 
 # Run user creation script
 python -c "
@@ -261,7 +252,7 @@ print(f'User created: {new_user.email}')
 
 ```bash
 # Access identity service
-docker-compose exec open-security-identity bash
+docker compose exec identity bash
 
 # Run password reset script
 python -c "
@@ -284,7 +275,7 @@ if user:
 
 ```bash
 # Access identity service
-docker-compose exec open-security-identity bash
+docker compose exec identity bash
 
 # Query users
 python -c "
@@ -322,9 +313,9 @@ Signature: HMACSHA256(header.payload, secret)
 ```bash
 # Tokens expire after 1 hour by default
 # To get a new token, authenticate again
-curl -X POST http://localhost:8001/token \
+curl -X POST http://localhost:8001/auth/jwt/login \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=admin@wildbox.local&password=password"
+  -d "username=$INITIAL_ADMIN_EMAIL&password=$INITIAL_ADMIN_PASSWORD"
 ```
 
 ### Revoke Tokens
@@ -371,11 +362,11 @@ curl -X POST http://localhost:8001/logout \
 
 ```bash
 # Check if user exists
-docker-compose exec postgres \
+docker compose exec postgres \
   psql -U postgres -d wildbox -c "SELECT email, is_active FROM users;"
 
 # Create admin user if missing
-docker-compose exec open-security-identity python -c "
+docker compose exec identity python -c "
 from app.db import SessionLocal
 from app.models import User
 from passlib.context import CryptContext
@@ -399,11 +390,11 @@ print('Admin user created')
 
 ```bash
 # Verify API key is set in environment
-docker-compose exec open-security-tools env | grep API_KEY
+docker compose exec open-security-tools env | grep API_KEY
 
 # Update .env and restart
 echo "API_KEY=dev-api-key-123" >> .env
-docker-compose restart open-security-tools
+docker compose restart open-security-tools
 ```
 
 ---

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -19,7 +19,7 @@ Before starting, ensure you have installed:
 
 ```bash
 docker --version
-docker-compose --version
+docker compose --version
 git --version
 ```
 
@@ -56,8 +56,8 @@ DATABASE_URL=postgresql+asyncpg://postgres:secure_password@postgres:5432/wildbox
 # API Gateway
 API_KEY=your-secure-api-key-here
 
-# OpenAI (for AI-powered features)
-OPENAI_API_KEY=sk-your-actual-key
+# Claude (Anthropic) — optional; enables AI threat analysis
+ANTHROPIC_API_KEY=sk-ant-your-actual-key
 
 # JWT Security
 JWT_SECRET_KEY=your-secure-jwt-secret-min-32-chars
@@ -65,9 +65,6 @@ JWT_SECRET_KEY=your-secure-jwt-secret-min-32-chars
 # Redis
 REDIS_URL=redis://redis:6379/0
 
-# Stripe (if using billing)
-STRIPE_SECRET_KEY=sk_test_your_stripe_key
-STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 ```
 
 ---
@@ -78,32 +75,32 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 
 ```bash
 # Start all services in the background
-docker-compose up -d
+docker compose up -d
 
 # Check service status
-docker-compose ps
+docker compose ps
 
 # View logs
-docker-compose logs -f
+docker compose logs -f
 
 # Stop everything
-docker-compose down
+docker compose down
 ```
 
 ### Option B: Run Specific Services
 
 ```bash
-# Start only the dashboard and API
-docker-compose up -d postgres redis nginx open-security-identity open-security-tools
+# Start only the core (gateway, identity, tools API) plus datastores
+docker compose up -d postgres wildbox-redis gateway identity api
 
 # Or start individual services
-docker-compose up -d postgres redis
+docker compose up -d postgres wildbox-redis
 
 # Wait for databases to be ready
 sleep 10
 
 # Then start application services
-docker-compose up -d open-security-identity open-security-tools
+docker compose up -d identity api
 ```
 
 ---
@@ -119,7 +116,7 @@ curl http://localhost:8001/health
 curl http://localhost:8006/health
 
 # Expected response:
-# {"status":"healthy","timestamp":"2024-11-07T...","version":"1.0.0"}
+# {"status":"healthy","timestamp":"...","version":"..."}
 ```
 
 ---
@@ -130,10 +127,8 @@ Open your browser and navigate to:
 
 | Service | URL | Default Credentials |
 | --------- | ----- | ------------------- |
-| **Dashboard** | http://localhost:3000 | See `QUICKSTART_CREDENTIALS.md` |
+| **Dashboard** | http://localhost:3000 | Set via `INITIAL_ADMIN_EMAIL`/`INITIAL_ADMIN_PASSWORD` in `.env` |
 | **API Docs** | http://localhost:8000/docs | N/A |
-| **Prometheus** | http://localhost:9090 | N/A |
-| **Grafana** | http://localhost:3001 | admin / admin |
 
 ---
 
@@ -143,11 +138,11 @@ Open your browser and navigate to:
 
 ```bash
 # Get initial admin token
-curl -X POST http://localhost:8001/login \
+curl -X POST http://localhost:8001/auth/jwt/login \
   -H "Content-Type: application/json" \
   -d '{
-    "email": "admin@wildbox.local",
-    "password": "your-admin-password"
+    "email": "$INITIAL_ADMIN_EMAIL",
+    "password": "$INITIAL_ADMIN_PASSWORD"
   }'
 
 # Use the returned token for API requests
@@ -158,7 +153,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/v1/dashboard
 
 ```bash
 # Access the identity service shell
-docker-compose exec open-security-identity bash
+docker compose exec identity bash
 
 # Reset password
 python -c "
@@ -179,24 +174,24 @@ hashed = pwd_context.hash('new-password-here')
 
 ```bash
 # All services
-docker-compose logs -f
+docker compose logs -f
 
 # Specific service
-docker-compose logs -f open-security-identity
-docker-compose logs -f open-security-agents
+docker compose logs -f identity
+docker compose logs -f agents
 
 # Last 100 lines
-docker-compose logs --tail=100 open-security-identity
+docker compose logs --tail=100 identity
 ```
 
 ### Run Database Migrations
 
 ```bash
 # For PostgreSQL-based services
-docker-compose exec open-security-identity \
+docker compose exec identity \
   alembic upgrade head
 
-docker-compose exec open-security-data \
+docker compose exec data \
   alembic upgrade head
 ```
 
@@ -204,20 +199,20 @@ docker-compose exec open-security-data \
 
 ```bash
 # Access a service shell
-docker-compose exec open-security-identity bash
-docker-compose exec open-security-agents bash
+docker compose exec identity bash
+docker compose exec agents bash
 
 # Run a specific command
-docker-compose exec -T postgres psql -U postgres -d wildbox -c "SELECT COUNT(*) FROM users;"
+docker compose exec -T postgres psql -U postgres -d wildbox -c "SELECT COUNT(*) FROM users;"
 ```
 
 ### Test API Endpoints
 
 ```bash
 # Get authentication token
-TOKEN=$(curl -s -X POST http://localhost:8001/token \
+TOKEN=$(curl -s -X POST http://localhost:8001/auth/jwt/login \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=admin&password=your-password" | jq -r '.access_token')
+  -d "username=$INITIAL_ADMIN_EMAIL&password=$INITIAL_ADMIN_PASSWORD" | jq -r '.access_token')
 
 # Make authenticated requests
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/v1/indicators
@@ -244,10 +239,10 @@ curl http://localhost:8000/stats | jq .
 
 ```bash
 # Check PostgreSQL
-docker-compose exec postgres pg_isready -U postgres
+docker compose exec postgres pg_isready -U postgres
 
 # Check Redis
-docker-compose exec redis redis-cli ping
+docker compose exec wildbox-redis redis-cli ping
 ```
 
 ### Memory & Disk Usage
@@ -268,24 +263,24 @@ docker system df
 
 ```bash
 # Check error logs
-docker-compose logs open-security-identity
+docker compose logs identity
 
 # Rebuild images
-docker-compose build --no-cache
+docker compose build --no-cache
 
 # Restart services
-docker-compose restart
+docker compose restart
 
 # Full reset (WARNING: Deletes data)
-docker-compose down -v
-docker-compose up -d
+docker compose down -v
+docker compose up -d
 ```
 
 ### Can't Connect to API
 
 ```bash
 # Verify services are running
-docker-compose ps
+docker compose ps
 
 # Check if ports are open
 netstat -an | grep 8000
@@ -299,13 +294,13 @@ curl -v http://localhost:8000/health
 
 ```bash
 # Check PostgreSQL logs
-docker-compose logs postgres
+docker compose logs postgres
 
 # Verify database exists
-docker-compose exec postgres psql -U postgres -l
+docker compose exec postgres psql -U postgres -l
 
 # Check Redis connection
-docker-compose exec redis redis-cli info
+docker compose exec wildbox-redis redis-cli info
 ```
 
 ### Out of Memory or Disk Space
@@ -318,7 +313,7 @@ docker system prune -a
 du -sh ./*
 
 # Reduce log retention
-docker-compose down
+docker compose down
 # Edit docker-compose.yml and adjust volumes
 ```
 
@@ -328,12 +323,12 @@ docker-compose down
 
 After successful deployment:
 
-1. **Security Hardening**: Review [SECURITY_REMEDIATION_CHECKLIST.md](SECURITY_REMEDIATION_CHECKLIST.md)
-2. **Full Documentation**: See [README.md](README.md) for comprehensive information
+1. **Security Hardening**: Review [remediation checklist](../security/remediation-checklist.md)
+2. **Full Documentation**: See [README.md](../../README.md) for comprehensive information
 3. **API Documentation**: Visit http://localhost:8000/docs for interactive API docs
 4. **Monitoring Setup**: Configure Grafana dashboards and alerting rules
 5. **Integration**: Set up external integrations (Slack, email, webhooks, etc.)
-6. **Custom Playbooks**: Create YAML-based automation playbooks in [open-security-responder](open-security-responder)
+6. **Custom Playbooks**: Create YAML-based automation playbooks in [open-security-responder](https://github.com/fabriziosalmi/wildbox/tree/main/open-security-responder)
 
 ---
 
@@ -346,13 +341,13 @@ For production use:
 cp .env .env.production
 nano .env.production
 
-# 2. Use production docker-compose
-docker-compose -f docker-compose.yml \
+# 2. Use production docker compose
+docker compose -f docker-compose.yml \
                -f docker-compose.prod.yml \
                up -d
 
-# 3. Enable SSL/TLS in nginx
-# Edit nginx-config.conf and enable HTTPS
+# 3. Enable SSL/TLS on the gateway
+# Configure certificates for the gateway service (see haproxy/ and docker-compose.prod.yml)
 
 # 4. Set up monitoring and alerting
 # Configure Prometheus retention and Grafana alerts
@@ -379,16 +374,16 @@ docker-compose -f docker-compose.yml \
 
 | Command | Purpose |
 | --------- | --------- |
-| `docker-compose up -d` | Start all services |
-| `docker-compose down` | Stop all services |
-| `docker-compose logs -f` | View live logs |
-| `docker-compose ps` | Show running services |
-| `docker-compose exec <service> bash` | Access service shell |
-| `docker-compose restart <service>` | Restart specific service |
-| `docker-compose build` | Rebuild images |
+| `docker compose up -d` | Start all services |
+| `docker compose down` | Stop all services |
+| `docker compose logs -f` | View live logs |
+| `docker compose ps` | Show running services |
+| `docker compose exec <service> bash` | Access service shell |
+| `docker compose restart <service>` | Restart specific service |
+| `docker compose build` | Rebuild images |
 
 ---
 
 **Happy Securing!**
 
-For questions or issues, refer to the comprehensive [README.md](README.md) or open an issue on GitHub.
+For questions or issues, refer to the comprehensive [README.md](../../README.md) or open an issue on GitHub.


### PR DESCRIPTION
Closes #171 — Sprint 0 (honesty & first-run).

README, SETUP_GUIDE, the quickstart and the credentials guide disagreed on the default admin login, ports, service names and the auth endpoint, and referenced scripts that don't exist. This makes them agree with the code and `docker-compose.yml`.

## One source of truth
- **Credentials**: everything now points to `INITIAL_ADMIN_EMAIL` / `INITIAL_ADMIN_PASSWORD` (set in `.env`, used by `docker-compose.yml` to seed the admin) — replacing three invented defaults (`admin@wildbox.security`/`CHANGE-THIS-PASSWORD`, `…/ChangeMeInProduction123!`, `admin@wildbox.local`/`your-password`).
- **Auth endpoint**: the real fastapi-users route `POST /auth/jwt/login` (was `/login` and `/token`, neither of which exists).
- **Service & port accuracy** vs `docker-compose.yml`: quickstart commands used directory names as service names — fixed `open-security-identity → identity`, `open-security-tools → api`, `open-security-data → data`, `redis → wildbox-redis`, `nginx → gateway`; dropped Prometheus/Grafana rows from the "running services" access table (not in the base compose).
- **Phantom scripts → real commands**: `comprehensive_health_check.sh → make health`; `system_monitor.sh → docker compose ps` / `docker stats`; `scripts/setup-ssl.sh` & `nginx-config.conf → gateway` + `docker-compose.prod.yml`.
- **Honesty**: "GPT-4 Analysis" → "Claude (Anthropic) Analysis"; removed Stripe/OpenAI from the quickstart and the credentials `.env` template (consistent with #169); fixed broken relative links.
- `docker-compose` → `docker compose` (v2) throughout these docs.

## Verification
`markdownlint` → **0 errors** on all four changed files (README, SETUP_GUIDE, quickstart, credentials). No phantom scripts / old endpoints / GPT-4 remain.

Follow-up: `docs/guides/credentials.md` still lists Grafana/Prometheus and unverified dev API keys in its tables — a deeper audit of that file is a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)