### PR TITLE
sprint1: install open-security-shared into each service image (#172)

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -55,6 +55,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./open-security-${{ matrix.service }}
+          build-contexts: |
+            shared=open-security-shared
           push: false
           load: false
           cache-from: type=gha,scope=${{ matrix.service }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Install Identity Service Dependencies
         run: |
+          pip install ./open-security-shared
           cd open-security-identity
           pip install -r requirements.txt
 
@@ -122,6 +123,7 @@ jobs:
 
       - name: Install Tools Service Dependencies
         run: |
+          pip install ./open-security-shared
           cd open-security-tools
           pip install -r requirements.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,6 +210,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./open-security-${{ matrix.service }}
+          build-contexts: |
+            shared=open-security-shared
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     build:
       context: ./open-security-identity
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-identity
     restart: unless-stopped
     security_opt:
@@ -52,6 +54,8 @@ services:
     build:
       context: ./open-security-tools
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-tools
     restart: unless-stopped
     security_opt:
@@ -84,6 +88,8 @@ services:
     build:
       context: ./open-security-tools
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-tools-worker
     restart: unless-stopped
     security_opt:
@@ -111,6 +117,8 @@ services:
     build:
       context: ./open-security-tools
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-tools-flower
     restart: unless-stopped
     security_opt:
@@ -141,6 +149,8 @@ services:
     build:
       context: ./open-security-data
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-data
     restart: unless-stopped
     security_opt:
@@ -168,6 +178,8 @@ services:
     build:
       context: ./open-security-data
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-data-scheduler
     restart: unless-stopped
     security_opt:
@@ -352,6 +364,8 @@ services:
     build:
       context: ./open-security-guardian
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-guardian
     restart: unless-stopped
     security_opt:
@@ -389,6 +403,8 @@ services:
     build:
       context: ./open-security-responder
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-responder
     restart: unless-stopped
     security_opt:
@@ -421,6 +437,8 @@ services:
     build:
       context: ./open-security-cspm
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-cspm
     restart: unless-stopped
     security_opt:
@@ -470,6 +488,8 @@ services:
     build:
       context: ./open-security-agents
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-agents
     restart: unless-stopped
     security_opt:
@@ -512,6 +532,8 @@ services:
     build:
       context: ./open-security-sensor
       dockerfile: Dockerfile
+      additional_contexts:
+        shared: ../open-security-shared
     container_name: open-security-sensor
     restart: unless-stopped
     security_opt:

--- a/open-security-agents/Dockerfile
+++ b/open-security-agents/Dockerfile
@@ -12,6 +12,12 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy application code
 COPY . .
 

--- a/open-security-cspm/Dockerfile
+++ b/open-security-cspm/Dockerfile
@@ -39,6 +39,12 @@ RUN apt-get update \
 # Copy installed Python packages from builder
 COPY --from=builder /install /usr/local
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy project
 COPY . .
 

--- a/open-security-data/Dockerfile
+++ b/open-security-data/Dockerfile
@@ -22,6 +22,12 @@ COPY requirements.txt .
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy application code
 COPY app/ ./app/
 COPY manage.py ./

--- a/open-security-guardian/Dockerfile
+++ b/open-security-guardian/Dockerfile
@@ -27,6 +27,12 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir -r requirements.txt
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy project
 COPY . .
 

--- a/open-security-identity/Dockerfile
+++ b/open-security-identity/Dockerfile
@@ -12,6 +12,12 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt .
 RUN pip install --no-cache-dir --require-hashes -r requirements.txt
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy application code
 COPY . .
 

--- a/open-security-responder/Dockerfile
+++ b/open-security-responder/Dockerfile
@@ -23,6 +23,12 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir -r requirements.txt
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy project
 COPY . .
 

--- a/open-security-sensor/Dockerfile
+++ b/open-security-sensor/Dockerfile
@@ -37,6 +37,12 @@ RUN ARCH=$(dpkg --print-architecture) && \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy application code
 COPY . .
 

--- a/open-security-tools/Dockerfile
+++ b/open-security-tools/Dockerfile
@@ -25,6 +25,12 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
+# Install the shared package, provided via the `shared` additional build
+# context (see docker-compose.yml / CI). --no-deps: its deps already come from
+# this service's requirements.txt.
+COPY --from=shared . /tmp/open-security-shared
+RUN pip install --no-deps /tmp/open-security-shared
+
 # Copy application code
 COPY . .
 


### PR DESCRIPTION
Refs #172 / #173 — Sprint 1. The plumbing to make `open-security-shared` available in every Python service image, so the `sys.path`/`try-except` shims and per-service auth copies can be removed next (#173/#174). **Fallbacks are kept** — this is a safe transitional step.

## Approach
Used a **BuildKit additional build context** named `shared`, rather than restructuring every per-service build context to repo root (which would bloat the build context and require rewriting every `COPY` path).

- **8 Python Dockerfiles** (identity, tools, data, agents, responder, cspm, sensor, guardian): `COPY --from=shared . /tmp/open-security-shared` + `pip install --no-deps /tmp/open-security-shared` after their requirements install. `--no-deps` keeps identity's `--require-hashes` intact and reuses each service's own deps; placed in cspm's **final** stage and before sensor's editable install.
- **docker-compose.yml**: `additional_contexts: { shared: ../open-security-shared }` on all 11 Python build stanzas (tools ×3, data ×2, rest ×1). gateway (Lua) and dashboard (Next.js) untouched.
- **CI**: `docker-build-validation.yml` and `test.yml` build-images pass `build-contexts: shared=open-security-shared`; `integration-tests.yml` installs the package for the identity/tools uvicorn services.

## Validation
The build-on-PR workflow (#229) runs on this PR and **builds all nine images with the `shared` context** — i.e. it actually verifies the `pip install --no-deps` step in each image before merge. Compose schema validated. The uvicorn integration tests now also install the package.

Next: PR-B removes the shims + per-service `auth.py` duplicates (#173/#174); PR-C scopes `X-API-Key` (#175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)