### PR TITLE
responder: scope run history to the owning team (#180)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -163,6 +163,29 @@ jobs:
           SECRET_KEY: test-secret-key-for-ci-only
           ENVIRONMENT: test
 
+      - name: Install Responder Service Dependencies
+        run: |
+          # Own venv (same rationale as data): responder pins its own
+          # dramatiq/redis/fastapi stack; keep it off the identity/tools env.
+          python -m venv /tmp/responder-venv
+          /tmp/responder-venv/bin/pip install --upgrade pip
+          /tmp/responder-venv/bin/pip install ./open-security-shared
+          cd open-security-responder
+          /tmp/responder-venv/bin/pip install -r requirements.txt
+
+      - name: Start Responder Service
+        run: |
+          # Run from the service dir so the default ./playbooks (bundled YAML)
+          # loads. uvicorn alone is enough — start_execution persists the
+          # initial run state to Redis synchronously, no Dramatiq worker needed.
+          cd open-security-responder
+          /tmp/responder-venv/bin/python -m uvicorn app.main:app --host 127.0.0.1 --port 8018 &
+          RESPONDER_PID=$!
+          echo "RESPONDER_PID=$RESPONDER_PID" >> $GITHUB_ENV
+        env:
+          REDIS_URL: redis://localhost:6379/3
+          ENVIRONMENT: test
+
       - name: Wait for all services to be healthy
         run: |
           # Give services a few seconds to bind to ports
@@ -171,8 +194,8 @@ jobs:
           ./scripts/wait-for-services.sh
         timeout-minutes: 5
         env:
-          # Only check services actually started in CI (identity, tools, data)
-          SERVICES: "identity:localhost:8001:/health tools:localhost:8000:/health data:localhost:8002:/health"
+          # Only check services actually started in CI (identity, tools, data, responder)
+          SERVICES: "identity:localhost:8001:/health tools:localhost:8000:/health data:localhost:8002:/health responder:localhost:8018:/health"
           # Skip optional services in CI (they don't exist in this environment)
           OPTIONAL_SERVICES: ""
 
@@ -189,6 +212,7 @@ jobs:
           IDENTITY_SERVICE_URL: http://localhost:8001
           TOOLS_SERVICE_URL: http://localhost:8000
           DATA_SERVICE_URL: http://localhost:8002
+          RESPONDER_SERVICE_URL: http://localhost:8018
           TEST_API_KEY: ${{ secrets.API_KEY }}
         timeout-minutes: 10
 
@@ -207,6 +231,7 @@ jobs:
         run: |
           if [ ! -z "$IDENTITY_PID" ]; then kill $IDENTITY_PID || true; fi
           if [ ! -z "$TOOLS_PID" ]; then kill $TOOLS_PID || true; fi
+          if [ ! -z "$RESPONDER_PID" ]; then kill $RESPONDER_PID || true; fi
 
   security-validation:
     name: Security Validation

--- a/open-security-responder/app/main.py
+++ b/open-security-responder/app/main.py
@@ -187,7 +187,10 @@ async def execute_playbook(
         
         # Start execution
         run_id = start_execution(playbook_id, request.trigger_data)
-        
+
+        # Record the owning team so other teams can't read or cancel this run.
+        workflow_engine.set_run_owner(run_id, current_user.team_id)
+
         return JSONResponse(
             status_code=status.HTTP_202_ACCEPTED,
             content={
@@ -215,13 +218,15 @@ async def get_execution_status(run_id: str, current_user: GatewayUser = Depends(
     """Get execution status and results"""
     try:
         execution_result = workflow_engine.get_execution_state(run_id)
-        
-        if not execution_result:
+
+        # Treat "not yours" the same as "not found" so existence isn't leaked
+        # across teams.
+        if not execution_result or not workflow_engine.is_run_owner(run_id, current_user.team_id):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Execution '{run_id}' not found"
             )
-        
+
         return execution_result
         
     except HTTPException:
@@ -275,8 +280,9 @@ async def cancel_execution(run_id: str, current_user: GatewayUser = Depends(get_
     try:
         # For now, we'll just mark it as cancelled in Redis
         execution_result = workflow_engine.get_execution_state(run_id)
-        
-        if not execution_result:
+
+        # "Not yours" -> 404, identical to "not found", to avoid cross-team leak.
+        if not execution_result or not workflow_engine.is_run_owner(run_id, current_user.team_id):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Execution '{run_id}' not found"

--- a/open-security-responder/app/workflow_engine.py
+++ b/open-security-responder/app/workflow_engine.py
@@ -129,6 +129,33 @@ class WorkflowEngine:
             logger.error(f"Failed to parse execution state for {run_id}: {e}")
             return None
     
+    def _get_owner_key(self, run_id: str) -> str:
+        """Get Redis key recording which team owns an execution (tenancy)."""
+        return f"{self.key_prefix}run:{run_id}:team"
+
+    def set_run_owner(self, run_id: str, team_id) -> None:
+        """Record which team owns a run so reads/cancels can be tenant-scoped.
+
+        Stored as a separate key with the same retention as the run state, so
+        it is independent of the worker rewriting the execution state.
+        """
+        key = self._get_owner_key(run_id)
+        self.redis_client.set(key, str(team_id))
+        expire_seconds = settings.execution_retention_days * 24 * 60 * 60
+        self.redis_client.expire(key, expire_seconds)
+
+    def get_run_owner(self, run_id: str) -> Optional[str]:
+        """Return the team_id that owns ``run_id``, or None if unknown."""
+        value = self.redis_client.get(self._get_owner_key(run_id))
+        if value is None:
+            return None
+        return value.decode() if isinstance(value, (bytes, bytearray)) else str(value)
+
+    def is_run_owner(self, run_id: str, team_id) -> bool:
+        """True only if ``team_id`` owns ``run_id`` (unknown owner -> False)."""
+        owner = self.get_run_owner(run_id)
+        return owner is not None and owner == str(team_id)
+
     def add_log(self, run_id: str, message: str, level: str = "INFO"):
         """Add a log entry for the execution"""
         logs_key = self._get_logs_key(run_id)

--- a/tests/integration/test_responder_tenancy.py
+++ b/tests/integration/test_responder_tenancy.py
@@ -1,0 +1,88 @@
+"""Cross-tenant isolation for the responder run history (#180).
+
+Responder stores run state in Redis (not SQL). Each run is owned by the team
+that triggered it; another team must not be able to read or cancel it. These
+tests execute a real bundled playbook as "team A" and assert "team B" gets 404
+for the same run id.
+"""
+
+import os
+import uuid
+from typing import Dict
+
+import pytest
+import requests
+
+
+def _gateway_headers(team_id: str, secret: str) -> Dict[str, str]:
+    return {
+        "X-Wildbox-User-ID": str(uuid.uuid4()),
+        "X-Wildbox-Team-ID": team_id,
+        "X-Wildbox-Role": "member",
+        "X-Gateway-Secret": secret,
+    }
+
+
+def _require_secret() -> str:
+    secret = os.environ.get("GATEWAY_INTERNAL_SECRET", "")
+    if not secret:
+        pytest.skip("GATEWAY_INTERNAL_SECRET not set (e.g. fork PR without secrets)")
+    return secret
+
+
+def test_responder_runs_reject_unauthenticated(service_urls):
+    """Reading a run without gateway auth must not succeed."""
+    try:
+        resp = requests.get(
+            f"{service_urls['responder']}/v1/runs/{uuid.uuid4()}", timeout=10
+        )
+    except requests.exceptions.RequestException:
+        pytest.fail("Responder service is not available. Ensure it's running in CI.")
+    assert resp.status_code in (401, 403, 503)
+
+
+def test_responder_run_not_readable_by_other_team(service_urls):
+    """A run created by team A returns 404 to team B (no cross-tenant leak)."""
+    secret = _require_secret()
+    base = service_urls["responder"]
+    team_a = str(uuid.uuid4())
+    team_b = str(uuid.uuid4())
+
+    # Pick any bundled playbook to execute.
+    pb_resp = requests.get(
+        f"{base}/v1/playbooks", headers=_gateway_headers(team_a, secret), timeout=10
+    )
+    assert pb_resp.status_code == 200, pb_resp.text
+    playbooks = pb_resp.json().get("playbooks", [])
+    if not playbooks:
+        pytest.skip("No bundled playbooks available to execute")
+    playbook_id = playbooks[0].get("playbook_id") or playbooks[0].get("id")
+    assert playbook_id, f"Could not determine a playbook id from {playbooks[0]}"
+
+    # Team A starts a run.
+    exec_resp = requests.post(
+        f"{base}/v1/playbooks/{playbook_id}/execute",
+        headers=_gateway_headers(team_a, secret),
+        json={},
+        timeout=10,
+    )
+    assert exec_resp.status_code == 202, exec_resp.text
+    run_id = exec_resp.json()["run_id"]
+
+    # Team A can read its own run (state is persisted synchronously as QUEUED).
+    a_resp = requests.get(
+        f"{base}/v1/runs/{run_id}", headers=_gateway_headers(team_a, secret), timeout=10
+    )
+    assert a_resp.status_code == 200, a_resp.text
+
+    # Team B must NOT see it — 404, indistinguishable from "not found".
+    b_resp = requests.get(
+        f"{base}/v1/runs/{run_id}", headers=_gateway_headers(team_b, secret), timeout=10
+    )
+    assert b_resp.status_code == 404, b_resp.text
+
+    # Team B must NOT be able to cancel it either.
+    b_del = requests.delete(
+        f"{base}/v1/runs/{run_id}", headers=_gateway_headers(team_b, secret), timeout=10
+    )
+    assert b_del.status_code == 404, b_del.text


### PR DESCRIPTION
Closes #180, Refs #183 — Sprint 2 (tenancy). Fixes a cross-tenant disclosure in the responder: its run read/cancel endpoints returned **any** run by id, so team B could read or cancel team A's runs.

## Approach
Responder stores run state in **Redis via Dramatiq** (not SQL), and `start_execution` persists an initial `QUEUED` state synchronously. Each run is owned by the team that triggered it (strict per-team — runs are team actions, not shared feeds).

- **workflow_engine**: `set_run_owner` / `get_run_owner` / `is_run_owner` store the owner in a side key `responder:run:{run_id}:team` with the same retention as the run state — decoupled from the worker rewriting the execution hash.
- **main.py**: `POST /v1/playbooks/{id}/execute` records the caller's team; `GET` and `DELETE /v1/runs/{run_id}` return **404** (indistinguishable from not-found, no existence leak) unless the caller's team owns the run.
- `start_execution` is called only from the API handler, so every run gets an owner.

## Validation
- **Harness extended** to run the responder service (own venv, Redis, bundled playbooks) — same pattern as data (#233).
- **Cross-tenant test** (`test_responder_tenancy.py`): team A executes a bundled playbook → reads its run (200); **team B gets 404** on both GET and DELETE; unauthenticated is rejected. This is a true two-team isolation test (no worker needed — initial state is synchronous).

py_compile + YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)