### PR TITLE
shared: add packaging metadata to open-security-shared (#172)

### DIFF
--- a/open-security-shared/README.md
+++ b/open-security-shared/README.md
@@ -1,0 +1,16 @@
+# open-security-shared
+
+Shared utilities for Wildbox security services.
+
+The primary export is the **gateway authentication** dependency
+(`open_security_shared.gateway_auth`): backend services trust the
+`X-Wildbox-*` identity headers stamped by the API gateway, verified by the
+shared `GATEWAY_INTERNAL_SECRET` proof-of-origin.
+
+```python
+from open_security_shared.gateway_auth import get_user_from_gateway_headers, GatewayUser, require_role
+```
+
+Install (from the repo root, per service): `pip install ./open-security-shared`.
+
+Optional extras: `observability` (OpenTelemetry), `events` (Redis/SQLAlchemy/httpx).

--- a/open-security-shared/pyproject.toml
+++ b/open-security-shared/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "open-security-shared"
+version = "1.0.0"
+description = "Shared utilities for Wildbox security services (gateway auth + auth helpers)."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Wildbox" }]
+
+# Core dependencies: everything the gateway-auth path needs. Importing the
+# package (open_security_shared) eagerly loads auth_utils via __init__, so these
+# must be present wherever the package is installed.
+dependencies = [
+    "fastapi>=0.110",
+    "pydantic>=2",
+    "passlib[bcrypt]>=1.7",
+    "python-jose[cryptography]>=3.3",
+]
+
+[project.optional-dependencies]
+# Heavier, optional modules (observability / eventing). They are not on the
+# gateway-auth path and are not required to import open_security_shared.gateway_auth.
+observability = ["opentelemetry-api", "opentelemetry-sdk"]
+events = ["redis>=5", "sqlalchemy>=2", "httpx>=0.27"]
+
+[tool.setuptools]
+# The modules live flat in this directory; expose them under the importable
+# package name `open_security_shared`.
+packages = ["open_security_shared"]
+
+[tool.setuptools.package-dir]
+open_security_shared = "."


### PR DESCRIPTION
Refs #172 — Sprint 1 (shared library & auth consolidation). **Foundation: the packaging-metadata checkbox.**

`open-security-shared/` was consumed via `sys.path.insert` hacks + `try/except ImportError` fallbacks rather than a real dependency (so in the containers the import actually fails and each service uses a local fallback copy). This makes it a real installable package.

## Changes
- **`pyproject.toml`**: setuptools build; maps the flat module dir to the importable package `open_security_shared` (`package-dir`); declares the core gateway-auth deps (`fastapi` / `pydantic` / `passlib` / `python-jose`) and optional `observability` / `events` extras for the heavier modules.
- **`README.md`** for the package.

## Verified
In a clean venv: `pip install ./open-security-shared` succeeds and `import open_security_shared.gateway_auth` (+ `auth_utils`, which `__init__` loads eagerly) work.

## Why this PR stops here (rigorous scoping)
The second checkbox — *install it in each service image* — plus #173 (remove the `sys.path`/`try-except` shims and the unvalidated dev-mode `GatewayUser` fallback) and #174 (collapse the five per-service `auth.py` onto the shared dependency) **change the Docker builds and the security-critical auth path across 5 services**. The PR CI does **not** build or run the Docker images (`Build Docker Images` is skipped on PRs), so merging those blind on a green-but-incomplete check would be unsafe. They should be done with real `docker compose build && up` validation — handled separately, not bundled into this foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)