### PR TITLE
enforce/audit gateway role on mutating endpoints (config=admin) (#182)

### DIFF
--- a/open-security-cspm/app/main.py
+++ b/open-security-cspm/app/main.py
@@ -219,6 +219,9 @@ async def health_check():
         )
 
 
+# #182 policy: starting/cancelling a scan is an operational action, member-
+# allowed (gated by gateway auth + per-team scan ownership, not by role).
+# CSPM has no configuration-mutation endpoint that would require owner/admin.
 @app.post(
     "/api/v1/scans",
     response_model=schemas.ScanResponse,

--- a/open-security-data/app/api/main.py
+++ b/open-security-data/app/api/main.py
@@ -294,6 +294,8 @@ async def get_indicator(
     )
 
 # Bulk lookup endpoint
+# #182 policy: POST but read-only (bulk lookup takes a request body) — no role
+# gate; results are already team-scoped.
 @app.post("/api/v1/indicators/lookup", response_model=BulkLookupResponse, tags=["Indicators"])
 async def bulk_lookup(
     request: BulkLookupRequest,
@@ -638,6 +640,8 @@ async def get_threat_intel_metrics(current_user: GatewayUser = Depends(get_curre
     }
 
 # Telemetry ingestion endpoints
+# #182 policy: machine-to-machine telemetry ingest from sensors (not a user
+# admin action) — gated by gateway auth + team scope, not by role.
 @app.post("/api/v1/ingest", response_model=TelemetryBatchResponse, tags=["Telemetry"])
 async def ingest_telemetry_batch(
     batch: TelemetryBatch,

--- a/open-security-responder/app/main.py
+++ b/open-security-responder/app/main.py
@@ -161,6 +161,8 @@ async def list_playbooks(current_user: GatewayUser = Depends(get_current_user)):
         )
 
 
+# #182 policy: executing a playbook is an operational action, member-allowed
+# (gated only by gateway auth + per-run team ownership, not by role).
 @app.post("/v1/playbooks/{playbook_id}/execute")
 async def execute_playbook(
     playbook_id: str,
@@ -239,6 +241,9 @@ async def get_execution_status(run_id: str, current_user: GatewayUser = Depends(
         )
 
 
+# #182 policy: configuration mutations require owner/admin. Reloading playbook
+# definitions from disk changes service config, so it is gated; operational
+# endpoints (execute/cancel a run) stay member-allowed.
 @app.post("/v1/playbooks/reload")
 async def reload_playbooks(current_user: GatewayUser = Depends(require_role("owner", "admin"))):
     """Reload playbooks from disk"""

--- a/tests/integration/test_responder_tenancy.py
+++ b/tests/integration/test_responder_tenancy.py
@@ -14,11 +14,11 @@ import pytest
 import requests
 
 
-def _gateway_headers(team_id: str, secret: str) -> Dict[str, str]:
+def _gateway_headers(team_id: str, secret: str, role: str = "member") -> Dict[str, str]:
     return {
         "X-Wildbox-User-ID": str(uuid.uuid4()),
         "X-Wildbox-Team-ID": team_id,
-        "X-Wildbox-Role": "member",
+        "X-Wildbox-Role": role,
         "X-Gateway-Secret": secret,
     }
 
@@ -86,3 +86,27 @@ def test_responder_run_not_readable_by_other_team(service_urls):
         f"{base}/v1/runs/{run_id}", headers=_gateway_headers(team_b, secret), timeout=10
     )
     assert b_del.status_code == 404, b_del.text
+
+
+def test_responder_reload_requires_admin_role(service_urls):
+    """#182 policy: configuration mutations require owner/admin. Reloading
+    playbook definitions from disk is config, so a member is denied (403) and an
+    admin is allowed (200). Operational mutations (execute/cancel) stay member-
+    allowed and are covered by the tenancy tests above."""
+    secret = _require_secret()
+    base = service_urls["responder"]
+    team = str(uuid.uuid4())
+
+    member = requests.post(
+        f"{base}/v1/playbooks/reload",
+        headers=_gateway_headers(team, secret, role="member"),
+        timeout=10,
+    )
+    assert member.status_code == 403, member.text
+
+    admin = requests.post(
+        f"{base}/v1/playbooks/reload",
+        headers=_gateway_headers(team, secret, role="admin"),
+        timeout=10,
+    )
+    assert admin.status_code == 200, admin.text


### PR DESCRIPTION
Closes #182, Refs #183 — Sprint 2 (RBAC).

Downstream services propagated `X-Wildbox-Role` but didn't enforce it. Audited every mutating endpoint in data/cspm/responder against the chosen policy: **configuration mutations require owner/admin; operational actions and machine-to-machine ingest stay member-allowed** (still gated by gateway auth + team scope).

## Audit
| Service | Endpoint | Class | Role gate |
|---|---|---|---|
| data | `POST /indicators/lookup` | read (POST body) | none |
| data | `POST /ingest` | M2M sensor telemetry | none |
| responder | `POST /playbooks/{id}/execute` | operation | none |
| responder | `DELETE /runs/{id}` | operation (cancel, team-scoped) | none |
| responder | `POST /playbooks/reload` | **config** | **owner/admin** ✓ already |
| cspm | `POST /scans`, `POST /batch/scans` | operation | none |
| cspm | `DELETE /scans/{id}` | operation (cancel, team-scoped) | none |

The policy was **already satisfied** in code: the only configuration mutation (`/playbooks/reload`) already uses the shared `require_role("owner","admin")`.

## Changes
- **Test** proving the gate works end-to-end: a member gets **403** and an admin **200** on `/playbooks/reload` (runs in the responder harness).
- Inline policy comments at the representative endpoints so the member-allowance is clearly intentional and future endpoints follow the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)