### PR TITLE
shared: add reusable team-scoped query helpers (#177)

### DIFF
--- a/open-security-shared/__init__.py
+++ b/open-security-shared/__init__.py
@@ -18,6 +18,7 @@ from .auth_utils import (
     get_bearer_token_from_header,
     AuthConfig,
 )
+from .tenancy import team_filter, scope_query, scope_select
 
 __version__ = "1.0.0"
 __all__ = [
@@ -29,4 +30,7 @@ __all__ = [
     "get_api_key_from_header",
     "get_bearer_token_from_header",
     "AuthConfig",
+    "team_filter",
+    "scope_query",
+    "scope_select",
 ]

--- a/open-security-shared/tenancy.py
+++ b/open-security-shared/tenancy.py
@@ -1,0 +1,38 @@
+"""Reusable tenancy helpers.
+
+One place to scope ORM queries to the caller's team, so downstream services
+enforce data isolation the same way instead of reinventing it. Pair with the
+gateway-auth dependency (`get_user_from_gateway_headers`) and `require_role`.
+
+The helpers are intentionally ORM-library-agnostic: they only build the
+`model.team_id == user.team_id` expression, which works with both the legacy
+SQLAlchemy Query API and the 2.0 `select()` API, so importing this module pulls
+no extra dependencies.
+"""
+
+from typing import Any
+
+from .gateway_auth import GatewayUser
+
+__all__ = ["team_filter", "scope_query", "scope_select"]
+
+
+def team_filter(model: Any, user: GatewayUser):
+    """Return a filter expression scoping ``model`` to the caller's team.
+
+    Usage::
+
+        db.query(Model).filter(team_filter(Model, user))      # legacy Query API
+        select(Model).where(team_filter(Model, user))         # SQLAlchemy 2.0
+    """
+    return model.team_id == user.team_id
+
+
+def scope_query(query: Any, model: Any, user: GatewayUser):
+    """Scope a legacy SQLAlchemy ``Query`` (``db.query(Model)``) to the team."""
+    return query.filter(team_filter(model, user))
+
+
+def scope_select(stmt: Any, model: Any, user: GatewayUser):
+    """Scope a SQLAlchemy 2.0 ``select()`` statement to the team."""
+    return stmt.where(team_filter(model, user))


### PR DESCRIPTION
Refs #177 — Sprint 2 (tenancy & authorization). The shared foundation the per-service scoping builds on.

New `open_security_shared.tenancy` module — one place to scope ORM queries to the caller's team:
- `team_filter(model, user)` → `model.team_id == user.team_id`
- `scope_query(query, model, user)` → legacy Query API (`db.query(M).filter(...)`)
- `scope_select(stmt, model, user)` → SQLAlchemy 2.0 `select()`

ORM-library-agnostic (only builds the equality expression) so it adds **no new dependency**. Exported from the package root.

`require_role` (FastAPI) already exists in `gateway_auth`. The **DRF permission for Guardian** (the issue's other checkbox) lands with the Guardian role work in **#181**, where the request/role wiring is known — hence "Refs", not "Closes".

These helpers back the per-service tenancy scoping (#178 data, #179 cspm, #180 responder) and the role enforcement (#182).

## Verification
Clean-venv import + functional test of all three helpers; `py_compile` clean. The build-validation workflow rebuilds the images (shared changed) so the new module is exercised in every image install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)