### PR TITLE
security: bind backend service ports to 127.0.0.1

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,8 +52,8 @@ services:
     container_name: open-security-dashboard
     restart: unless-stopped
     ports:
-      - "3000:3000"
-      - "3001:3001"  # For Next.js HMR
+      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:3001:3001"  # For Next.js HMR
     environment:
       - NODE_ENV=development
       - NEXT_PUBLIC_API_BASE_URL=http://open-security-tools:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8001:8001"
+      - "127.0.0.1:8001:8001"
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=${REDIS_URL}
@@ -57,7 +57,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       - API_KEY=${API_KEY}
       - DEBUG=${DEBUG:-false}
@@ -146,7 +146,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8002:8002"
+      - "127.0.0.1:8002:8002"
     environment:
       - DATABASE_URL=${DATA_DATABASE_URL}
       - DEBUG=${DEBUG:-false}
@@ -245,7 +245,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./open-security-dashboard:/app
       - /app/node_modules
@@ -357,7 +357,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8013:8013"
+      - "127.0.0.1:8013:8013"
     environment:
       - SECRET_KEY=${GUARDIAN_SECRET_KEY}
       - GATEWAY_INTERNAL_SECRET=${GATEWAY_INTERNAL_SECRET}
@@ -394,7 +394,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8018:8018"
+      - "127.0.0.1:8018:8018"
     environment:
       - DATABASE_URL=${RESPONDER_DATABASE_URL}
       - GATEWAY_INTERNAL_SECRET=${GATEWAY_INTERNAL_SECRET}
@@ -426,7 +426,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8019:8019"
+      - "127.0.0.1:8019:8019"
     environment:
       # cspm requires SECRET_KEY (min 32 chars); without it the service crashes
       # on startup with a pydantic "secret_key Field required" error.
@@ -475,7 +475,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8006:8006"
+      - "127.0.0.1:8006:8006"
     environment:
       # Claude (Anthropic) — analysis is optional; the service starts without a
       # key and analysis tasks fail gracefully until one is set.
@@ -517,7 +517,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "8004:8004"
+      - "127.0.0.1:8004:8004"
     environment:
       - SENSOR_LOGGING_LEVEL=${SENSOR_LOGGING_LEVEL:-INFO}
       - PYTHONPATH=/app


### PR DESCRIPTION
Closes #164 — Sprint 0 (honesty & first-run).

Backend services published their ports as `<port>:<port>` (on `0.0.0.0`), so on any networked host they were directly reachable — defeating "the gateway is the sole entrypoint." This matters more now that services fail closed on a forged-header check (#163) rather than on network isolation.

## Changes
- **`docker-compose.yml`**: prefix `127.0.0.1:` on identity (8001), api/tools (8000), data (8002), guardian (8013), responder (8018), cspm (8019), agents (8006), sensor (8004) and dashboard (3000). Only the **gateway (80/443/8080)** stays publicly published. Flower (5555) and n8n (5678) were already loopback.
- **`docker-compose.override.yml`**: bind the dev dashboard 3000/3001 (Next.js HMR) to loopback so the dev override doesn't re-expose it.

## Impact
`http://localhost:<port>` (the documented access) still works from the host — `127.0.0.1` binding only removes remote/network exposure. Reach services from another machine via the gateway or an SSH tunnel. Verified no non-loopback publishes remain across the compose files except the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)