### PR TITLE
test: true two-team cross-tenant isolation for the data service (#183)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -236,6 +236,9 @@ jobs:
           DATA_SERVICE_URL: http://localhost:8002
           RESPONDER_SERVICE_URL: http://localhost:8018
           CSPM_SERVICE_URL: http://localhost:8019
+          # psycopg2 DSN for the data DB, used to seed the cross-tenant test
+          # (data has no create API). Same DB the data service runs against.
+          DATA_DB_DSN: postgresql://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
           TEST_API_KEY: ${{ secrets.API_KEY }}
         timeout-minutes: 10
 

--- a/tests/integration/test_data_cross_tenant.py
+++ b/tests/integration/test_data_cross_tenant.py
@@ -12,6 +12,7 @@ import pytest
 import requests
 
 psycopg2 = pytest.importorskip("psycopg2")
+from psycopg2.extras import Json  # noqa: E402
 
 
 def _gateway_headers(team_id: str, secret: str) -> Dict[str, str]:
@@ -38,9 +39,13 @@ def _seed(conn, *, team_id, value):
         cur.execute(
             "INSERT INTO indicators "
             "(id, source_id, team_id, indicator_type, value, normalized_value, "
+            " threat_types, confidence, severity, tags, "
             " first_seen, last_seen, collection_date, active) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            # threat_types/confidence/severity/tags are NOT NULL in the response
+            # schema (pydantic defaults don't apply to a NULL read from the ORM).
             (str(indicator_id), str(source_id), team_id, "ipv4", value, value,
+             Json([]), "medium", 5, Json([]),
              now, now, now, True),
         )
     conn.commit()

--- a/tests/integration/test_data_cross_tenant.py
+++ b/tests/integration/test_data_cross_tenant.py
@@ -1,0 +1,93 @@
+"""True two-team cross-tenant isolation for the data service (#183, completing
+#178). The data service has no create API, so seed Source/Indicator rows
+directly in its database, then assert team B cannot read team A's data via the
+API while global (team_id NULL) data is visible to both.
+"""
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Dict
+
+import pytest
+import requests
+
+psycopg2 = pytest.importorskip("psycopg2")
+
+
+def _gateway_headers(team_id: str, secret: str) -> Dict[str, str]:
+    return {
+        "X-Wildbox-User-ID": str(uuid.uuid4()),
+        "X-Wildbox-Team-ID": team_id,
+        "X-Wildbox-Role": "member",
+        "X-Gateway-Secret": secret,
+    }
+
+
+def _seed(conn, *, team_id, value):
+    """Insert a Source + Indicator (active) owned by team_id (NULL = global).
+    Returns (source_id, indicator_id)."""
+    now = datetime.now(timezone.utc)
+    source_id = uuid.uuid4()
+    indicator_id = uuid.uuid4()
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (id, team_id, name, source_type, enabled) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (str(source_id), team_id, f"test-src-{source_id}", "feed", True),
+        )
+        cur.execute(
+            "INSERT INTO indicators "
+            "(id, source_id, team_id, indicator_type, value, normalized_value, "
+            " first_seen, last_seen, collection_date, active) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (str(indicator_id), str(source_id), team_id, "ipv4", value, value,
+             now, now, now, True),
+        )
+    conn.commit()
+    return source_id, indicator_id
+
+
+def _search_values(service_urls, team_id, secret, query):
+    resp = requests.get(
+        f"{service_urls['data']}/api/v1/indicators/search",
+        params={"q": query},
+        headers=_gateway_headers(team_id, secret),
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    items = body.get("indicators") or body.get("results") or []
+    return {i.get("value") for i in items}
+
+
+def test_data_team_cannot_read_other_teams_indicator(service_urls):
+    secret = os.environ.get("GATEWAY_INTERNAL_SECRET", "")
+    dsn = os.environ.get("DATA_DB_DSN", "")
+    if not secret or not dsn:
+        pytest.skip("GATEWAY_INTERNAL_SECRET / DATA_DB_DSN not set")
+
+    team_a = str(uuid.uuid4())
+    team_b = str(uuid.uuid4())
+    val_a = f"10.0.0.{uuid.uuid4().hex[:6]}"        # team A private
+    val_global = f"10.1.1.{uuid.uuid4().hex[:6]}"   # shared/global feed
+
+    conn = psycopg2.connect(dsn)
+    seeded = []
+    try:
+        seeded.append(_seed(conn, team_id=team_a, value=val_a))
+        seeded.append(_seed(conn, team_id=None, value=val_global))
+
+        # Team A sees its own private indicator; team B does not.
+        assert val_a in _search_values(service_urls, team_a, secret, val_a)
+        assert val_a not in _search_values(service_urls, team_b, secret, val_a)
+
+        # Global (team_id NULL) indicator is visible to both teams.
+        assert val_global in _search_values(service_urls, team_a, secret, val_global)
+        assert val_global in _search_values(service_urls, team_b, secret, val_global)
+    finally:
+        with conn.cursor() as cur:
+            for source_id, indicator_id in seeded:
+                cur.execute("DELETE FROM indicators WHERE id = %s", (str(indicator_id),))
+                cur.execute("DELETE FROM sources WHERE id = %s", (str(source_id),))
+        conn.commit()
+        conn.close()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,6 +13,9 @@ pytest-xdist==3.6.1
 requests==2.33.0
 httpx==0.27.2
 
+# Direct DB access for cross-tenant seeding tests (data service has no create API)
+psycopg2-binary==2.9.10
+
 # Async testing support
 aiohttp==3.14.1
 


### PR DESCRIPTION
Closes #183 — Sprint 2 capstone.

Locks in the tenancy/role work with integration tests that fail if isolation regresses. The data service was the one service lacking a true two-team test (it has no create API). This seeds Source/Indicator rows **directly in the data DB** (new `psycopg2-binary` dep + `DATA_DB_DSN`) and asserts via the API:

- team A sees its own private indicator (`team_id = A`),
- **team B does NOT see team A's indicator**,
- a global indicator (`team_id NULL`) is visible to **both** teams (shared-feed overlay).

Rows are cleaned up in a `finally`; the test skips when secrets/DSN are absent (fork PRs).

## #183 coverage across services (all in the CI harness)
| Service | Test | What it locks in |
|---|---|---|
| data | `test_data_cross_tenant.py` (new) | team B can't read team A's indicators; global stays shared |
| responder | `test_responder_tenancy.py` | run ownership (B→404) + reload role gate (member→403) |
| cspm | `test_cspm_tenancy.py` | scan isolation (B→403) |
| guardian | `test_role_enforcement.py` (unit) | member can't mutate; tightened has_perm |

🤖 Generated with [Claude Code](https://claude.com/claude-code)