### PR TITLE
build: add generate/validate-secrets targets, fix data DATABASE_URL boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Wildbox Security Platform - Simplified Makefile
 # Use Docker Compose for orchestration - this is just a convenience wrapper
 
-.PHONY: help setup start stop restart logs health test clean
+.PHONY: help setup generate-secrets validate-secrets start stop restart logs health test clean
 
 # Colors
 BLUE := \033[0;34m
@@ -14,7 +14,9 @@ help:
 	@echo "$(BLUE)Wildbox Security Platform$(NC)"
 	@echo ""
 	@echo "$(GREEN)Essential Commands:$(NC)"
-	@echo "  make setup    - First-time setup (copy .env, validate config)"
+	@echo "  make setup            - First-time setup (copy .env, validate config)"
+	@echo "  make generate-secrets - Generate a .env with secure random secrets"
+	@echo "  make validate-secrets - Check .env for insecure/default values"
 	@echo "  make start    - Start all services"
 	@echo "  make stop     - Stop all services"
 	@echo "  make restart  - Restart all services"
@@ -44,6 +46,14 @@ setup:
 	@echo ""
 	@echo "$(GREEN)✓ Setup complete!$(NC)"
 	@echo "Next: make start"
+
+generate-secrets:
+	@echo "$(BLUE)Generating .env with secure secrets...$(NC)"
+	@python3 scripts/generate_secrets.py
+
+validate-secrets:
+	@echo "$(BLUE)Validating .env secrets...$(NC)"
+	@python3 scripts/validate_secrets.py
 
 start:
 	@echo "$(BLUE)Starting services...$(NC)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
     ports:
       - "127.0.0.1:8002:8002"
     environment:
-      - DATABASE_URL=${DATA_DATABASE_URL}
+      - DATABASE_URL=${DATA_DATABASE_URL:-${DATABASE_URL}}
       - DEBUG=${DEBUG:-false}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000}
@@ -174,7 +174,7 @@ services:
       - no-new-privileges:true
     command: python -m app.scheduler.main
     environment:
-      - DATABASE_URL=${DATA_DATABASE_URL}
+      - DATABASE_URL=${DATA_DATABASE_URL:-${DATABASE_URL}}
       - DEBUG=${DEBUG:-false}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     depends_on:
@@ -361,7 +361,7 @@ services:
     environment:
       - SECRET_KEY=${GUARDIAN_SECRET_KEY}
       - GATEWAY_INTERNAL_SECRET=${GATEWAY_INTERNAL_SECRET}
-      - DATABASE_URL=${GUARDIAN_DATABASE_URL}
+      - DATABASE_URL=${GUARDIAN_DATABASE_URL:-${DATABASE_URL}}
       - REDIS_URL=${GUARDIAN_REDIS_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/1}
       - CELERY_BROKER_URL=${GUARDIAN_CELERY_BROKER_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/1}
       - CELERY_RESULT_BACKEND=${GUARDIAN_CELERY_RESULT_BACKEND:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/1}
@@ -396,7 +396,7 @@ services:
     ports:
       - "127.0.0.1:8018:8018"
     environment:
-      - DATABASE_URL=${RESPONDER_DATABASE_URL}
+      - DATABASE_URL=${RESPONDER_DATABASE_URL:-${DATABASE_URL}}
       - GATEWAY_INTERNAL_SECRET=${GATEWAY_INTERNAL_SECRET}
       - REDIS_URL=${RESPONDER_REDIS_URL:-redis://:${REDIS_PASSWORD:-changeme}@wildbox-redis:6379/2}
       - DEBUG=${DEBUG:-false}


### PR DESCRIPTION
Closes #170 — Sprint 0 (honesty & first-run).

Two first-run papercuts:

1. `.env.template` and the docs tell users to run **`make generate-secrets`** / **`make validate-secrets`**, but those Makefile targets didn't exist (only `scripts/generate_secrets.py` / `scripts/validate_secrets.py` did).
2. `data`/`guardian`/`responder` received `DATABASE_URL` only from their per-service vars (`DATA_DATABASE_URL` etc.). A setup that defines just `DATABASE_URL` booted them with an **empty URL → crash**.

## Changes
- **Makefile**: add `generate-secrets` and `validate-secrets` targets (wrapping the scripts) + `.PHONY` + `help` entries.
- **docker-compose.yml**: fall back to the shared var — `DATABASE_URL=${DATA_DATABASE_URL:-${DATABASE_URL}}` for `data` and `data-scheduler`, same for `guardian`/`responder`. Works whether the user sets per-service URLs (the `.env.example` default) or a single `DATABASE_URL`.

## Verification
`make -n generate-secrets` / `validate-secrets` resolve to the script invocations; scripts compile; `docker-compose.yml` parses. Also helps the CI `data-test` empty-`DATABASE_URL` crash tracked in #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)