### PR TITLE
ci: run the data service in the integration harness (#178, #183 prep)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -137,6 +137,26 @@ jobs:
           API_KEY: ${{ secrets.API_KEY }}
           REDIS_URL: redis://localhost:6379/2
 
+      - name: Install Data Service Dependencies
+        run: |
+          pip install ./open-security-shared
+          cd open-security-data
+          pip install -r requirements.txt
+
+      - name: Start Data Service
+        run: |
+          cd open-security-data
+          python -m uvicorn app.api.main:app --host 127.0.0.1 --port 8002 &
+          DATA_PID=$!
+          echo "DATA_PID=$DATA_PID" >> $GITHUB_ENV
+        env:
+          # Reuse the postgres "identity" database in CI (no separate DB needed);
+          # data's create_tables() lifespan hook adds its own tables on startup.
+          DATABASE_URL: postgresql://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
+          REDIS_URL: redis://localhost:6379/1
+          SECRET_KEY: test-secret-key-for-ci-only
+          ENVIRONMENT: test
+
       - name: Wait for all services to be healthy
         run: |
           # Give services a few seconds to bind to ports
@@ -145,8 +165,8 @@ jobs:
           ./scripts/wait-for-services.sh
         timeout-minutes: 5
         env:
-          # Only check services actually started in CI (identity and tools)
-          SERVICES: "identity:localhost:8001:/health tools:localhost:8000:/health"
+          # Only check services actually started in CI (identity, tools, data)
+          SERVICES: "identity:localhost:8001:/health tools:localhost:8000:/health data:localhost:8002:/health"
           # Skip optional services in CI (they don't exist in this environment)
           OPTIONAL_SERVICES: ""
 
@@ -162,6 +182,7 @@ jobs:
         env:
           IDENTITY_SERVICE_URL: http://localhost:8001
           TOOLS_SERVICE_URL: http://localhost:8000
+          DATA_SERVICE_URL: http://localhost:8002
           TEST_API_KEY: ${{ secrets.API_KEY }}
         timeout-minutes: 10
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,14 +139,20 @@ jobs:
 
       - name: Install Data Service Dependencies
         run: |
-          pip install ./open-security-shared
+          # Isolate data's deps in their own venv: it pins different
+          # pydantic/fastapi/sqlalchemy versions than identity/tools, and
+          # installing them into the shared env would break the already-running
+          # services.
+          python -m venv /tmp/data-venv
+          /tmp/data-venv/bin/pip install --upgrade pip
+          /tmp/data-venv/bin/pip install ./open-security-shared
           cd open-security-data
-          pip install -r requirements.txt
+          /tmp/data-venv/bin/pip install -r requirements.txt
 
       - name: Start Data Service
         run: |
           cd open-security-data
-          python -m uvicorn app.api.main:app --host 127.0.0.1 --port 8002 &
+          /tmp/data-venv/bin/python -m uvicorn app.api.main:app --host 127.0.0.1 --port 8002 &
           DATA_PID=$!
           echo "DATA_PID=$DATA_PID" >> $GITHUB_ENV
         env:


### PR DESCRIPTION
Refs #178 / #183 — Sprint 2. The **safety net** for the per-service tenancy work: `data`/`cspm`/`responder` aren't started in CI, so tenancy changes there can't be runtime-validated. This starts the **data** service in the integration-tests job (analogous to the build-on-PR job for the Sprint 1 Docker migration).

## Changes (integration-tests.yml)
- Install data deps + `open-security-shared`; start `app.api.main:app` on `:8002`.
- Reuse the postgres **identity** DB in CI — `data`'s `create_tables()` lifespan hook adds its own tables on startup, so no separate DB to provision. `GATEWAY_INTERNAL_SECRET` is inherited from the job env (so the consolidated gateway auth works).
- Add `data` to the health-check service list and expose `DATA_SERVICE_URL` to the tests (`conftest` already maps `service_urls["data"]`).

## Validation
This PR runs the integration workflow, which now **starts data and health-checks it** — verifying the service boots with the consolidated shared auth before any tenancy change lands.

Unblocks **#178** (data `team_id` scoping) and the cross-tenant tests (**#183**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)