### PR TITLE
cspm: fix dashboard/summary response contract (#179 follow-up)

### DIFF
--- a/open-security-cspm/app/main.py
+++ b/open-security-cspm/app/main.py
@@ -627,26 +627,50 @@ async def get_dashboard_summary(
         # Get the team's scans via its index set (no cross-team key scanning).
         team_scans = list(_iter_team_scan_metadata(current_user["team_id"]))
 
-        # Calculate summary metrics. Use defensive .get() — a freshly started
-        # scan has no resources/summary yet (the worker fills them on completion).
         total_scans = len(team_scans)
-        total_resources = sum(len(s.get("resources", [])) for s in team_scans)
-        total_findings = sum(s.get("summary", {}).get("total_findings", 0) for s in team_scans)
-        total_passed = sum(s.get("summary", {}).get("passed", 0) for s in team_scans)
-        total_failed = sum(s.get("summary", {}).get("failed", 0) for s in team_scans)
-        total_skipped = sum(s.get("summary", {}).get("skipped", 0) for s in team_scans)
-        
-        # Get trending metrics
-        trending_metrics = _get_trending_metrics(redis_client, "all", current_user["team_id"])
-        
+        active_states = {"started", "running", "queued", "pending"}
+        active_scans = sum(1 for s in team_scans if s.get("status") in active_states)
+        failed_scans = sum(1 for s in team_scans if s.get("status") == "failed")
+        completed_scans = sum(1 for s in team_scans if s.get("status") == "completed")
+
+        # Aggregate findings from each scan's results (present only after a scan
+        # completes). Per-check severity isn't tracked yet, so the per-severity
+        # buckets stay 0; total_findings counts failed checks.
+        all_results = []
+        for s in team_scans:
+            raw = redis_client.get(f"scan:{s['scan_id']}:results")
+            if not raw:
+                continue
+            try:
+                all_results.extend(json.loads(raw).get("results", []))
+            except (ValueError, TypeError):
+                continue
+        total_findings = sum(1 for r in all_results if r.get("status") == "failed")
+        compliance_score = (
+            _calculate_compliance_score({"results": all_results}) if all_results else 0.0
+        )
+
+        # Most recent scan start time.
+        started_times = []
+        for s in team_scans:
+            try:
+                started_times.append(datetime.fromisoformat(s["started_at"]))
+            except (KeyError, ValueError, TypeError):
+                continue
+        last_scan_at = max(started_times) if started_times else None
+
         return schemas.DashboardSummaryResponse(
             total_scans=total_scans,
-            total_resources=total_resources,
+            active_scans=active_scans,
+            failed_scans=failed_scans,
+            completed_scans=completed_scans,
             total_findings=total_findings,
-            total_passed=total_passed,
-            total_failed=total_failed,
-            total_skipped=total_skipped,
-            trending_metrics=trending_metrics
+            critical_findings=0,
+            high_findings=0,
+            medium_findings=0,
+            low_findings=0,
+            compliance_score=compliance_score,
+            last_scan_at=last_scan_at,
         )
         
     except (ValueError, KeyError, TypeError, ConnectionError, TimeoutError) as e:

--- a/tests/integration/test_cspm_tenancy.py
+++ b/tests/integration/test_cspm_tenancy.py
@@ -83,8 +83,15 @@ def test_cspm_scan_isolated_by_team(service_urls):
     )
     assert b_del.status_code == 403, b_del.text
 
-    # NOTE: the /dashboard/summary endpoint has a pre-existing broken response
-    # contract (its return doesn't match DashboardSummaryResponse), so it 500s
-    # regardless of tenancy — not asserted here. The per-team scan index that
-    # backs it is still exercised by start_scan above; the dashboard response
-    # contract is a separate fix.
+    # Team A's dashboard counts the scan; team B's does not (per-team index).
+    a_dash = requests.get(
+        f"{base}/api/v1/dashboard/summary", headers=_gateway_headers(team_a, secret), timeout=10
+    )
+    assert a_dash.status_code == 200, a_dash.text
+    assert a_dash.json()["total_scans"] >= 1
+
+    b_dash = requests.get(
+        f"{base}/api/v1/dashboard/summary", headers=_gateway_headers(team_b, secret), timeout=10
+    )
+    assert b_dash.status_code == 200, b_dash.text
+    assert b_dash.json()["total_scans"] == 0


### PR DESCRIPTION
Follow-up to #179 (task spawned during that PR).

`GET /api/v1/dashboard/summary` returned `total_resources`/`total_passed`/`total_skipped`/`trending_metrics`, none of which exist on `DashboardSummaryResponse` — so it raised **8 pydantic validation errors and 500'd for every caller**, regardless of tenancy.

## Fix
Return exactly the declared fields:
- `total/active/failed/completed_scans` from the team's scan metadata,
- `total_findings` = failed checks aggregated from each scan's results (present once a scan completes); per-severity buckets stay 0 (per-check severity isn't tracked yet) and `compliance_score` via the existing `_calculate_compliance_score` helper,
- `last_scan_at` = most recent `started_at`.

## Validation
Re-enabled the cspm dashboard assertions in `test_cspm_tenancy.py` (removed in #179 because the endpoint 500'd): team A starts a scan → its dashboard reports `total_scans >= 1`; team B's reports `0`. Runs in the cspm harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)