### PR TITLE
dashboard: add error, not-found and global-error boundaries

### DIFF
--- a/open-security-dashboard/src/app/error.tsx
+++ b/open-security-dashboard/src/app/error.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { AlertTriangle, RotateCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+/**
+ * Route-level error boundary. Next.js renders this when a Server/Client
+ * Component below the root layout throws during render, instead of
+ * white-screening the app.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Surface the error for diagnostics; replace with your telemetry sink.
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader>
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle className="h-6 w-6 text-destructive" />
+          </div>
+          <CardTitle>Something went wrong</CardTitle>
+          <CardDescription>
+            An unexpected error occurred. You can try again or return to the dashboard.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+            <Button onClick={() => reset()}>
+              <RotateCw className="mr-2 h-4 w-4" />
+              Try again
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/dashboard">Go to dashboard</Link>
+            </Button>
+          </div>
+          {error.digest && (
+            <p className="text-xs text-muted-foreground">Error reference: {error.digest}</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/open-security-dashboard/src/app/global-error.tsx
+++ b/open-security-dashboard/src/app/global-error.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Top-level error boundary. Catches errors thrown in the root layout itself
+ * (which the route-level error.tsx cannot), and replaces the whole document.
+ * It must render its own <html>/<body>, and can't rely on the app's styles or
+ * components — keep it self-contained with inline styles.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0a0b0d',
+          color: '#e7e9ee',
+          fontFamily:
+            "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+          padding: '1rem',
+        }}
+      >
+        <div style={{ maxWidth: '28rem', textAlign: 'center' }}>
+          <h1 style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+            Something went wrong
+          </h1>
+          <p style={{ color: '#9aa1ac', marginBottom: '1.5rem', lineHeight: 1.6 }}>
+            The dashboard hit an unexpected error and couldn&rsquo;t render. Please try again.
+          </p>
+          <button
+            onClick={() => reset()}
+            style={{
+              background: '#3b82f6',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '8px',
+              padding: '0.5rem 1.25rem',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+          {error.digest && (
+            <p style={{ color: '#6b7280', fontSize: '0.75rem', marginTop: '1rem' }}>
+              Error reference: {error.digest}
+            </p>
+          )}
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/open-security-dashboard/src/app/not-found.tsx
+++ b/open-security-dashboard/src/app/not-found.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { FileQuestion } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+/**
+ * Branded 404 page, rendered for unmatched routes and notFound() calls.
+ */
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader>
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <FileQuestion className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <CardTitle>Page not found</CardTitle>
+          <CardDescription>
+            The page you&rsquo;re looking for doesn&rsquo;t exist or has moved.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link href="/dashboard">Back to dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #166 — Sprint 0 (honesty & first-run).

There was no `app/error.tsx`, `app/not-found.tsx` or top-level error boundary, so a single render throw white-screened the app and 404s were unstyled.

## Changes
- **`app/error.tsx`** — branded route-level error boundary (Try again / Go to dashboard); logs the error and surfaces `error.digest`.
- **`app/not-found.tsx`** — branded 404 with a link back to the dashboard.
- **`app/global-error.tsx`** — top-level boundary for failures in the root layout itself (which `error.tsx` can't catch); renders its own `<html>`/`<body>` with self-contained inline styles since the app's CSS/components may be unavailable.

Built on the existing shadcn `Card`/`Button` primitives. `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)