### PR TITLE
auth: scope the legacy X-API-Key + forward caller identity agents→tools (#175)

### DIFF
--- a/open-security-agents/app/config.py
+++ b/open-security-agents/app/config.py
@@ -39,6 +39,10 @@ class Settings(BaseSettings):
     
     # Security
     internal_api_key: str = Field(default="", env="INTERNAL_API_KEY")  # REQUIRED: set via env var
+    # Proof-of-origin secret used to forward the caller's gateway identity to
+    # downstream services (#175). When set, internal tool calls carry the user's
+    # X-Wildbox-* headers + this secret instead of the static service key.
+    gateway_internal_secret: str = Field(default="", env="GATEWAY_INTERNAL_SECRET")
     
     # Analysis Settings
     max_analysis_time_minutes: int = 10

--- a/open-security-agents/app/main.py
+++ b/open-security-agents/app/main.py
@@ -264,10 +264,16 @@ async def analyze_ioc(
             json.dumps(task_metadata)
         )
         
-        # Submit Celery task
+        # Submit Celery task, forwarding the caller's gateway identity so tool
+        # calls run with the user's real team scope, not the legacy key (#175).
         celery_task = run_threat_enrichment_task.delay(
             task_id=task_id,
-            ioc=request.ioc.dict()
+            ioc=request.ioc.dict(),
+            caller={
+                "user_id": str(user.user_id),
+                "team_id": str(user.team_id),
+                "role": getattr(user, "role", "member"),
+            },
         )
         
         # Store Celery task ID mapping

--- a/open-security-agents/app/tools/wildbox_client.py
+++ b/open-security-agents/app/tools/wildbox_client.py
@@ -6,12 +6,29 @@ Provides authenticated access to the Wildbox security toolkit.
 
 import asyncio
 import logging
+from contextvars import ContextVar
 from typing import Dict, Any, Optional
 import httpx
 
 from ..config import settings
 
 logger = logging.getLogger(__name__)
+
+# Identity of the user on whose behalf internal tool calls are made (#175). Set
+# per analysis task (see worker.run_threat_enrichment_task) so downstream calls
+# carry the real team-scoped identity instead of a god-mode service key.
+_caller_identity: ContextVar[Optional[Dict[str, str]]] = ContextVar(
+    "wildbox_caller_identity", default=None
+)
+
+
+def set_caller_identity(user_id: str, team_id: str, role: str = "member") -> None:
+    """Record the gateway identity to forward on subsequent internal calls."""
+    _caller_identity.set({
+        "user_id": str(user_id),
+        "team_id": str(team_id),
+        "role": role or "member",
+    })
 
 
 class WildboxAPIClient:
@@ -35,19 +52,37 @@ class WildboxAPIClient:
         self.guardian_url = settings.wildbox_guardian_url
         self.responder_url = settings.wildbox_responder_url
         self.api_key = settings.internal_api_key
-        if not self.api_key:
+        self.gateway_secret = settings.gateway_internal_secret
+        if not self.api_key and not self.gateway_secret:
             logger.warning(
-                "INTERNAL_API_KEY is not set — internal tool calls will go out "
-                "without an X-API-Key and be rejected by the backend services."
+                "Neither INTERNAL_API_KEY nor GATEWAY_INTERNAL_SECRET is set — "
+                "internal tool calls will be unauthenticated and rejected."
             )
 
         # HTTP client configuration
         self.timeout = httpx.Timeout(30.0, connect=10.0)
-        self.headers = {
+
+    def _request_headers(self) -> Dict[str, str]:
+        """Build auth headers per call.
+
+        Preferred (#175): forward the caller's gateway identity (X-Wildbox-*)
+        plus the proof-of-origin secret, so downstream services apply the user's
+        real team scope and role. Fall back to the static (now non-privileged,
+        #175) service API key only when no caller identity / secret is available.
+        """
+        headers = {
             "User-Agent": "Open-Security-Agents/1.0",
-            "X-API-Key": self.api_key,
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
+        caller = _caller_identity.get()
+        if caller and self.gateway_secret:
+            headers["X-Wildbox-User-ID"] = caller["user_id"]
+            headers["X-Wildbox-Team-ID"] = caller["team_id"]
+            headers["X-Wildbox-Role"] = caller["role"]
+            headers["X-Gateway-Secret"] = self.gateway_secret
+        else:
+            headers["X-API-Key"] = self.api_key
+        return headers
     
     async def run_tool(self, tool_name: str, params: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -94,7 +129,7 @@ class WildboxAPIClient:
                         response = await client.post(
                             url,
                             json=transformed_params,  # Send params directly, not wrapped
-                            headers=self.headers
+                            headers=self._request_headers()
                         )
                         
                         # Handle rate limiting with exponential backoff
@@ -149,7 +184,7 @@ class WildboxAPIClient:
                 response = await client.get(
                     url,
                     params=params,
-                    headers=self.headers
+                    headers=self._request_headers()
                 )
                 response.raise_for_status()
                 
@@ -330,7 +365,7 @@ class WildboxAPIClient:
                 response = await client.get(
                     url,
                     params=params,
-                    headers=self.headers
+                    headers=self._request_headers()
                 )
                 response.raise_for_status()
                 return response.json()
@@ -360,7 +395,7 @@ class WildboxAPIClient:
                 async with httpx.AsyncClient(timeout=httpx.Timeout(5.0)) as client:
                     response = await client.get(
                         f"{service_url}/health",
-                        headers={"X-API-Key": self.api_key}
+                        headers=self._request_headers()
                     )
                     if response.status_code == 200:
                         health_status[service_name] = "healthy"

--- a/open-security-agents/app/worker.py
+++ b/open-security-agents/app/worker.py
@@ -7,13 +7,14 @@ Handles asynchronous AI-powered threat analysis tasks.
 import logging
 import asyncio
 from datetime import datetime, timezone
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from celery import Celery
 import redis
 
 from .config import settings
 from .agents.threat_enrichment_agent import get_threat_enrichment_agent
+from .tools.wildbox_client import set_caller_identity
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -47,26 +48,38 @@ redis_client = redis.from_url(settings.redis_url)
 
 
 @celery_app.task(bind=True, name="run_threat_enrichment_task")
-def run_threat_enrichment_task(self, task_id: str, ioc: Dict[str, Any]) -> Dict[str, Any]:
+def run_threat_enrichment_task(
+    self, task_id: str, ioc: Dict[str, Any], caller: Optional[Dict[str, str]] = None
+) -> Dict[str, Any]:
     """
     Main Celery task for AI-powered threat enrichment
-    
+
     This task orchestrates the entire analysis process:
     1. Initialize the AI agent
     2. Run the analysis
     3. Generate structured report
     4. Update task status
-    
+
     Args:
         task_id: Unique task identifier
         ioc: IOC dictionary with 'type' and 'value'
-        
+        caller: Gateway identity of the requesting user (user_id/team_id/role).
+            Forwarded to downstream services so tool calls run with the user's
+            real team scope instead of the legacy service key (#175).
+
     Returns:
         Complete analysis result dictionary
     """
-    
+
     try:
         logger.info(f"Starting threat enrichment task {task_id} for IOC type: {ioc['type']}")
+
+        # Forward the caller's identity to internal tool calls (#175). Set before
+        # the event loop runs so it is visible to the async agent/tool stack.
+        if caller and caller.get("user_id") and caller.get("team_id"):
+            set_caller_identity(
+                caller["user_id"], caller["team_id"], caller.get("role", "member")
+            )
         
         # Update task status to running
         self.update_state(

--- a/open-security-agents/pytest.ini
+++ b/open-security-agents/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Don't inherit the repo-root addopts (--html needs a plugin not installed in
+# the per-service unit-test job). Keep agents' unit tests self-contained.
+addopts =
+testpaths = tests

--- a/open-security-agents/tests/unit/test_wildbox_client_auth.py
+++ b/open-security-agents/tests/unit/test_wildbox_client_auth.py
@@ -1,0 +1,54 @@
+"""Unit tests for #175: internal tool calls forward the caller's gateway
+identity (X-Wildbox-* + secret) instead of a static god-mode key, with a safe
+fallback to the (now non-privileged) service key.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from app.tools.wildbox_client import (  # noqa: E402
+    WildboxAPIClient,
+    set_caller_identity,
+    _caller_identity,
+)
+
+
+@pytest.fixture
+def client():
+    c = WildboxAPIClient()
+    c.api_key = "SERVICE-KEY"
+    c.gateway_secret = "GW-SECRET"
+    _caller_identity.set(None)
+    yield c
+    _caller_identity.set(None)
+
+
+def test_falls_back_to_service_key_without_caller(client):
+    headers = client._request_headers()
+    assert headers["X-API-Key"] == "SERVICE-KEY"
+    assert "X-Wildbox-User-ID" not in headers
+    assert "X-Gateway-Secret" not in headers
+
+
+def test_forwards_caller_gateway_identity(client):
+    set_caller_identity("user-1", "team-1", "admin")
+    headers = client._request_headers()
+    assert headers["X-Wildbox-User-ID"] == "user-1"
+    assert headers["X-Wildbox-Team-ID"] == "team-1"
+    assert headers["X-Wildbox-Role"] == "admin"
+    assert headers["X-Gateway-Secret"] == "GW-SECRET"
+    # The static key is NOT sent when forwarding real identity.
+    assert "X-API-Key" not in headers
+
+
+def test_falls_back_when_secret_missing(client):
+    # A caller identity without a configured secret can't prove gateway origin,
+    # so we must not send unverified X-Wildbox-* headers — fall back to the key.
+    client.gateway_secret = ""
+    set_caller_identity("user-1", "team-1", "member")
+    headers = client._request_headers()
+    assert headers["X-API-Key"] == "SERVICE-KEY"
+    assert "X-Wildbox-User-ID" not in headers

--- a/open-security-tools/app/auth.py
+++ b/open-security-tools/app/auth.py
@@ -4,8 +4,10 @@ Two authentication modes:
 1. **Gateway** (production): requests arrive through the API gateway with
    X-Wildbox-* identity headers and the X-Gateway-Secret proof-of-origin. This
    is delegated to the shared `open_security_shared.gateway_auth` dependency.
-2. **Direct API key** (legacy/dev): a static X-API-Key. Tracked for removal/
-   scoping in #175 — it currently authenticates as a zero-team admin.
+2. **Direct API key** (legacy/dev): a static X-API-Key. Scoped in #175 to a
+   non-privileged "service" identity (no admin role) so it can no longer
+   escalate; internal callers (agents) should forward the user's gateway
+   identity instead and fall back to this key only transitionally.
 """
 
 from typing import Optional
@@ -40,7 +42,10 @@ async def get_current_user(
             x_gateway_secret=x_gateway_secret,
         )
 
-    # Legacy/dev: direct API key. NOTE: returns a zero-team admin — see #175.
+    # Legacy/dev: direct API key. Scoped (#175) to a non-privileged "service"
+    # identity — NOT admin — so a leaked/over-broad key can't perform
+    # privileged actions. team_id stays the zero UUID, which under per-team
+    # scoping (#178) only ever resolves to global/shared data.
     if x_api_key:
         if x_api_key != settings.get_api_key():
             client = request.client.host if request and request.client else "unknown"
@@ -50,11 +55,11 @@ async def get_current_user(
                 detail="Invalid API key",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        logger.info("Direct API key authentication (legacy mode)")
+        logger.info("Direct API key authentication (legacy service mode)")
         return GatewayUser(
             user_id="00000000-0000-0000-0000-000000000000",
             team_id="00000000-0000-0000-0000-000000000000",
-            role="admin",
+            role="service",
         )
 
     client = request.client.host if request and request.client else "unknown"


### PR DESCRIPTION
Closes #175 — the last Sprint 1 carry-over (paired with Sprint 2 tenancy).

The tools service mapped a static `X-API-Key` to `role=admin` / `team_id=0`, and agents called every backend through that key — so AI analysis ran as a **zero-team admin**, defeating tenancy and role checks.

## Changes
- **tools/auth.py**: the legacy `X-API-Key` now authenticates as a non-privileged `role="service"` identity (not admin). It can't perform privileged actions; `team_id` stays the zero UUID, which under #178 scoping resolves only to global/shared data.
- **agents → tools identity forwarding**: `WildboxAPIClient` builds headers per call — the caller's `X-Wildbox-*` + `X-Gateway-Secret` when a caller identity and secret are present, else the (now scoped) service key as a **safe fallback**. `/v1/analyze` passes the user's identity into the Celery task, which sets it via a `contextvar` before the async agent runs, so downstream tool calls inherit the user's real team scope.
- **config**: add `GATEWAY_INTERNAL_SECRET` to agents (already wired in `docker-compose.yml`).

## Validation
- Header-builder unit tests (`tests/unit/test_wildbox_client_auth.py`): service-key fallback / forwarded gateway identity / fallback-when-secret-missing. **Validated locally (3 passed)** against pydantic+httpx.
- Added `open-security-agents/pytest.ini` so the agents unit-test job stops inheriting the repo-root `--html` addopts (it was silently collecting nothing) — the new tests now actually run in CI.
- The integration harness already exercises the tools legacy-key auth path (`test_tools_with_valid_api_key`), confirming the key still authenticates after the role downgrade.

The fallback keeps agents working even if identity/secret is absent, so the change is safe; agents is not in the integration harness, so the end-to-end Celery→agent→tools flow is covered by the unit-tested header logic + the safe fallback rather than a live e2e test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)