### PR TITLE
dashboard: hide unbacked header chrome (notifications, status, search)

### DIFF
--- a/open-security-dashboard/src/components/main-layout.tsx
+++ b/open-security-dashboard/src/components/main-layout.tsx
@@ -15,8 +15,6 @@ import {
   Settings,
   Menu,
   X,
-  Bell,
-  Search,
   User,
   LogOut,
   ChevronDown,
@@ -329,33 +327,10 @@ export function MainLayout({ children }: MainLayoutProps) {
               {sidebarOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
             </button>
             
-            {/* Search */}
-            <div className="hidden md:flex items-center gap-2 bg-accent/50 rounded-md px-3 py-2 min-w-96">
-              <Search className="w-4 h-4 text-muted-foreground" />
-              <input
-                type="text"
-                placeholder="Search IOCs, playbooks, tools..."
-                className="bg-transparent border-0 outline-none flex-1 text-sm placeholder:text-muted-foreground"
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center gap-4">
-            {/* Notifications */}
-            <button className="relative p-2 rounded-md hover:bg-accent">
-              <Bell className="w-5 h-5" />
-              <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full text-xs flex items-center justify-center text-white">
-                3
-              </span>
-            </button>
-
-            {/* Status Indicator */}
-            <div className="flex items-center gap-2 px-3 py-1 bg-green-100 dark:bg-green-900 rounded-full">
-              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-              <span className="text-xs font-medium text-green-800 dark:text-green-100">
-                All Systems Operational
-              </span>
-            </div>
+            {/* Global search, notifications and the system-status pill are
+                hidden until they're backed by real data — showing a static
+                badge / always-green "operational" pill / dead search box made
+                the app look like a mockup. */}
           </div>
         </header>
 


### PR DESCRIPTION
Closes #168 — Sprint 0 (honesty & first-run). **Last issue in Sprint 0.**

The header hardcoded a "3" notification badge, a permanently-green "All Systems Operational" pill, and a non-functional global search box — it looked like a product but behaved like a mockup.

None of the three has a backing data source yet, so per the issue ("data-driven or hidden") they're **hidden until implemented**:
- remove the static `3` notifications badge/button,
- remove the always-green system-status pill,
- remove the dead global search input,
- drop the now-unused `Bell` / `Search` icon imports.

`tsc --noEmit` clean. (Re-introduce each element wired to a real source — unread-notification count, an aggregated health check, a working search endpoint — when those exist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)