### PR TITLE
guardian: enforce gateway role on mutating viewsets + tighten has_perm (#181)

### DIFF
--- a/open-security-guardian/apps/assets/views.py
+++ b/open-security-guardian/apps/assets/views.py
@@ -23,7 +23,7 @@ from .serializers import (
 )
 from .tasks import discover_assets, update_asset_inventory
 from .filters import AssetFilter
-from apps.core.permissions import IsAssetManager
+from apps.core.permissions import IsAssetManager, IsGatewayAdminOrReadOnly
 
 
 class AssetViewSet(viewsets.ModelViewSet):
@@ -32,7 +32,7 @@ class AssetViewSet(viewsets.ModelViewSet):
         'environment', 'business_function', 'owner', 'technical_contact'
     ).prefetch_related('software', 'ports', 'groups')
     serializer_class = AssetSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_class = AssetFilter
     search_fields = ['name', 'hostname', 'fqdn', 'ip_address', 'description']
@@ -148,7 +148,7 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
     """Environment management viewset"""
     queryset = Environment.objects.all()
     serializer_class = EnvironmentSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ['name', 'description']
     ordering = ['name']
@@ -158,7 +158,7 @@ class BusinessFunctionViewSet(viewsets.ModelViewSet):
     """Business function management viewset"""
     queryset = BusinessFunction.objects.all()
     serializer_class = BusinessFunctionSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ['name', 'description']
     ordering = ['name']
@@ -168,7 +168,7 @@ class AssetGroupViewSet(viewsets.ModelViewSet):
     """Asset group management viewset"""
     queryset = AssetGroup.objects.prefetch_related('assets')
     serializer_class = AssetGroupSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ['name', 'description']
     ordering = ['name']
@@ -279,7 +279,7 @@ class AssetSoftwareViewSet(viewsets.ModelViewSet):
     """Asset software management viewset"""
     queryset = AssetSoftware.objects.select_related('asset')
     serializer_class = AssetSoftwareSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_fields = ['asset', 'name', 'vendor', 'is_critical']
     search_fields = ['name', 'vendor', 'version']
@@ -302,7 +302,7 @@ class AssetPortViewSet(viewsets.ModelViewSet):
     """Asset port management viewset"""
     queryset = AssetPort.objects.select_related('asset')
     serializer_class = AssetPortSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_fields = ['asset', 'port_number', 'protocol', 'state', 'service']
     search_fields = ['service', 'banner']

--- a/open-security-guardian/apps/compliance/views.py
+++ b/open-security-guardian/apps/compliance/views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets, status, permissions
+from apps.core.permissions import IsGatewayAdminOrReadOnly
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
@@ -23,7 +24,7 @@ from .filters import (
 class ComplianceFrameworkViewSet(viewsets.ModelViewSet):
     queryset = ComplianceFramework.objects.all()
     serializer_class = ComplianceFrameworkSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ComplianceFrameworkFilter
     search_fields = ['name', 'description', 'authority']
@@ -60,7 +61,7 @@ class ComplianceFrameworkViewSet(viewsets.ModelViewSet):
 class ComplianceControlViewSet(viewsets.ModelViewSet):
     queryset = ComplianceControl.objects.select_related('framework').all()
     serializer_class = ComplianceControlSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ComplianceControlFilter
     search_fields = ['control_id', 'title', 'description']
@@ -87,7 +88,7 @@ class ComplianceControlViewSet(viewsets.ModelViewSet):
 class ComplianceAssessmentViewSet(viewsets.ModelViewSet):
     queryset = ComplianceAssessment.objects.select_related('framework', 'assessor').prefetch_related('assets').all()
     serializer_class = ComplianceAssessmentSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ComplianceAssessmentFilter
     search_fields = ['name', 'description']
@@ -151,7 +152,7 @@ class ComplianceAssessmentViewSet(viewsets.ModelViewSet):
 class ComplianceEvidenceViewSet(viewsets.ModelViewSet):
     queryset = ComplianceEvidence.objects.select_related('assessment', 'control', 'collected_by').all()
     serializer_class = ComplianceEvidenceSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['title', 'description']
     ordering_fields = ['title', 'evidence_type', 'collected_at']
@@ -161,7 +162,7 @@ class ComplianceEvidenceViewSet(viewsets.ModelViewSet):
 class ComplianceResultViewSet(viewsets.ModelViewSet):
     queryset = ComplianceResult.objects.select_related('assessment', 'control', 'tested_by', 'reviewed_by').all()
     serializer_class = ComplianceResultSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ComplianceResultFilter
     search_fields = ['findings', 'recommendations']
@@ -190,7 +191,7 @@ class ComplianceResultViewSet(viewsets.ModelViewSet):
 class ComplianceExceptionViewSet(viewsets.ModelViewSet):
     queryset = ComplianceException.objects.select_related('control', 'requested_by', 'approved_by').all()
     serializer_class = ComplianceExceptionSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ComplianceExceptionFilter
     search_fields = ['title', 'justification']
@@ -229,7 +230,7 @@ class ComplianceExceptionViewSet(viewsets.ModelViewSet):
 class ComplianceMetricsViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ComplianceMetrics.objects.select_related('framework', 'assessment').all()
     serializer_class = ComplianceMetricsSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ['metric_date', 'compliance_percentage']
     ordering = ['-metric_date']

--- a/open-security-guardian/apps/core/gateway_middleware.py
+++ b/open-security-guardian/apps/core/gateway_middleware.py
@@ -70,17 +70,23 @@ class GatewayUser:
     def __repr__(self):
         return self.__str__()
     
-    def has_perm(self, perm):
-        """Check if user has permission."""
-        # Owner/admin have all permissions
-        if self.role in ["owner", "admin"]:
+    def has_perm(self, perm, obj=None):
+        """Check if the user has a Django-style permission.
+
+        Owner/admin get everything. A member gets ONLY read permissions
+        (``view_*`` / ``read_*``) and never cross-tenant ``*_all`` scopes or any
+        add/change/delete/manage perm. Matching is on the perm codename
+        (``app_label.codename``) by prefix, not a loose substring, so a perm
+        like ``approve_review`` can't slip through on the word "view".
+        """
+        if self.role in ("owner", "admin"):
             return True
-        # Members only get basic view permissions, not view_all_*
-        if "view_all" in perm:
+        if self.role != "member":
             return False
-        if "view" in perm or "read" in perm:
-            return True
-        return False
+        codename = perm.split(".", 1)[-1] if isinstance(perm, str) else ""
+        if "_all" in codename:  # cross-tenant view_all_* etc.
+            return False
+        return codename.startswith(("view_", "read_")) or codename in ("view", "read")
     
     def has_module_perms(self, app_label):
         """Check if user has module permissions."""

--- a/open-security-guardian/apps/core/permissions.py
+++ b/open-security-guardian/apps/core/permissions.py
@@ -1,56 +1,82 @@
 """
 Custom permissions for the Guardian application.
+
+Mutating requests are gated on the caller's gateway role (owner/admin); plain
+members get read-only access at the service layer (#181). The role comes from
+``request.gateway_user`` (set by GatewayAuthMiddleware); for the legacy API-key
+path we fall back to the mirrored ``auth.User`` staff flags.
 """
 
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import BasePermission, SAFE_METHODS
 
 
-class IsAssetManager(BasePermission):
-    """
-    Permission class that allows access to asset management functions.
-    Currently allows any authenticated user, but can be extended
-    to check for specific roles or groups.
-    """
-    
+def _gateway_role(request):
+    """Return the caller's gateway role ("owner" | "admin" | "member")."""
+    gu = getattr(request, "gateway_user", None)
+    if gu is not None and getattr(gu, "role", None):
+        return gu.role
+    user = getattr(request, "user", None)
+    if getattr(user, "is_superuser", False):
+        return "owner"
+    if getattr(user, "is_staff", False):
+        return "admin"
+    return "member"
+
+
+def _is_authenticated(request):
+    user = getattr(request, "user", None)
+    return bool(user and user.is_authenticated)
+
+
+class IsGatewayAdminOrReadOnly(BasePermission):
+    """Any authenticated user may read (safe methods); only owner/admin (by
+    gateway role) may perform a mutating request. Enforces #181 at the service
+    layer so a plain member cannot run admin-only writes even by calling the
+    service directly behind the gateway."""
+
     def has_permission(self, request, view):
-        """
-        Check if user has asset management permissions.
-        """
-        # For now, any authenticated user can manage assets
-        # This can be extended to check for specific groups or roles
-        return request.user and request.user.is_authenticated
-    
+        if not _is_authenticated(request):
+            return False
+        if request.method in SAFE_METHODS:
+            return True
+        return _gateway_role(request) in ("owner", "admin")
+
     def has_object_permission(self, request, view, obj):
-        """
-        Check if user has permission to access specific asset object.
-        """
-        # For now, any authenticated user can access any asset
-        # This can be extended to check ownership or team membership
-        return request.user and request.user.is_authenticated
+        return self.has_permission(request, view)
 
 
-class IsComplianceManager(BasePermission):
+def RequireGatewayRole(*roles):
+    """Permission factory requiring the caller's gateway role to be one of
+    ``roles`` for ALL methods (no public-read side)::
+
+        permission_classes = [RequireGatewayRole("owner", "admin")]
     """
-    Permission class for compliance management functions.
-    """
-    
-    def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated
+    allowed = tuple(roles)
+
+    class _RequireGatewayRole(BasePermission):
+        def has_permission(self, request, view):
+            return _is_authenticated(request) and _gateway_role(request) in allowed
+
+        def has_object_permission(self, request, view, obj):
+            return self.has_permission(request, view)
+
+    _RequireGatewayRole.__name__ = "RequireGatewayRole_" + "_".join(allowed or ("none",))
+    return _RequireGatewayRole
 
 
-class IsSecurityAnalyst(BasePermission):
-    """
-    Permission class for security analysis functions.
-    """
-    
-    def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated
+# The role/domain permission classes below keep their names (used across the
+# viewsets) but now enforce the read-for-members / mutate-for-admins policy.
+class IsAssetManager(IsGatewayAdminOrReadOnly):
+    """Asset management: read for any authenticated user, mutate for owner/admin."""
 
 
-class IsVulnerabilityManager(BasePermission):
-    """
-    Permission class for vulnerability management functions.
-    """
-    
-    def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated
+class IsComplianceManager(IsGatewayAdminOrReadOnly):
+    """Compliance management: read for members, mutate for owner/admin."""
+
+
+class IsSecurityAnalyst(IsGatewayAdminOrReadOnly):
+    """Security analysis: read for members, mutate for owner/admin."""
+
+
+class IsVulnerabilityManager(IsGatewayAdminOrReadOnly):
+    """Vulnerability management: read for members, mutate for owner/admin."""

--- a/open-security-guardian/apps/integrations/views.py
+++ b/open-security-guardian/apps/integrations/views.py
@@ -5,6 +5,7 @@ Django REST Framework views for managing integrations with external systems.
 """
 
 from rest_framework import viewsets, status, permissions
+from apps.core.permissions import IsGatewayAdminOrReadOnly
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
@@ -19,7 +20,7 @@ from .models import (
 class ExternalSystemViewSet(viewsets.ModelViewSet):
     """ViewSet for managing external system integrations"""
     queryset = ExternalSystem.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description', 'vendor']
     filterset_fields = ['system_type', 'status', 'auth_type']
@@ -51,7 +52,7 @@ class ExternalSystemViewSet(viewsets.ModelViewSet):
 class IntegrationMappingViewSet(viewsets.ModelViewSet):
     """ViewSet for managing field mappings between Guardian and external systems"""
     queryset = IntegrationMapping.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ['system', 'guardian_entity', 'sync_direction', 'is_active']
     ordering_fields = ['created_at', 'updated_at']
@@ -75,7 +76,7 @@ class IntegrationMappingViewSet(viewsets.ModelViewSet):
 class SyncRecordViewSet(viewsets.ModelViewSet):
     """ViewSet for managing synchronization records"""
     queryset = SyncRecord.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ['system', 'sync_type', 'status', 'entity_type']
     ordering_fields = ['sync_time', 'created_at']
@@ -103,7 +104,7 @@ class SyncRecordViewSet(viewsets.ModelViewSet):
 class WebhookEndpointViewSet(viewsets.ModelViewSet):
     """ViewSet for managing webhook endpoints"""
     queryset = WebhookEndpoint.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description']
     filterset_fields = ['system', 'is_active', 'event_types']
@@ -129,7 +130,7 @@ class WebhookEndpointViewSet(viewsets.ModelViewSet):
 class IntegrationLogViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for viewing integration logs"""
     queryset = IntegrationLog.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ['system', 'operation_type', 'log_level', 'entity_type']
     search_fields = ['message', 'entity_id']
@@ -157,7 +158,7 @@ class IntegrationLogViewSet(viewsets.ReadOnlyModelViewSet):
 class NotificationChannelViewSet(viewsets.ModelViewSet):
     """ViewSet for managing notification channels"""
     queryset = NotificationChannel.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description']
     filterset_fields = ['channel_type', 'is_active', 'severity_levels']

--- a/open-security-guardian/apps/remediation/views.py
+++ b/open-security-guardian/apps/remediation/views.py
@@ -5,6 +5,7 @@ Django REST Framework views for remediation ticket and workflow management.
 """
 
 from rest_framework import viewsets, status, permissions
+from apps.core.permissions import IsGatewayAdminOrReadOnly
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
@@ -19,7 +20,7 @@ from .models import (
 class RemediationTicketViewSet(viewsets.ModelViewSet):
     """ViewSet for managing remediation tickets"""
     queryset = RemediationTicket.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['title', 'description', 'external_ticket_id']
     filterset_fields = ['status', 'priority', 'assigned_to', 'ticketing_system']
@@ -58,7 +59,7 @@ class RemediationTicketViewSet(viewsets.ModelViewSet):
 class RemediationWorkflowViewSet(viewsets.ModelViewSet):
     """ViewSet for managing remediation workflows"""
     queryset = RemediationWorkflow.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description']
     filterset_fields = ['vulnerability', 'status', 'priority', 'assigned_to']
@@ -108,7 +109,7 @@ class RemediationWorkflowViewSet(viewsets.ModelViewSet):
 class RemediationStepViewSet(viewsets.ModelViewSet):
     """ViewSet for managing remediation steps"""
     queryset = RemediationStep.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['title', 'description']
     filterset_fields = ['workflow', 'status', 'assigned_to', 'step_type']
@@ -144,7 +145,7 @@ class RemediationStepViewSet(viewsets.ModelViewSet):
 class RemediationCommentViewSet(viewsets.ModelViewSet):
     """ViewSet for managing remediation comments"""
     queryset = RemediationComment.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['content']
     filterset_fields = ['ticket', 'workflow', 'author', 'comment_type']
@@ -159,7 +160,7 @@ class RemediationCommentViewSet(viewsets.ModelViewSet):
 class RemediationTemplateViewSet(viewsets.ModelViewSet):
     """ViewSet for managing remediation templates"""
     queryset = RemediationTemplate.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description']
     filterset_fields = ['category', 'is_active', 'created_by']

--- a/open-security-guardian/apps/reporting/views.py
+++ b/open-security-guardian/apps/reporting/views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets, status, permissions
+from apps.core.permissions import IsGatewayAdminOrReadOnly
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
@@ -26,7 +27,7 @@ import os
 class ReportTemplateViewSet(viewsets.ModelViewSet):
     queryset = ReportTemplate.objects.all()
     serializer_class = ReportTemplateSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ReportTemplateFilter
     search_fields = ['name', 'description']
@@ -80,7 +81,7 @@ class ReportTemplateViewSet(viewsets.ModelViewSet):
 class ReportScheduleViewSet(viewsets.ModelViewSet):
     queryset = ReportSchedule.objects.select_related('template', 'created_by').all()
     serializer_class = ReportScheduleSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ReportScheduleFilter
     search_fields = ['name', 'description']
@@ -126,7 +127,7 @@ class ReportScheduleViewSet(viewsets.ModelViewSet):
 class ReportViewSet(viewsets.ModelViewSet):
     queryset = Report.objects.select_related('template', 'schedule', 'generated_by').all()
     serializer_class = ReportSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = ReportFilter
     search_fields = ['name']
@@ -174,7 +175,7 @@ class ReportViewSet(viewsets.ModelViewSet):
 class DashboardViewSet(viewsets.ModelViewSet):
     queryset = Dashboard.objects.prefetch_related('shared_with').all()
     serializer_class = DashboardSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = DashboardFilter
     search_fields = ['name', 'description']
@@ -227,7 +228,7 @@ class DashboardViewSet(viewsets.ModelViewSet):
 class WidgetViewSet(viewsets.ModelViewSet):
     queryset = Widget.objects.all()
     serializer_class = WidgetSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = WidgetFilter
     search_fields = ['name', 'description']
@@ -268,7 +269,7 @@ class WidgetViewSet(viewsets.ModelViewSet):
 class ReportMetricsViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ReportMetrics.objects.select_related('template').all()
     serializer_class = ReportMetricsSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ['metric_date', 'generation_count', 'success_rate']
     ordering = ['-metric_date']
@@ -303,7 +304,7 @@ class ReportMetricsViewSet(viewsets.ReadOnlyModelViewSet):
 class AlertRuleViewSet(viewsets.ModelViewSet):
     queryset = AlertRule.objects.all()
     serializer_class = AlertRuleSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = AlertRuleFilter
     search_fields = ['name', 'description']

--- a/open-security-guardian/apps/scanners/views.py
+++ b/open-security-guardian/apps/scanners/views.py
@@ -5,6 +5,7 @@ Django REST Framework views for scanner management.
 """
 
 from rest_framework import viewsets, status, permissions
+from apps.core.permissions import IsGatewayAdminOrReadOnly
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
@@ -22,7 +23,7 @@ from .serializers import (
 class ScannerViewSet(viewsets.ModelViewSet):
     """ViewSet for managing scanners"""
     queryset = Scanner.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description', 'scanner_type']
     filterset_fields = ['scanner_type', 'status']
@@ -64,7 +65,7 @@ class ScanProfileViewSet(viewsets.ModelViewSet):
     """ViewSet for managing scan profiles"""
     queryset = ScanProfile.objects.all()
     serializer_class = ScanProfileSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description']
     filterset_fields = ['scanner']
@@ -75,7 +76,7 @@ class ScanProfileViewSet(viewsets.ModelViewSet):
 class ScanViewSet(viewsets.ModelViewSet):
     """ViewSet for managing scans"""
     queryset = Scan.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description']
     filterset_fields = ['scanner', 'profile', 'status']
@@ -152,7 +153,7 @@ class ScanResultViewSet(viewsets.ModelViewSet):
     """ViewSet for managing scan results"""
     queryset = ScanResult.objects.all()
     serializer_class = ScanResultSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['plugin_name', 'description', 'host']
     filterset_fields = ['scan', 'severity', 'processed', 'vulnerability_created']
@@ -164,7 +165,7 @@ class ScanScheduleViewSet(viewsets.ModelViewSet):
     """ViewSet for managing scan schedules"""
     queryset = ScanSchedule.objects.all()
     serializer_class = ScanScheduleSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     search_fields = ['name', 'description']
     filterset_fields = ['scanner', 'is_active']

--- a/open-security-guardian/apps/vulnerabilities/views.py
+++ b/open-security-guardian/apps/vulnerabilities/views.py
@@ -9,6 +9,7 @@ from django.db.models import Q, Count, Avg, F, Case, When, IntegerField
 from django.utils import timezone
 from django.contrib.auth.models import User
 from rest_framework import viewsets, status, filters
+from apps.core.permissions import IsGatewayAdminOrReadOnly
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
@@ -41,7 +42,7 @@ class VulnerabilityViewSet(viewsets.ModelViewSet):
     Provides CRUD operations plus additional actions for vulnerability lifecycle
     """
     queryset = Vulnerability.objects.select_related('asset', 'assigned_to', 'created_by')
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_class = VulnerabilityFilter
     search_fields = ['title', 'description', 'cve_id', 'asset__name']
@@ -407,7 +408,7 @@ class VulnerabilityTemplateViewSet(viewsets.ModelViewSet):
     """ViewSet for vulnerability templates"""
     queryset = VulnerabilityTemplate.objects.all()
     serializer_class = VulnerabilityTemplateSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ['title', 'cve_id', 'category']
     ordering_fields = ['title', 'severity', 'created_at']
@@ -418,6 +419,6 @@ class VulnerabilityAssessmentViewSet(viewsets.ModelViewSet):
     """ViewSet for vulnerability risk assessments"""
     queryset = VulnerabilityAssessment.objects.select_related('vulnerability')
     serializer_class = VulnerabilityAssessmentSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsGatewayAdminOrReadOnly]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ['vulnerability', 'exploit_available', 'exploit_public']

--- a/open-security-guardian/tests/unit/test_gateway_auth_mirror.py
+++ b/open-security-guardian/tests/unit/test_gateway_auth_mirror.py
@@ -15,12 +15,23 @@ from django.test import RequestFactory
 from apps.core.gateway_middleware import GatewayAuthMiddleware, GatewayUser
 from apps.reporting.models import ReportTemplate
 
+# Since #163 the middleware fails closed: it returns 503 unless
+# GATEWAY_INTERNAL_SECRET is configured and the matching X-Gateway-Secret header
+# is present. Provide both so these tests exercise the authenticated path.
+_GW_SECRET = "test-gateway-secret"
+
+
+@pytest.fixture(autouse=True)
+def _configure_gateway_secret(monkeypatch):
+    monkeypatch.setenv("GATEWAY_INTERNAL_SECRET", _GW_SECRET)
+
 
 def _gateway_request(role="admin", user_id=None):
     req = RequestFactory().post("/api/v1/reporting/templates/")
     req.META["HTTP_X_WILDBOX_USER_ID"] = user_id or str(uuid.uuid4())
     req.META["HTTP_X_WILDBOX_TEAM_ID"] = str(uuid.uuid4())
     req.META["HTTP_X_WILDBOX_ROLE"] = role
+    req.META["HTTP_X_GATEWAY_SECRET"] = _GW_SECRET
     assert GatewayAuthMiddleware(lambda r: None).process_request(req) is None
     return req
 

--- a/open-security-guardian/tests/unit/test_role_enforcement.py
+++ b/open-security-guardian/tests/unit/test_role_enforcement.py
@@ -1,0 +1,77 @@
+"""Unit tests for #181: enforce the gateway role on mutating viewsets and
+tighten GatewayUser.has_perm().
+
+Pure permission-logic tests — no DB access required.
+"""
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.test import APIRequestFactory
+
+from apps.core.permissions import IsGatewayAdminOrReadOnly, RequireGatewayRole
+from apps.core.gateway_middleware import GatewayUser
+
+factory = APIRequestFactory()
+
+
+def _request(method, role="member", authenticated=True):
+    req = getattr(factory, method.lower())("/x")
+    req.user = SimpleNamespace(
+        is_authenticated=authenticated,
+        is_staff=role in ("owner", "admin"),
+        is_superuser=role == "owner",
+    )
+    req.gateway_user = SimpleNamespace(role=role) if authenticated else None
+    return req
+
+
+# --- IsGatewayAdminOrReadOnly ------------------------------------------------
+@pytest.mark.parametrize("role,allowed", [("owner", True), ("admin", True), ("member", False)])
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_mutations_require_admin_role(role, allowed, method):
+    assert IsGatewayAdminOrReadOnly().has_permission(_request(method, role), None) is allowed
+
+
+@pytest.mark.parametrize("role", ["owner", "admin", "member"])
+@pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS"])
+def test_safe_methods_allowed_for_any_authenticated(role, method):
+    assert IsGatewayAdminOrReadOnly().has_permission(_request(method, role), None) is True
+
+
+def test_unauthenticated_denied_everywhere():
+    perm = IsGatewayAdminOrReadOnly()
+    assert perm.has_permission(_request("GET", authenticated=False), None) is False
+    assert perm.has_permission(_request("POST", authenticated=False), None) is False
+
+
+def test_role_falls_back_to_staff_flags_without_gateway_user():
+    # Legacy API-key path: no request.gateway_user, rely on mirrored auth.User.
+    req = factory.post("/x")
+    req.user = SimpleNamespace(is_authenticated=True, is_staff=True, is_superuser=False)
+    req.gateway_user = None
+    assert IsGatewayAdminOrReadOnly().has_permission(req, None) is True
+
+
+# --- RequireGatewayRole ------------------------------------------------------
+def test_require_gateway_role_gates_all_methods():
+    Perm = RequireGatewayRole("owner", "admin")()
+    assert Perm.has_permission(_request("GET", "admin"), None) is True
+    assert Perm.has_permission(_request("POST", "owner"), None) is True
+    # A member is denied even read, since this gate has no public-read side.
+    assert Perm.has_permission(_request("GET", "member"), None) is False
+
+
+# --- GatewayUser.has_perm() (tightened) --------------------------------------
+@pytest.mark.parametrize("perm,role,expected", [
+    ("guardian.view_asset", "member", True),
+    ("guardian.read_finding", "member", True),
+    ("guardian.add_asset", "member", False),
+    ("guardian.change_asset", "member", False),
+    ("guardian.delete_asset", "member", False),
+    ("guardian.view_all_assets", "member", False),   # cross-tenant scope
+    ("guardian.approve_review", "member", False),     # no loose "view" substring match
+    ("guardian.delete_asset", "admin", True),
+    ("guardian.delete_asset", "owner", True),
+])
+def test_has_perm_tightened(perm, role, expected):
+    assert GatewayUser("u", "t", role).has_perm(perm) is expected


### PR DESCRIPTION
Closes #181, Closes #177 — Sprint 2 (tenancy / RBAC).

Guardian's DRF viewsets used only `IsAuthenticated`, so a plain **member could POST/PUT/PATCH/DELETE** admin-only resources directly at the service layer. `GatewayUser.has_perm()` also granted any `view`/`read` perm via loose substring matching.

## Changes
- **`IsGatewayAdminOrReadOnly`** (new): safe methods for any authenticated user; mutating methods require gateway role `owner`/`admin`. Role is read from `request.gateway_user` (set by the gateway middleware) with a fallback to the mirrored `auth.User` staff flags for the legacy API-key path.
- **`RequireGatewayRole(*roles)`** (new): the reusable DRF permission factory #177 asked for — gates ALL methods on role.
- The `IsAssetManager` / `IsComplianceManager` / `IsSecurityAnalyst` / `IsVulnerabilityManager` placeholders now subclass `IsGatewayAdminOrReadOnly` (same names, real enforcement).
- Applied `IsGatewayAdminOrReadOnly` to the **39 mutating viewsets** across reporting, compliance, integrations, scanners, assets, vulnerabilities, remediation.
- **`has_perm()` tightened**: owner/admin get all; a member gets only `view_`/`read_` codenames (prefix match, not substring) and never `*_all` cross-tenant scopes or any add/change/delete/manage perm.

## Validation
Unit tests for the permission classes and `has_perm` (no DB) in `tests/unit/test_role_enforcement.py`. Validated locally against **Django 4.2 + DRF — 36/36 logic checks pass** (member mutations denied across POST/PUT/PATCH/DELETE; safe methods allowed; unauthenticated denied; staff fallback; `RequireGatewayRole` gating; tightened `has_perm`). Guardian isn't in the integration harness (Django service); the unit-test job runs these in CI.

Default policy is now **read for members, mutate for owner/admin** — finer per-viewset member-write rules can use `RequireGatewayRole` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)