### PR TITLE
ci: validate Docker image builds on pull requests (build-only)

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -1,0 +1,61 @@
+name: Docker Build Validation
+
+# Build (but never push) each service image on pull requests, so changes that
+# touch the Docker builds — Dockerfiles, requirements, service code, the shared
+# package, or compose — are validated before merge. The existing
+# "Build Docker Images" job (test.yml) still builds and pushes on main only.
+#
+# Path-filtered so it doesn't run on docs-only PRs.
+
+on:
+  pull_request:
+    paths:
+      - 'open-security-*/Dockerfile'
+      - 'open-security-*/Dockerfile.*'
+      - 'open-security-*/requirements.txt'
+      - 'open-security-*/app/**'
+      - 'open-security-*/pyproject.toml'
+      - 'open-security-*/manage.py'
+      - 'open-security-shared/**'
+      - 'docker-compose*.yml'
+      - '.github/workflows/docker-build-validation.yml'
+
+# Newer pushes to the same PR cancel in-flight builds.
+concurrency:
+  group: docker-build-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.service }} image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - identity
+          - tools
+          - data
+          - guardian
+          - responder
+          - agents
+          - cspm
+          - gateway
+          - dashboard
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./open-security-${{ matrix.service }}
+          push: false
+          load: false
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}


### PR DESCRIPTION
Refs #172 / #173 / #174 — the safety net for the Sprint 1 shared-package + auth-consolidation work.

The existing `build-images` job (`test.yml`) only builds/pushes on **push to `main`** (`if: push && ref==main`), so changes that touch the Docker builds couldn't be validated **before** merge — and there's no local Docker here. That makes the Sprint 1 migration (install `open-security-shared` into each image, drop the `sys.path`/fallback shims) un-validatable pre-merge.

This adds a **build-only (never-push)** workflow that builds each service image on PRs:
- **Path-filtered** — runs only when a PR touches Dockerfiles, `requirements.txt`, service `app/**`, `open-security-shared/**`, or `docker-compose*.yml`; docs-only PRs skip it.
- Matrix over all nine services, `fail-fast: false` so every image is reported.
- GHA layer cache (scoped per service); concurrency cancels superseded runs.

All nine images already build successfully on `main` (latest Test Suite run: every `Build Docker Images (<svc>)` job green), so this gate is green on the current code — it only starts catching regressions from here. This PR touches a workflow in the filter, so the new job runs on itself and validates all nine builds.

With this in place, the Sprint 1 Docker migration becomes PR-validatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)