### PR TITLE
security(tools): extend the SSRF guard to file_url/app_url/download_url

### DIFF
--- a/open-security-tools/app/input_validation.py
+++ b/open-security-tools/app/input_validation.py
@@ -161,7 +161,9 @@ class InputSanitizer:
         return url
 
     # Tool-input fields that carry a URL the tool will connect to (SSRF surface).
-    URL_REQUEST_FIELDS = ("target_url", "url")
+    # Keep in sync with any tool that fetches an attacker-supplied URL, e.g.
+    # metadata_extractor (file_url), mobile_security_analyzer (app_url).
+    URL_REQUEST_FIELDS = ("target_url", "url", "file_url", "app_url", "download_url")
 
     @classmethod
     def validate_request_urls(cls, input_obj) -> None:


### PR DESCRIPTION
Closes #165 — Sprint 0 (honesty & first-run).

The central SSRF guard `InputSanitizer.validate_request_urls` only inspected the field names `target_url`/`url`, so a tool that fetches an attacker-supplied URL through a differently-named field bypassed it — notably **`metadata_extractor` (`file_url`)** and **`mobile_security_analyzer` (`app_url`)**, both of which download the URL server-side.

## Change
- Add `file_url`, `app_url`, `download_url` to `URL_REQUEST_FIELDS`.

## Verification
Both tools route through the guard: `validate_request_urls(validated_input)` is called on both central execution paths — `app/tasks.py:104` (Celery worker) and `app/api/router.py:171` (sync API) — and both schemas declare the fields (`metadata_extractor` `file_url`, `mobile_security_analyzer` `app_url`) and fetch them (`_download_file`, `download_app_file`). So they're now guarded.

## Follow-up (separate, needs per-tool judgement)
While auditing I found other URL fields that are fetched server-side and still bypass the guard:
- `source_url` — `threat_intelligence_aggregator`
- `profile_url` — `digital_footprint_analyzer`, `social_engineering_toolkit`, `social_media_osint`
- `api_base_url` — `api_security_tester` (deliberately pointed at user-chosen targets, so guarding it needs care)

Left out of this scoped fix; worth a dedicated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)