### PR TITLE
dashboard: remove dead nav links and mock-data fallback

### DIFF
--- a/open-security-dashboard/src/app/auth/login/page.tsx
+++ b/open-security-dashboard/src/app/auth/login/page.tsx
@@ -147,12 +147,6 @@ export default function LoginPage() {
                     Remember me
                   </label>
                 </div>
-                <Link
-                  href="/auth/forgot-password"
-                  className="text-sm text-blue-600 hover:text-blue-500 dark:text-blue-400"
-                >
-                  Forgot password?
-                </Link>
               </div>
 
               <Button
@@ -183,18 +177,6 @@ export default function LoginPage() {
           </CardContent>
         </Card>
 
-        <div className="mt-8 text-center text-xs text-gray-500 dark:text-gray-400">
-          <p>
-            By signing in, you agree to our{' '}
-            <Link href="/terms" className="text-blue-600 hover:text-blue-500 dark:text-blue-400">
-              Terms of Service
-            </Link>{' '}
-            and{' '}
-            <Link href="/privacy" className="text-blue-600 hover:text-blue-500 dark:text-blue-400">
-              Privacy Policy
-            </Link>
-          </p>
-        </div>
       </div>
     </div>
   )

--- a/open-security-dashboard/src/app/auth/signup/page.tsx
+++ b/open-security-dashboard/src/app/auth/signup/page.tsx
@@ -221,13 +221,9 @@ export default function SignupPage() {
                 <div className="ml-3 text-sm">
                   <label htmlFor="terms" className="text-gray-700 dark:text-gray-300">
                     I agree to the{' '}
-                    <Link href="/terms" className="text-blue-600 hover:text-blue-500 dark:text-blue-400">
-                      Terms of Service
-                    </Link>{' '}
+                    <span className="font-medium text-gray-900 dark:text-gray-100">Terms of Service</span>{' '}
                     and{' '}
-                    <Link href="/privacy" className="text-blue-600 hover:text-blue-500 dark:text-blue-400">
-                      Privacy Policy
-                    </Link>
+                    <span className="font-medium text-gray-900 dark:text-gray-100">Privacy Policy</span>
                   </label>
                 </div>
               </div>

--- a/open-security-dashboard/src/app/response/runs/page.tsx
+++ b/open-security-dashboard/src/app/response/runs/page.tsx
@@ -43,56 +43,10 @@ interface RunsResponse {
   total: number
 }
 
-// Mock data since the API endpoint might not be implemented yet
-const mockRuns: PlaybookRun[] = [
-  {
-    id: 'run-001',
-    playbookId: 'triage_ip',
-    playbookName: 'IP Address Triage',
-    status: 'completed',
-    startTime: new Date(Date.now() - 30000).toISOString(),
-    endTime: new Date(Date.now() - 15000).toISOString(),
-    duration: 15,
-    trigger: 'manual',
-    userId: 'admin',
-  },
-  {
-    id: 'run-002',
-    playbookId: 'triage_url',
-    playbookName: 'URL Analysis and Response',
-    status: 'running',
-    startTime: new Date(Date.now() - 45000).toISOString(),
-    trigger: 'api',
-    userId: 'security-team',
-    progress: 65,
-  },
-  {
-    id: 'run-003',
-    playbookId: 'simple_notification',
-    playbookName: 'Simple Notification Test',
-    status: 'failed',
-    startTime: new Date(Date.now() - 120000).toISOString(),
-    endTime: new Date(Date.now() - 110000).toISOString(),
-    duration: 10,
-    trigger: 'manual',
-    userId: 'admin',
-    error: 'Connection timeout to external service',
-  },
-]
-
 async function fetchRuns(): Promise<RunsResponse> {
-  try {
-    // Try to fetch from API, but fall back to mock data if not available
-    const response = await responderClient.get('/v1/runs')
-    return response
-  } catch (error) {
-    console.warn('API not available, using mock data:', error)
-    // Return mock data for demonstration
-    return {
-      runs: mockRuns,
-      total: mockRuns.length
-    }
-  }
+  // Let API errors propagate so the page renders its real loading / error /
+  // "No runs found" states via react-query — never fabricated demo data.
+  return responderClient.get('/v1/runs')
 }
 
 function getStatusIcon(status: string) {

--- a/open-security-dashboard/src/components/main-layout.tsx
+++ b/open-security-dashboard/src/components/main-layout.tsx
@@ -12,7 +12,6 @@ import {
   Monitor,
   Bug,
   Zap,
-  Brain,
   Settings,
   Menu,
   X,
@@ -91,12 +90,6 @@ const baseNavigation: NavigationItem[] = [
       { name: 'Playbooks', href: '/response/playbooks' },
       { name: 'Runs', href: '/response/runs' },
     ],
-  },
-  {
-    name: 'AI Analyst',
-    href: '/ai-analyst',
-    icon: Brain,
-    description: 'Intelligent analysis',
   },
   {
     name: 'API Docs',


### PR DESCRIPTION
Closes #167 — Sprint 0 (honesty & first-run).

Nav/footer linked to routes that don't exist, and the runs page silently fabricated demo data when the API was unavailable — both make the dashboard look more complete than it is.

## Changes
- **`main-layout.tsx`**: remove the **"AI Analyst"** sidebar item (`/ai-analyst` doesn't exist) and its now-unused `Brain` icon import.
- **`auth/login`**: remove the **"Forgot password?"** link (`/auth/forgot-password` doesn't exist) and the **Terms/Privacy** agreement block (no `/terms`, `/privacy`).
- **`auth/signup`**: keep the required-consent checkbox but render *Terms of Service* / *Privacy Policy* as plain text instead of dead links.
- **`response/runs`**: drop the hardcoded `mockRuns` fallback — `fetchRuns` now lets API errors propagate so the page renders its **real loading / error / "No runs found"** states (already implemented) instead of fake runs.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)