### PR TITLE
sprint1(auth): consolidate gateway auth onto the shared dependency (#173, #174)

### DIFF
--- a/open-security-agents/app/auth.py
+++ b/open-security-agents/app/auth.py
@@ -1,118 +1,17 @@
+"""Gateway authentication for the Agents service.
+
+Delegates to the shared `open_security_shared.gateway_auth` dependency, which
+verifies the `GATEWAY_INTERNAL_SECRET` proof-of-origin and validates the
+gateway-injected `X-Wildbox-*` headers. The gateway is the sole entrypoint.
 """
-Gateway authentication for Agents service.
 
-This module provides authentication by trusting headers injected by the API gateway.
-In production, all requests MUST go through the gateway which validates credentials
-and injects trusted X-Wildbox-* headers.
-"""
+from open_security_shared.gateway_auth import (
+    GatewayUser,
+    get_user_from_gateway_headers,
+    require_role,
+)
 
-import sys
-import os
-import logging
-from typing import Optional
-from pydantic import BaseModel, UUID4
+# The shared dependency IS this service's authentication dependency.
+get_current_user = get_user_from_gateway_headers
 
-# Add shared modules to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'open-security-shared'))
-
-try:
-    from gateway_auth import get_user_from_gateway_headers as _get_gateway_user, GatewayUser as _GatewayUser, require_role
-    GATEWAY_AUTH_AVAILABLE = True
-    GatewayUser = _GatewayUser
-except ImportError:
-    GATEWAY_AUTH_AVAILABLE = False
-    logging.warning("Gateway auth module not available - using fallback authentication")
-    
-    # Fallback GatewayUser model
-    class GatewayUser(BaseModel):
-        """Fallback user model when shared gateway_auth is not available"""
-        user_id: UUID4
-        team_id: UUID4
-        role: str = "member"
-        
-        class Config:
-            frozen = True
-
-from fastapi import Header, HTTPException, Depends
-
-
-logger = logging.getLogger(__name__)
-
-
-def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
-    """Reject forged X-Wildbox-* headers: only the gateway holds the shared
-    secret. The service port is reachable directly, so without this a client
-    could forge identity headers. Enforced when the secret is configured."""
-    import hmac
-    expected = os.getenv("GATEWAY_INTERNAL_SECRET")
-    if not expected:
-        logger.error(
-            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
-            "headers (fail-closed)."
-        )
-        raise HTTPException(
-            status_code=503,
-            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
-        )
-    if not provided_secret or not hmac.compare_digest(provided_secret, expected):
-        raise HTTPException(status_code=403, detail="Direct access is not permitted; requests must traverse the gateway.")
-
-
-async def get_current_user(
-    x_wildbox_user_id: Optional[str] = Header(None, alias="X-Wildbox-User-ID"),
-    x_wildbox_team_id: Optional[str] = Header(None, alias="X-Wildbox-Team-ID"),
-    x_wildbox_role: Optional[str] = Header(None, alias="X-Wildbox-Role"),
-    x_gateway_secret: Optional[str] = Header(None, alias="X-Gateway-Secret"),
-) -> GatewayUser:
-    """
-    Primary authentication dependency for Agents service.
-
-    Authenticates via X-Wildbox-* headers injected by the API gateway.
-
-    Returns:
-        GatewayUser object with user_id, team_id, role
-
-    Raises:
-        HTTPException 401: No authentication provided
-    """
-    # Priority 1: Gateway headers (production mode)
-    if x_wildbox_user_id and x_wildbox_team_id:
-        _verify_gateway_origin(x_gateway_secret)
-        if GATEWAY_AUTH_AVAILABLE:
-            # Use shared gateway auth module
-            return await _get_gateway_user(
-                x_wildbox_user_id=x_wildbox_user_id,
-                x_wildbox_team_id=x_wildbox_team_id,
-                x_wildbox_role=x_wildbox_role
-            )
-        else:
-            # Fallback implementation without shared module
-            try:
-                return GatewayUser(
-                    user_id=x_wildbox_user_id,
-                    team_id=x_wildbox_team_id,
-                    role=x_wildbox_role or "member"
-                )
-            except (ValueError, KeyError, TypeError, ConnectionError, TimeoutError) as e:
-                logger.error(f"[AUTH-ERROR] Invalid gateway headers: {e}")
-                raise HTTPException(
-                    status_code=400,
-                    detail="Invalid authentication headers from gateway"
-                )
-    
-    # No authentication provided
-    raise HTTPException(
-        status_code=401,
-        detail="Authentication required. Access via gateway with X-Wildbox-* headers.",
-        headers={"WWW-Authenticate": "Bearer"}
-    )
-
-
-__all__ = [
-    "get_current_user",
-    "GatewayUser"
-]
-
-# Re-export gateway auth helpers if available
-if GATEWAY_AUTH_AVAILABLE:
-    __all__.extend(["require_role"])
+__all__ = ["GatewayUser", "get_current_user", "require_role"]

--- a/open-security-data/app/auth.py
+++ b/open-security-data/app/auth.py
@@ -1,153 +1,17 @@
-"""
-Gateway Authentication for Data Service
+"""Gateway authentication for the Data service.
 
-This module provides authentication by trusting headers injected by the gateway.
-The gateway validates API keys and JWT tokens, then injects trusted headers
-that this service uses to identify and authorize users.
-
-Security Model:
-- Gateway performs authentication (API key or JWT validation)
-- Gateway injects X-Wildbox-* headers after successful auth
-- This service trusts these headers (they're never exposed externally)
-- All requests MUST pass through the gateway; direct access is rejected
+Delegates to the shared `open_security_shared.gateway_auth` dependency, which
+verifies the `GATEWAY_INTERNAL_SECRET` proof-of-origin and validates the
+gateway-injected `X-Wildbox-*` headers. The gateway is the sole entrypoint.
 """
 
-import hmac
-import logging
-import os
-from typing import Optional
-from uuid import UUID
+from open_security_shared.gateway_auth import (
+    GatewayUser,
+    get_user_from_gateway_headers,
+    require_role,
+)
 
-from fastapi import Header, HTTPException, status, Depends
+# The shared dependency IS this service's authentication dependency.
+get_current_user = get_user_from_gateway_headers
 
-# Try to import shared gateway_auth module (if available)
-try:
-    from open_security_shared.gateway_auth import GatewayUser, get_user_from_gateway_headers
-    SHARED_AUTH_AVAILABLE = True
-except ImportError:
-    SHARED_AUTH_AVAILABLE = False
-    
-    # Fallback: Define GatewayUser locally if shared module not available
-    from pydantic import BaseModel, Field
-    
-    class GatewayUser(BaseModel):
-        """User model populated from gateway-injected headers"""
-        user_id: UUID = Field(..., description="User's unique identifier")
-        team_id: UUID = Field(..., description="User's team identifier")
-        role: str = Field(default="member", description="User role (owner, admin, member)")
-        
-        class Config:
-            frozen = True  # Immutable for security
-
-logger = logging.getLogger(__name__)
-
-
-def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
-    """Reject forged X-Wildbox-* headers: only the gateway holds the shared
-    secret. The service port is reachable directly, so without this a client
-    could forge identity headers. Enforced when the secret is configured."""
-    expected = os.getenv("GATEWAY_INTERNAL_SECRET")
-    if not expected:
-        logger.error(
-            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
-            "headers (fail-closed)."
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
-        )
-    if not provided_secret or not hmac.compare_digest(provided_secret, expected):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Direct access is not permitted; requests must traverse the gateway.",
-        )
-
-
-async def get_current_user(
-    x_wildbox_user_id: Optional[str] = Header(None),
-    x_wildbox_team_id: Optional[str] = Header(None),
-    x_wildbox_role: Optional[str] = Header(None),
-    x_gateway_secret: Optional[str] = Header(None, alias="X-Gateway-Secret"),
-) -> GatewayUser:
-    """
-    Get current user from gateway-injected headers.
-
-    Args:
-        x_wildbox_user_id: User ID injected by gateway
-        x_wildbox_team_id: Team ID injected by gateway
-        x_wildbox_role: User role injected by gateway
-
-    Returns:
-        GatewayUser: Authenticated user information
-
-    Raises:
-        HTTPException: 401 if no gateway headers present
-        HTTPException: 403 if gateway headers have invalid format
-    """
-    
-    # Priority 1: Check for gateway headers
-    if x_wildbox_user_id and x_wildbox_team_id:
-        _verify_gateway_origin(x_gateway_secret)
-        try:
-            # Validate UUIDs
-            user_id = UUID(x_wildbox_user_id)
-            team_id = UUID(x_wildbox_team_id)
-            
-            # Create gateway user
-            user = GatewayUser(
-                user_id=user_id,
-                team_id=team_id,
-                role=x_wildbox_role or "member"
-            )
-            
-            logger.info(f"🔐 Gateway auth successful - User: {user_id}, Team: {team_id}")
-            return user
-            
-        except ValueError as e:
-            logger.error(f"❌ Invalid gateway header format: {e}")
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid authentication headers - possible bypass attempt"
-            )
-    
-    # No valid authentication found
-    logger.error("Authentication failed - no gateway headers provided")
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required. Use X-API-Key header or contact support.",
-        headers={"WWW-Authenticate": "Bearer"}
-    )
-
-
-# Dependency factory for role-based access control
-
-
-def require_role(*allowed_roles: str):
-    """
-    Dependency factory for role-based access control.
-    
-    Usage:
-        @app.delete("/admin/data/{data_id}")
-        async def delete_data(
-            data_id: str,
-            user: GatewayUser = Depends(require_role("owner", "admin"))
-        ):
-            # Only owners and admins can delete data
-            pass
-    
-    Args:
-        *allowed_roles: Variable number of allowed role names
-    
-    Returns:
-        Dependency function that validates user's role
-    """
-    async def _check_role(user: GatewayUser = Depends(get_current_user)) -> GatewayUser:
-        if user.role not in allowed_roles:
-            logger.warning(f"⚠️ Role restriction violation - User role: {user.role}, Required: {allowed_roles}")
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"This action requires one of these roles: {', '.join(allowed_roles)}"
-            )
-        return user
-    
-    return _check_role
+__all__ = ["GatewayUser", "get_current_user", "require_role"]

--- a/open-security-responder/app/auth.py
+++ b/open-security-responder/app/auth.py
@@ -1,163 +1,17 @@
-"""
-Gateway Authentication for Responder Service
+"""Gateway authentication for the Responder service.
 
-This module provides authentication by trusting headers injected by the gateway.
-The gateway validates API keys and JWT tokens, then injects trusted headers
-that this service uses to identify and authorize users.
-
-Security Model:
-- Gateway performs authentication (API key or JWT validation)
-- Gateway injects X-Wildbox-* headers after successful auth
-- This service trusts these headers (they're never exposed externally)
-- Legacy Bearer token support maintained during migration period
-
-Migration Strategy:
-- Priority 1: Check for gateway headers (X-Wildbox-User-ID, etc.)
-- Priority 2: Fall back to Bearer token (legacy authentication)
-- This allows gradual migration without breaking existing clients
+Delegates to the shared `open_security_shared.gateway_auth` dependency, which
+verifies the `GATEWAY_INTERNAL_SECRET` proof-of-origin and validates the
+gateway-injected `X-Wildbox-*` headers. The gateway is the sole entrypoint.
 """
 
-import hmac
-import logging
-import os
-from typing import Optional
-from uuid import UUID
+from open_security_shared.gateway_auth import (
+    GatewayUser,
+    get_user_from_gateway_headers,
+    require_role,
+)
 
-from fastapi import Header, HTTPException, status, Depends
+# The shared dependency IS this service's authentication dependency.
+get_current_user = get_user_from_gateway_headers
 
-# Try to import shared gateway_auth module (if available)
-try:
-    from open_security_shared.gateway_auth import GatewayUser, get_user_from_gateway_headers
-    SHARED_AUTH_AVAILABLE = True
-except ImportError:
-    SHARED_AUTH_AVAILABLE = False
-    
-    # Fallback: Define GatewayUser locally if shared module not available
-    from pydantic import BaseModel, Field
-    
-    class GatewayUser(BaseModel):
-        """User model populated from gateway-injected headers"""
-        user_id: UUID = Field(..., description="User's unique identifier")
-        team_id: UUID = Field(..., description="User's team identifier")
-        role: str = Field(default="member", description="User role (owner, admin, member)")
-        
-        class Config:
-            frozen = True  # Immutable for security
-
-logger = logging.getLogger(__name__)
-
-
-def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
-    """Reject forged X-Wildbox-* headers: only the gateway holds the shared
-    secret. The service port is reachable directly, so without this a client
-    could forge identity headers. Enforced when the secret is configured."""
-    expected = os.getenv("GATEWAY_INTERNAL_SECRET")
-    if not expected:
-        logger.error(
-            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
-            "headers (fail-closed)."
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
-        )
-    if not provided_secret or not hmac.compare_digest(provided_secret, expected):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Direct access is not permitted; requests must traverse the gateway.",
-        )
-
-
-async def get_current_user(
-    x_wildbox_user_id: Optional[str] = Header(None),
-    x_wildbox_team_id: Optional[str] = Header(None),
-    x_wildbox_role: Optional[str] = Header(None),
-    x_gateway_secret: Optional[str] = Header(None, alias="X-Gateway-Secret"),
-) -> GatewayUser:
-    """
-    Get current user from gateway headers or legacy Bearer token.
-    
-    Authentication Priority:
-    1. Gateway headers (X-Wildbox-*) - PREFERRED
-    2. Bearer token - LEGACY (for backward compatibility during migration)
-    
-    Args:
-        x_wildbox_user_id: User ID injected by gateway
-        x_wildbox_team_id: Team ID injected by gateway
-        x_wildbox_role: User role injected by gateway
-        authorization: Legacy Bearer token (optional)
-    
-    Returns:
-        GatewayUser: Authenticated user information
-    
-    Raises:
-        HTTPException: 401 if authentication fails
-        HTTPException: 403 if gateway bypass attempt detected
-    """
-    
-    # Priority 1: Check for gateway headers
-    if x_wildbox_user_id and x_wildbox_team_id:
-        _verify_gateway_origin(x_gateway_secret)
-        try:
-            # Validate UUIDs
-            user_id = UUID(x_wildbox_user_id)
-            team_id = UUID(x_wildbox_team_id)
-            
-            # Create gateway user
-            user = GatewayUser(
-                user_id=user_id,
-                team_id=team_id,
-                role=x_wildbox_role or "member"
-            )
-            
-            logger.info(f"🔐 Gateway auth successful - User: {user_id}, Team: {team_id}")
-            return user
-            
-        except ValueError as e:
-            logger.error(f"❌ Invalid gateway header format: {e}")
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid authentication headers - possible bypass attempt"
-            )
-    
-    # No valid authentication found
-    logger.error("Authentication failed - no gateway headers provided")
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required. Use X-API-Key header or contact support.",
-        headers={"WWW-Authenticate": "Bearer"}
-    )
-
-
-# Dependency factory for role-based access control
-
-
-def require_role(*allowed_roles: str):
-    """
-    Dependency factory for role-based access control.
-    
-    Usage:
-        @app.delete("/admin/users/{user_id}")
-        async def delete_user(
-            user_id: str,
-            user: GatewayUser = Depends(require_role("owner", "admin"))
-        ):
-            # Only owners and admins can delete users
-            pass
-    
-    Args:
-        *allowed_roles: Variable number of allowed role names
-    
-    Returns:
-        Dependency function that validates user's role
-    """
-    async def _check_role(user: GatewayUser = Depends(get_current_user)) -> GatewayUser:
-        if user.role not in allowed_roles:
-            logger.warning(f"⚠️ Role restriction violation - User role: {user.role}, Required: {allowed_roles}")
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"This action requires one of these roles: {', '.join(allowed_roles)}"
-            )
-        return user
-    
-    return _check_role
+__all__ = ["GatewayUser", "get_current_user", "require_role"]

--- a/open-security-tools/app/auth.py
+++ b/open-security-tools/app/auth.py
@@ -1,63 +1,23 @@
-"""Security implementation for Tools service authentication.
+"""Authentication for the Tools service.
 
-The Tools service accepts authentication in two ways:
-1. **Gateway Authentication** (recommended): Requests coming through the API gateway
-   with X-Wildbox-* headers injected after user auth validation
-2. **Direct API Key** (legacy/development): Direct access with API key for testing
-
-In production, all requests should go through the gateway.
+Two authentication modes:
+1. **Gateway** (production): requests arrive through the API gateway with
+   X-Wildbox-* identity headers and the X-Gateway-Secret proof-of-origin. This
+   is delegated to the shared `open_security_shared.gateway_auth` dependency.
+2. **Direct API key** (legacy/dev): a static X-API-Key. Tracked for removal/
+   scoping in #175 — it currently authenticates as a zero-team admin.
 """
 
-from fastapi import HTTPException, Depends, status, Request, Header
 from typing import Optional
-import sys
-import os
 
-# Add parent directory to path to import shared modules
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'open-security-shared'))
+from fastapi import HTTPException, status, Request, Header
 
-try:
-    from gateway_auth import get_user_from_gateway_headers, GatewayUser
-    GATEWAY_AUTH_AVAILABLE = True
-except ImportError:
-    GATEWAY_AUTH_AVAILABLE = False
-    GatewayUser = None
-    
-    # Fallback if shared module not available
-    class _FallbackGatewayUser:
-        def __init__(self, user_id: str, team_id: str, role: str = "member"):
-            self.user_id = user_id
-            self.team_id = team_id
-            self.role = role
-    
-    GatewayUser = _FallbackGatewayUser
+from open_security_shared.gateway_auth import GatewayUser, get_user_from_gateway_headers
 
 from app.config import settings
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-
-def _verify_gateway_origin(provided_secret: Optional[str]) -> None:
-    """Reject forged X-Wildbox-* headers: only the gateway holds the shared
-    secret. The service port is reachable directly, so without this a client
-    could forge identity headers. Enforced when the secret is configured."""
-    import hmac
-    expected = os.getenv("GATEWAY_INTERNAL_SECRET")
-    if not expected:
-        logger.error(
-            "GATEWAY_INTERNAL_SECRET not configured — refusing to trust gateway "
-            "headers (fail-closed)."
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Service misconfigured: GATEWAY_INTERNAL_SECRET is not set.",
-        )
-    if not provided_secret or not hmac.compare_digest(provided_secret, expected):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Direct access is not permitted; requests must traverse the gateway.",
-        )
 
 
 async def get_current_user(
@@ -66,74 +26,43 @@ async def get_current_user(
     x_wildbox_role: Optional[str] = Header(None, alias="X-Wildbox-Role"),
     x_gateway_secret: Optional[str] = Header(None, alias="X-Gateway-Secret"),
     x_api_key: Optional[str] = Header(None, alias="X-API-Key"),
-    request: Request = None
+    request: Request = None,
 ) -> GatewayUser:
-    """
-    Unified authentication dependency for Tools service.
-    
-    Accepts authentication from:
-    1. Gateway headers (X-Wildbox-*) - production path
-    2. API key (X-API-Key) - legacy/dev path
-    
-    Args:
-        x_wildbox_user_id: User ID from gateway
-        x_wildbox_team_id: Team ID from gateway
-        x_wildbox_role: User role from gateway
-        x_api_key: Direct API key (fallback)
-        request: FastAPI request object
-        
-    Returns:
-        GatewayUser with user information
-        
-    Raises:
-        HTTPException 401: If authentication fails
-    """
-    
-    # Prefer gateway authentication
-    if x_wildbox_user_id and x_wildbox_team_id:
-        _verify_gateway_origin(x_gateway_secret)
-        logger.info(f"Gateway-authenticated request: user={x_wildbox_user_id}, team={x_wildbox_team_id}")
+    """Unified auth dependency: gateway headers (preferred) or a legacy API key."""
 
-        if GATEWAY_AUTH_AVAILABLE:
-            # Use shared dependency for proper validation
-            return await get_user_from_gateway_headers(
-                x_wildbox_user_id=x_wildbox_user_id,
-                x_wildbox_team_id=x_wildbox_team_id,
-                x_wildbox_role=x_wildbox_role
-            )
-        else:
-            # Fallback without validation (for development)
-            logger.warning("Gateway auth module not available, using fallback")
-            return GatewayUser(
-                user_id=x_wildbox_user_id,
-                team_id=x_wildbox_team_id,
-                role=x_wildbox_role or "member"
-            )
-    
-    # Fallback to direct API key (legacy/development)
+    # Gateway path (production): the shared dependency verifies the
+    # GATEWAY_INTERNAL_SECRET proof-of-origin and validates the headers.
+    if x_wildbox_user_id and x_wildbox_team_id:
+        return await get_user_from_gateway_headers(
+            x_wildbox_user_id=x_wildbox_user_id,
+            x_wildbox_team_id=x_wildbox_team_id,
+            x_wildbox_role=x_wildbox_role,
+            x_gateway_secret=x_gateway_secret,
+        )
+
+    # Legacy/dev: direct API key. NOTE: returns a zero-team admin — see #175.
     if x_api_key:
         if x_api_key != settings.get_api_key():
-            logger.warning(f"Invalid API key attempt from {request.client.host if request and request.client else 'unknown'}")
+            client = request.client.host if request and request.client else "unknown"
+            logger.warning(f"Invalid API key attempt from {client}")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid API key",
-                headers={"WWW-Authenticate": "Bearer"}
+                headers={"WWW-Authenticate": "Bearer"},
             )
-        
         logger.info("Direct API key authentication (legacy mode)")
-        # Return a generic user for API key auth
         return GatewayUser(
-            user_id="00000000-0000-0000-0000-000000000000",  # System user
-            team_id="00000000-0000-0000-0000-000000000000",  # System team
-            role="admin"
+            user_id="00000000-0000-0000-0000-000000000000",
+            team_id="00000000-0000-0000-0000-000000000000",
+            role="admin",
         )
-    
-    # No authentication provided
-    logger.warning(f"Unauthenticated request from {request.client.host if request and request.client else 'unknown'}")
+
+    client = request.client.host if request and request.client else "unknown"
+    logger.warning(f"Unauthenticated request from {client}")
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Authentication required. Provide X-API-Key header or access via gateway.",
-        headers={"WWW-Authenticate": "Bearer"}
+        headers={"WWW-Authenticate": "Bearer"},
     )
 
 


### PR DESCRIPTION
Closes #173, #174 — Sprint 1. Now that `open-security-shared` is installed in every image and the CI uvicorn path (#172, #230), drop the per-service auth shims and duplicated gateway-auth logic.

## Changes
- **tools / agents / data / responder**: remove the `sys.path.insert` hacks, `try/except ImportError` fallbacks, fallback `GatewayUser` classes, and the duplicated `_verify_gateway_origin` / `require_role` reimplementations.
- **agents / data / responder** (gateway-only): `get_current_user` is now exactly the shared `get_user_from_gateway_headers` dependency, and `require_role` comes from the shared module. This also **fixes a latent bug** — the old code called the shared validator without forwarding `X-Gateway-Secret`; as a proper FastAPI dependency the `GATEWAY_INTERNAL_SECRET` proof-of-origin is now enforced.
- **tools** keeps its dual mode: the gateway path delegates to the shared dependency (now forwarding the secret); the legacy `X-API-Key` path is unchanged and tracked for scoping/removal in **#175**.
- **identity** is intentionally untouched — it's the JWT/API-key *provider*, not a gateway-header consumer, so it must not depend on the gateway dependency.

## Verification
- `from open_security_shared.gateway_auth import GatewayUser, get_user_from_gateway_headers, require_role` resolves in a clean venv.
- `py_compile` clean on all four `auth.py` + the importing `main.py`; no shim left (checked).
- The build-validation workflow rebuilds the affected images (which install the shared package), and the tools/identity integration tests exercise the runtime import + the X-API-Key / no-auth paths.

LOC removed: the four services drop ~100–160 lines of duplicated auth each, down to a thin shared re-export.

Next: **#175** scopes the `X-API-Key` zero-team-admin path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)