### PR TITLE
security: make GATEWAY_INTERNAL_SECRET mandatory (fail-closed) downstream

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -137,6 +137,7 @@ services:
   tools-test:
     build: ./open-security-tools
     environment:
+      GATEWAY_INTERNAL_SECRET: test-gateway-secret-change-this
       API_KEY: test-api-key-for-ci-only
       DEBUG: "true"
       LOG_LEVEL: DEBUG
@@ -157,6 +158,7 @@ services:
   data-test:
     build: ./open-security-data
     environment:
+      GATEWAY_INTERNAL_SECRET: test-gateway-secret-change-this
       DATA_DATABASE_URL: postgresql://postgres:test_password@postgres-test:5432/wildbox_test
       REDIS_URL: redis://redis-test:6379/1
       API_KEY: test-api-key-for-ci-only
@@ -184,6 +186,7 @@ services:
   guardian-test:
     build: ./open-security-guardian
     environment:
+      GATEWAY_INTERNAL_SECRET: test-gateway-secret-change-this
       GUARDIAN_DATABASE_URL: postgresql://postgres:test_password@postgres-test:5432/wildbox_test
       REDIS_URL: redis://redis-test:6379/3
       API_KEY: test-api-key-for-ci-only
@@ -211,6 +214,7 @@ services:
   responder-test:
     build: ./open-security-responder
     environment:
+      GATEWAY_INTERNAL_SECRET: test-gateway-secret-change-this
       RESPONDER_DATABASE_URL: postgresql://postgres:test_password@postgres-test:5432/wildbox_test
       REDIS_URL: redis://redis-test:6379/4
       API_KEY: test-api-key-for-ci-only
@@ -233,6 +237,7 @@ services:
   agents-test:
     build: ./open-security-agents
     environment:
+      GATEWAY_INTERNAL_SECRET: test-gateway-secret-change-this
       REDIS_URL: redis://redis-test:6379/6
       API_KEY: test-api-key-for-ci-only
       ANTHROPIC_API_KEY: ""
@@ -253,6 +258,7 @@ services:
   cspm-test:
     build: ./open-security-cspm
     environment:
+      GATEWAY_INTERNAL_SECRET: test-gateway-secret-change-this
       REDIS_URL: redis://redis-test:6379/7
       API_KEY: test-api-key-for-ci-only
       DEBUG: "true"

--- a/open-security-agents/app/auth.py
+++ b/open-security-agents/app/auth.py
@@ -46,8 +46,14 @@ def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
     import hmac
     expected = os.getenv("GATEWAY_INTERNAL_SECRET")
     if not expected:
-        logger.warning("GATEWAY_INTERNAL_SECRET not set — cannot verify gateway origin")
-        return
+        logger.error(
+            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
+            "headers (fail-closed)."
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
+        )
     if not provided_secret or not hmac.compare_digest(provided_secret, expected):
         raise HTTPException(status_code=403, detail="Direct access is not permitted; requests must traverse the gateway.")
 

--- a/open-security-data/app/auth.py
+++ b/open-security-data/app/auth.py
@@ -48,8 +48,14 @@ def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
     could forge identity headers. Enforced when the secret is configured."""
     expected = os.getenv("GATEWAY_INTERNAL_SECRET")
     if not expected:
-        logger.warning("GATEWAY_INTERNAL_SECRET not set — cannot verify gateway origin")
-        return
+        logger.error(
+            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
+            "headers (fail-closed)."
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
+        )
     if not provided_secret or not hmac.compare_digest(provided_secret, expected):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/open-security-guardian/apps/core/gateway_middleware.py
+++ b/open-security-guardian/apps/core/gateway_middleware.py
@@ -126,17 +126,23 @@ class GatewayAuthMiddleware(MiddlewareMixin):
             # X-Wildbox-User-ID/Role and authenticate as anyone. Enforced when the
             # secret is configured.
             gw_secret = os.getenv('GATEWAY_INTERNAL_SECRET')
-            if gw_secret:
-                provided = request.META.get('HTTP_X_GATEWAY_SECRET', '')
-                if not hmac.compare_digest(provided, gw_secret):
-                    logger.warning("[GATEWAY-AUTH] Rejected X-Wildbox-* headers without a valid gateway secret")
-                    return JsonResponse({
-                        'error': 'forbidden',
-                        'message': 'Direct access is not permitted; requests must traverse the gateway.',
-                        'code': 'GATEWAY_SECRET_REQUIRED',
-                    }, status=403)
-            else:
-                logger.warning("[GATEWAY-AUTH] GATEWAY_INTERNAL_SECRET not set — cannot verify gateway origin")
+            if not gw_secret:
+                # Fail closed: without the secret we cannot verify the request
+                # came from the gateway, so the X-Wildbox-* headers can't be trusted.
+                logger.error("[GATEWAY-AUTH] GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway headers (fail-closed).")
+                return JsonResponse({
+                    'error': 'service_misconfigured',
+                    'message': 'GATEWAY_INTERNAL_SECRET is not set; the service cannot verify gateway origin.',
+                    'code': 'GATEWAY_SECRET_NOT_CONFIGURED',
+                }, status=503)
+            provided = request.META.get('HTTP_X_GATEWAY_SECRET', '')
+            if not hmac.compare_digest(provided, gw_secret):
+                logger.warning("[GATEWAY-AUTH] Rejected X-Wildbox-* headers without a valid gateway secret")
+                return JsonResponse({
+                    'error': 'forbidden',
+                    'message': 'Direct access is not permitted; requests must traverse the gateway.',
+                    'code': 'GATEWAY_SECRET_REQUIRED',
+                }, status=403)
             try:
                 # Validate UUIDs
                 user_id = uuid.UUID(user_id_header)

--- a/open-security-responder/app/auth.py
+++ b/open-security-responder/app/auth.py
@@ -53,8 +53,14 @@ def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
     could forge identity headers. Enforced when the secret is configured."""
     expected = os.getenv("GATEWAY_INTERNAL_SECRET")
     if not expected:
-        logger.warning("GATEWAY_INTERNAL_SECRET not set — cannot verify gateway origin")
-        return
+        logger.error(
+            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
+            "headers (fail-closed)."
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
+        )
     if not provided_secret or not hmac.compare_digest(provided_secret, expected):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/open-security-shared/gateway_auth.py
+++ b/open-security-shared/gateway_auth.py
@@ -97,6 +97,26 @@ async def get_user_from_gateway_headers(
         ```
     """
     
+    # Fail closed: without GATEWAY_INTERNAL_SECRET the service cannot verify that
+    # a request actually came from the gateway, so the X-Wildbox-* headers can't
+    # be trusted at all. Refuse to operate rather than trust forged headers.
+    # (Mirrors identity's /authorize, which also returns 503 when unconfigured.)
+    expected_secret = os.getenv("GATEWAY_INTERNAL_SECRET")
+    if not expected_secret:
+        logger.error(
+            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
+            "headers (fail-closed)."
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "error": "Service misconfigured",
+                "message": "GATEWAY_INTERNAL_SECRET is not set; the service cannot "
+                           "verify gateway origin and will not trust request headers.",
+                "code": "GATEWAY_SECRET_NOT_CONFIGURED",
+            },
+        )
+
     # Check if headers are present
     if not x_wildbox_user_id or not x_wildbox_team_id:
         logger.error(
@@ -115,22 +135,18 @@ async def get_user_from_gateway_headers(
 
     # Proof-of-origin: the X-Wildbox-* headers are only trustworthy when the
     # request also carries the shared gateway secret (which the gateway stamps
-    # on every proxied request and clients cannot supply). Without this, a
-    # request reaching the service directly with forged headers would be trusted.
-    expected_secret = os.getenv("GATEWAY_INTERNAL_SECRET")
-    if expected_secret:
-        if not x_gateway_secret or not hmac.compare_digest(x_gateway_secret, expected_secret):
-            logger.warning("Rejected gateway headers without a valid X-Gateway-Secret")
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "error": "Gateway authentication required",
-                    "message": "Direct access is not permitted; requests must traverse the gateway.",
-                    "code": "GATEWAY_SECRET_REQUIRED",
-                },
-            )
-    else:
-        logger.warning("GATEWAY_INTERNAL_SECRET not set — cannot verify gateway origin")
+    # on every proxied request and clients cannot supply). Without it, a request
+    # reaching the service directly with forged headers would otherwise be trusted.
+    if not x_gateway_secret or not hmac.compare_digest(x_gateway_secret, expected_secret):
+        logger.warning("Rejected gateway headers without a valid X-Gateway-Secret")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "Gateway authentication required",
+                "message": "Direct access is not permitted; requests must traverse the gateway.",
+                "code": "GATEWAY_SECRET_REQUIRED",
+            },
+        )
     
     # Validate UUIDs
     try:

--- a/open-security-tools/app/auth.py
+++ b/open-security-tools/app/auth.py
@@ -45,8 +45,14 @@ def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
     import hmac
     expected = os.getenv("GATEWAY_INTERNAL_SECRET")
     if not expected:
-        logger.warning("GATEWAY_INTERNAL_SECRET not set — cannot verify gateway origin")
-        return
+        logger.error(
+            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
+            "headers (fail-closed)."
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
+        )
     if not provided_secret or not hmac.compare_digest(provided_secret, expected):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
Closes #163 — Sprint 0 (honesty & first-run).

The shared gateway-auth dependency and every per-service auth wrapper **trusted the `X-Wildbox-*` identity headers when `GATEWAY_INTERNAL_SECRET` was unset** (logged a warning and continued). Backend service ports are reachable directly, so a client could forge `X-Wildbox-User-ID/Team-ID/Role` and authenticate as anyone.

Mirrors identity's `/authorize` (which already fails closed): if the secret isn't configured, refuse to trust the headers and return **503 Service misconfigured** instead of warn-and-trust.

## Changes
- `open-security-shared/gateway_auth.py` — fail closed when the secret is unset.
- `open-security-{tools,data,agents,responder}/app/auth.py` — same in each `_verify_gateway_origin` wrapper (each had its own fail-open copy).
- `open-security-guardian/apps/core/gateway_middleware.py` — same in the Django middleware (503 `JsonResponse` instead of warn-and-continue).
- `docker-compose.test.yml` — set `GATEWAY_INTERNAL_SECRET` on all backend test services (was only on `identity-test`) so the compose test path stays green under fail-closed.

## Verification
Logic test on the shared dependency: unset secret → **503**; secret set + wrong/missing `X-Gateway-Secret` → **403**; secret set + correct → authenticated. Behavior is unchanged when the secret IS set (the normal deployment), so this only closes the misconfigured-direct-access hole.

Note: the 5 duplicated `auth.py` wrappers are exactly what Sprint 1 #174 will consolidate onto the shared dependency; until then the fix is applied in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)