### PR TITLE
data: scope reads to the caller's team (shared feeds + per-team overlay) (#178)

### DIFF
--- a/open-security-data/app/api/main.py
+++ b/open-security-data/app/api/main.py
@@ -24,6 +24,7 @@ from app.models import Source, Indicator, IPAddress, Domain, FileHash, Collectio
 from app.utils.database import get_db_session, create_tables
 from app.schemas.api import *
 from app.auth import get_current_user, GatewayUser
+from open_security_shared.tenancy import team_or_global_filter
 
 logger = logging.getLogger(__name__)
 config = get_config()
@@ -115,17 +116,24 @@ async def get_statistics(current_user: GatewayUser = Depends(get_current_user), 
         Indicator.indicator_type,
         func.count(Indicator.id).label('count')
     ).filter(
-        Indicator.active == True
+        Indicator.active == True,
+        team_or_global_filter(Indicator, current_user)
     ).group_by(Indicator.indicator_type).all()
-    
+
     indicator_stats = {item.indicator_type: item.count for item in indicator_counts}
-    
-    # Count sources
-    active_sources = db.query(func.count(Source.id)).filter(Source.enabled == True).scalar()
-    total_sources = db.query(func.count(Source.id)).scalar()
-    
-    # Total indicators
-    total_indicators = db.query(func.count(Indicator.id)).filter(Indicator.active == True).scalar()
+
+    # Count sources (caller's team + global)
+    active_sources = db.query(func.count(Source.id)).filter(
+        Source.enabled == True, team_or_global_filter(Source, current_user)
+    ).scalar()
+    total_sources = db.query(func.count(Source.id)).filter(
+        team_or_global_filter(Source, current_user)
+    ).scalar()
+
+    # Total indicators (caller's team + global)
+    total_indicators = db.query(func.count(Indicator.id)).filter(
+        Indicator.active == True, team_or_global_filter(Indicator, current_user)
+    ).scalar()
     
     # Recent collection runs
     recent_collections = db.query(func.count(CollectionRun.id)).filter(
@@ -162,8 +170,8 @@ async def search_indicators(
     
     logger.info(f"🔐 Authenticated request to search indicators (User: {current_user.user_id}, Team: {current_user.team_id})")
     
-    query = db.query(Indicator)
-    
+    query = db.query(Indicator).filter(team_or_global_filter(Indicator, current_user))
+
     # Apply filters
     if active_only:
         query = query.filter(Indicator.active == True)
@@ -224,7 +232,7 @@ async def get_indicator(
 ):
     """Get detailed information about a specific indicator"""
 
-    indicator = db.query(Indicator).filter(Indicator.id == indicator_id).first()
+    indicator = db.query(Indicator).filter(team_or_global_filter(Indicator, current_user)).filter(Indicator.id == indicator_id).first()
     
     if not indicator:
         raise HTTPException(
@@ -304,7 +312,7 @@ async def bulk_lookup(
     
     for item in request.indicators:
         # Find matching indicators
-        query = db.query(Indicator).filter(
+        query = db.query(Indicator).filter(team_or_global_filter(Indicator, current_user)).filter(
             and_(
                 Indicator.indicator_type == item.indicator_type.lower(),
                 or_(
@@ -341,7 +349,7 @@ async def get_ip_intelligence(
     """Get intelligence about an IP address"""
     
     # Find IP indicators
-    indicators = db.query(Indicator).filter(
+    indicators = db.query(Indicator).filter(team_or_global_filter(Indicator, current_user)).filter(
         and_(
             Indicator.indicator_type == 'ip_address',
             or_(
@@ -398,7 +406,7 @@ async def get_domain_intelligence(
     normalized_domain = domain.lower().strip()
     
     # Find domain indicators
-    indicators = db.query(Indicator).filter(
+    indicators = db.query(Indicator).filter(team_or_global_filter(Indicator, current_user)).filter(
         and_(
             Indicator.indicator_type == 'domain',
             or_(
@@ -454,7 +462,7 @@ async def get_hash_intelligence(
     normalized_hash = file_hash.lower().strip()
     
     # Find hash indicators
-    indicators = db.query(Indicator).filter(
+    indicators = db.query(Indicator).filter(team_or_global_filter(Indicator, current_user)).filter(
         and_(
             Indicator.indicator_type == 'file_hash',
             or_(
@@ -506,7 +514,7 @@ async def list_sources(
 ):
     """List data sources"""
     
-    query = db.query(Source)
+    query = db.query(Source).filter(team_or_global_filter(Source, current_user))
     
     if enabled_only:
         query = query.filter(Source.enabled == True)
@@ -539,7 +547,7 @@ async def realtime_feed(
     
     since_time = datetime.now(timezone.utc) - timedelta(minutes=since_minutes)
     
-    query = db.query(Indicator).filter(
+    query = db.query(Indicator).filter(team_or_global_filter(Indicator, current_user)).filter(
         and_(
             Indicator.last_seen >= since_time,
             Indicator.active == True

--- a/open-security-data/app/collectors/__init__.py
+++ b/open-security-data/app/collectors/__init__.py
@@ -220,6 +220,9 @@ class BaseCollector(ABC):
                 # Create new indicator
                 indicator = Indicator(
                     source_id=self.source.id,
+                    # Inherit tenancy from the source: NULL (global feed) stays
+                    # global; a team-owned source yields team-owned indicators.
+                    team_id=self.source.team_id,
                     indicator_type=indicator_data['indicator_type'],
                     value=indicator_data['value'],
                     normalized_value=indicator_data['normalized_value'],

--- a/open-security-data/app/models.py
+++ b/open-security-data/app/models.py
@@ -61,6 +61,10 @@ class Source(Base):
     __tablename__ = "sources"
     
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # Tenancy: NULL means a global/shared feed source (visible to every team);
+    # a value means the source is private to that team. See open_security_shared
+    # .tenancy.team_or_global_filter.
+    team_id = Column(UUID(as_uuid=True), nullable=True, index=True)
     name = Column(String(255), unique=True, nullable=False)
     description = Column(Text)
     url = Column(String(1024))
@@ -108,7 +112,10 @@ class Indicator(Base):
     
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     source_id = Column(UUID(as_uuid=True), ForeignKey("sources.id"), nullable=False)
-    
+    # Tenancy: inherited from the source. NULL = global/shared feed indicator
+    # (visible to every team); a value = private to that team.
+    team_id = Column(UUID(as_uuid=True), nullable=True, index=True)
+
     # Core indicator data
     indicator_type = Column(String(50), nullable=False)
     value = Column(String(1024), nullable=False)

--- a/open-security-shared/tenancy.py
+++ b/open-security-shared/tenancy.py
@@ -14,11 +14,17 @@ from typing import Any
 
 from .gateway_auth import GatewayUser
 
-__all__ = ["team_filter", "scope_query", "scope_select"]
+__all__ = [
+    "team_filter",
+    "scope_query",
+    "scope_select",
+    "team_or_global_filter",
+    "scope_query_shared",
+]
 
 
 def team_filter(model: Any, user: GatewayUser):
-    """Return a filter expression scoping ``model`` to the caller's team.
+    """Return a filter expression scoping ``model`` strictly to the caller's team.
 
     Usage::
 
@@ -26,6 +32,24 @@ def team_filter(model: Any, user: GatewayUser):
         select(Model).where(team_filter(Model, user))         # SQLAlchemy 2.0
     """
     return model.team_id == user.team_id
+
+
+def team_or_global_filter(model: Any, user: GatewayUser):
+    """Filter for the "shared feeds + per-team overlay" model: rows the caller's
+    team owns OR rows with no owner (``team_id IS NULL``, i.e. global/shared).
+
+    Use for data where collector/feed records are global and only
+    team-configured records are private::
+
+        db.query(Model).filter(team_or_global_filter(Model, user))
+    """
+    # `== None` intentionally maps to SQL `IS NULL` (do not change to `is None`).
+    return (model.team_id == None) | (model.team_id == user.team_id)  # noqa: E711
+
+
+def scope_query_shared(query: Any, model: Any, user: GatewayUser):
+    """Scope a legacy ``Query`` to the caller's team plus global rows."""
+    return query.filter(team_or_global_filter(model, user))
 
 
 def scope_query(query: Any, model: Any, user: GatewayUser):

--- a/tests/integration/test_data_tenancy.py
+++ b/tests/integration/test_data_tenancy.py
@@ -1,0 +1,56 @@
+"""Integration checks for the data service's team-scoped, gateway-authenticated
+read path (#178).
+
+These exercise the auth + tenancy code path end-to-end against the running
+service. They do NOT prove cross-tenant isolation by seeding two teams' data —
+that fuller test (DB seeding) is tracked in #183.
+"""
+
+import os
+import uuid
+from typing import Dict
+
+import pytest
+import requests
+
+
+def _gateway_headers(team_id: str, secret: str) -> Dict[str, str]:
+    return {
+        "X-Wildbox-User-ID": str(uuid.uuid4()),
+        "X-Wildbox-Team-ID": team_id,
+        "X-Wildbox-Role": "member",
+        "X-Gateway-Secret": secret,
+    }
+
+
+def test_data_search_rejects_unauthenticated(service_urls):
+    """Without gateway headers the data search must not return data."""
+    try:
+        resp = requests.get(
+            f"{service_urls['data']}/api/v1/indicators/search", timeout=10
+        )
+    except requests.exceptions.RequestException:
+        pytest.fail("Data service is not available. Ensure it's running in CI.")
+    # 401 (no identity headers), 403 (missing/invalid gateway secret) or
+    # 503 (secret not configured) — never 200.
+    assert resp.status_code in (401, 403, 503)
+
+
+def test_data_search_team_scoped_ok(service_urls):
+    """With valid gateway headers + secret the team-scoped query runs (200)."""
+    secret = os.environ.get("GATEWAY_INTERNAL_SECRET", "")
+    if not secret:
+        pytest.skip("GATEWAY_INTERNAL_SECRET not set (e.g. fork PR without secrets)")
+
+    resp = requests.get(
+        f"{service_urls['data']}/api/v1/indicators/search",
+        params={"q": "zzz-no-such-indicator"},
+        headers=_gateway_headers(str(uuid.uuid4()), secret),
+        timeout=10,
+    )
+    # The scoped query (team rows + global NULL rows) executes; a fresh CI DB
+    # has no matches, so this is an empty-but-200 response, proving the
+    # team_or_global_filter path doesn't error against a real database.
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body, dict)


### PR DESCRIPTION
Closes #178, Refs #183 — Sprint 2 (tenancy). Fixes the cross-tenant disclosure in the data service: its read endpoints returned **every team's** indicators/sources.

## Model: shared feeds + per-team overlay (per the chosen design)
Collector/feed records stay **global** (`team_id IS NULL`, visible to all teams); team-owned records are private. Reads return **global OR own-team** — so the global threat-intel search keeps working while team data is isolated.

## Changes
- **shared**: `open_security_shared.tenancy.team_or_global_filter` / `scope_query_shared` (`team_id IS NULL OR team_id == caller.team`).
- **data models**: nullable, indexed `team_id` on `Source` and `Indicator` (NULL = global). `create_tables()` adds the columns on a fresh DB; existing deployments need a migration/backfill (data has no alembic yet — noted).
- **data API**: every Indicator/Source read scoped — stats, search, `get_indicator`, `bulk_lookup`, ip/domain/hash intelligence, `list_sources`, realtime feed (9 indicator + 3 source sites).
- **collectors**: new indicators inherit `team_id` from their source (global source → global indicator; team source → team indicator).
- **test**: integration checks that data search rejects unauthenticated requests and runs the team-scoped query (200) with valid gateway headers + secret.

## Validation
Build-validation rebuilds all images (shared + data changed). The integration harness (now running data, #233) executes the new `test_data_tenancy.py` against real postgres — exercising `team_or_global_filter` end-to-end and confirming the gateway-auth + scoping path works and the global search isn't broken. py_compile clean.

The full **two-team cross-tenant isolation test** (seed team A data, assert team B can't read it) needs DB seeding infra and is tracked in **#183**, alongside responder/cspm and the role-enforcement tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)