### PR TITLE
feat(tools): add Entra ID security analyzer module

### DIFF
--- a/open-security-tools/app/tools/entra_id_security_analyzer/main.py
+++ b/open-security-tools/app/tools/entra_id_security_analyzer/main.py
@@ -1,0 +1,300 @@
+"""
+Entra ID Security Analyzer
+
+Connects to Microsoft Graph using an app-registration's client-credentials
+flow and flags two common identity hygiene gaps in Microsoft Entra ID
+(Azure AD) tenants:
+
+  * Stale accounts - enabled users with no sign-in activity within a
+    configurable threshold (or no recorded sign-in at all).
+  * MFA gaps - enabled users who are not registered for multi-factor
+    authentication.
+
+Required Microsoft Graph **application** permissions on the app
+registration (admin consent required):
+  * User.Read.All
+  * AuditLog.Read.All
+  * Reports.Read.All
+
+Credentials can be supplied per-request or via the ENTRA_TENANT_ID,
+ENTRA_CLIENT_ID and ENTRA_CLIENT_SECRET environment variables.
+"""
+
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+try:
+    from schemas import (
+        EntraIDSecurityAnalyzerInput,
+        EntraIDSecurityAnalyzerOutput,
+        MfaGap,
+        StaleAccount,
+    )
+except ImportError:
+    from schemas import (
+        EntraIDSecurityAnalyzerInput,
+        EntraIDSecurityAnalyzerOutput,
+        MfaGap,
+        StaleAccount,
+    )
+
+GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+LOGIN_BASE_URL = "https://login.microsoftonline.com"
+
+
+class EntraIDSecurityAnalyzer:
+    """Queries Microsoft Graph for stale accounts and MFA registration gaps."""
+
+    def __init__(self, tenant_id: str, client_id: str, client_secret: str, verify_ssl: bool = True):
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.verify_ssl = verify_ssl
+
+    async def _get_access_token(self, session: aiohttp.ClientSession) -> str:
+        """Authenticate via the OAuth2 client-credentials grant."""
+        token_url = f"{LOGIN_BASE_URL}/{self.tenant_id}/oauth2/v2.0/token"
+        payload = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "scope": "https://graph.microsoft.com/.default",
+        }
+
+        async with session.post(token_url, data=payload, ssl=self.verify_ssl) as response:
+            body = await response.json()
+            if response.status != 200:
+                error_description = body.get("error_description", "Unknown error")
+                raise RuntimeError(f"Failed to authenticate with Microsoft Graph: {error_description}")
+            return body["access_token"]
+
+    async def _get_paginated(
+        self, session: aiohttp.ClientSession, url: str, headers: Dict[str, str], max_items: int
+    ) -> List[Dict[str, Any]]:
+        """Follow @odata.nextLink until max_items is reached or pages run out."""
+        items: List[Dict[str, Any]] = []
+        next_url: Optional[str] = url
+
+        while next_url and len(items) < max_items:
+            async with session.get(next_url, headers=headers, ssl=self.verify_ssl) as response:
+                body = await response.json()
+                if response.status != 200:
+                    error_message = body.get("error", {}).get("message", "Unknown error")
+                    raise RuntimeError(f"Microsoft Graph request failed ({response.status}): {error_message}")
+
+                items.extend(body.get("value", []))
+                next_url = body.get("@odata.nextLink")
+
+        return items[:max_items]
+
+    async def get_users_with_signin_activity(
+        self, session: aiohttp.ClientSession, headers: Dict[str, str], max_users: int
+    ) -> List[Dict[str, Any]]:
+        select = "id,userPrincipalName,displayName,accountEnabled,signInActivity"
+        url = f"{GRAPH_BASE_URL}/users?$select={select}&$top=999"
+        return await self._get_paginated(session, url, headers, max_users)
+
+    async def get_mfa_registration_details(
+        self, session: aiohttp.ClientSession, headers: Dict[str, str], max_users: int
+    ) -> List[Dict[str, Any]]:
+        url = f"{GRAPH_BASE_URL}/reports/authenticationMethods/userRegistrationDetails?$top=999"
+        return await self._get_paginated(session, url, headers, max_users)
+
+
+def _classify_stale_severity(days_inactive: Optional[int], threshold: int) -> str:
+    if days_inactive is None:
+        return "Medium"
+    if days_inactive >= threshold * 3:
+        return "Critical"
+    if days_inactive >= threshold * 2:
+        return "High"
+    return "Medium"
+
+
+def _classify_mfa_severity(is_admin: bool) -> str:
+    return "Critical" if is_admin else "High"
+
+
+def _build_stale_accounts(
+    users: List[Dict[str, Any]], threshold_days: int, include_disabled: bool
+) -> List[StaleAccount]:
+    stale_accounts: List[StaleAccount] = []
+    now = datetime.now(timezone.utc)
+
+    for user in users:
+        if not include_disabled and not user.get("accountEnabled", True):
+            continue
+
+        sign_in_activity = user.get("signInActivity") or {}
+        last_sign_in = sign_in_activity.get("lastSignInDateTime")
+
+        days_inactive: Optional[int] = None
+        if last_sign_in:
+            last_sign_in_dt = datetime.fromisoformat(last_sign_in.replace("Z", "+00:00"))
+            days_inactive = (now - last_sign_in_dt).days
+
+        is_stale = days_inactive is None or days_inactive >= threshold_days
+        if not is_stale:
+            continue
+
+        stale_accounts.append(
+            StaleAccount(
+                user_principal_name=user.get("userPrincipalName", "unknown"),
+                display_name=user.get("displayName"),
+                account_enabled=user.get("accountEnabled", True),
+                last_sign_in_date_time=last_sign_in,
+                days_inactive=days_inactive,
+                severity=_classify_stale_severity(days_inactive, threshold_days),
+            )
+        )
+
+    return stale_accounts
+
+
+def _build_mfa_gaps(registration_details: List[Dict[str, Any]]) -> List[MfaGap]:
+    mfa_gaps: List[MfaGap] = []
+
+    for detail in registration_details:
+        if detail.get("isMfaRegistered"):
+            continue
+
+        is_admin = bool(detail.get("isAdmin", False))
+        mfa_gaps.append(
+            MfaGap(
+                user_principal_name=detail.get("userPrincipalName", "unknown"),
+                is_mfa_registered=False,
+                is_mfa_capable=bool(detail.get("isMfaCapable", False)),
+                is_sspr_registered=bool(detail.get("isSsprRegistered", False)),
+                is_admin=is_admin,
+                severity=_classify_mfa_severity(is_admin),
+            )
+        )
+
+    return mfa_gaps
+
+
+def _generate_recommendations(stale_accounts: List[StaleAccount], mfa_gaps: List[MfaGap]) -> List[str]:
+    recommendations: List[str] = []
+
+    admin_mfa_gaps = [gap for gap in mfa_gaps if gap.is_admin]
+    if admin_mfa_gaps:
+        recommendations.append(
+            "URGENT: Enforce MFA for privileged/admin accounts that are not currently registered"
+        )
+    if mfa_gaps:
+        recommendations.append(
+            "Enable an Entra ID Conditional Access policy requiring MFA for all users"
+        )
+        recommendations.append("Use Entra ID Identity Protection to drive MFA registration campaigns")
+
+    if stale_accounts:
+        recommendations.append(
+            "Review and disable or remove accounts with no recent sign-in activity"
+        )
+        recommendations.append("Set up an access review workflow to periodically re-certify account activity")
+
+    if not stale_accounts and not mfa_gaps:
+        recommendations.append("No stale accounts or MFA gaps detected within the configured thresholds")
+
+    return recommendations
+
+
+async def execute_tool(data: EntraIDSecurityAnalyzerInput) -> EntraIDSecurityAnalyzerOutput:
+    start_time = time.time()
+
+    tenant_id = data.tenant_id or os.getenv("ENTRA_TENANT_ID")
+    client_id = data.client_id or os.getenv("ENTRA_CLIENT_ID")
+    client_secret = data.client_secret or os.getenv("ENTRA_CLIENT_SECRET")
+
+    if not tenant_id or not client_id or not client_secret:
+        return EntraIDSecurityAnalyzerOutput(
+            success=False,
+            tool_name="entra_id_security_analyzer",
+            tenant_id=tenant_id,
+            error_message=(
+                "Missing Entra ID credentials. Provide tenant_id, client_id and "
+                "client_secret, or set ENTRA_TENANT_ID, ENTRA_CLIENT_ID and "
+                "ENTRA_CLIENT_SECRET environment variables."
+            ),
+            execution_time=time.time() - start_time,
+        )
+
+    analyzer = EntraIDSecurityAnalyzer(tenant_id, client_id, client_secret, verify_ssl=data.verify_ssl)
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=data.timeout)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            access_token = await analyzer._get_access_token(session)
+            headers = {"Authorization": f"Bearer {access_token}"}
+
+            stale_accounts: List[StaleAccount] = []
+            mfa_gaps: List[MfaGap] = []
+            users: List[Dict[str, Any]] = []
+
+            if data.check_stale_accounts:
+                users = await analyzer.get_users_with_signin_activity(session, headers, data.max_users)
+                stale_accounts = _build_stale_accounts(
+                    users, data.stale_threshold_days, data.include_disabled_accounts
+                )
+
+            if data.check_mfa_gaps:
+                registration_details = await analyzer.get_mfa_registration_details(
+                    session, headers, data.max_users
+                )
+                mfa_gaps = _build_mfa_gaps(registration_details)
+                if not users:
+                    users = registration_details
+
+            critical_issues = len([s for s in stale_accounts if s.severity == "Critical"])
+            critical_issues += len([g for g in mfa_gaps if g.severity == "Critical"])
+            high_issues = len([s for s in stale_accounts if s.severity == "High"])
+            high_issues += len([g for g in mfa_gaps if g.severity == "High"])
+            medium_issues = len([s for s in stale_accounts if s.severity == "Medium"])
+            low_issues = len([s for s in stale_accounts if s.severity == "Low"])
+
+            return EntraIDSecurityAnalyzerOutput(
+                success=True,
+                tool_name="entra_id_security_analyzer",
+                tenant_id=tenant_id,
+                total_users_scanned=len(users),
+                stale_accounts=stale_accounts,
+                mfa_gaps=mfa_gaps,
+                critical_issues=critical_issues,
+                high_issues=high_issues,
+                medium_issues=medium_issues,
+                low_issues=low_issues,
+                recommendations=_generate_recommendations(stale_accounts, mfa_gaps),
+                summary=(
+                    f"Scanned {len(users)} users: {len(stale_accounts)} stale account(s), "
+                    f"{len(mfa_gaps)} MFA registration gap(s)"
+                ),
+                execution_time=time.time() - start_time,
+            )
+
+    except (RuntimeError, ValueError, KeyError, TypeError, ConnectionError, TimeoutError, aiohttp.ClientError) as e:
+        return EntraIDSecurityAnalyzerOutput(
+            success=False,
+            tool_name="entra_id_security_analyzer",
+            tenant_id=tenant_id,
+            error_message=f"Entra ID analysis failed: {str(e)}",
+            execution_time=time.time() - start_time,
+        )
+
+
+# Tool metadata
+TOOL_INFO = {
+    "name": "entra_id_security_analyzer",
+    "display_name": "Entra ID Security Analyzer",
+    "description": (
+        "Connects to Microsoft Graph to find stale accounts and MFA "
+        "registration gaps in a Microsoft Entra ID (Azure AD) tenant"
+    ),
+    "category": "identity_security",
+    "version": "1.0.0",
+    "author": "Wildbox Security",
+    "tags": ["entra-id", "azure-ad", "identity", "mfa", "microsoft-graph", "iam"],
+}

--- a/open-security-tools/app/tools/entra_id_security_analyzer/schemas.py
+++ b/open-security-tools/app/tools/entra_id_security_analyzer/schemas.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+from standardized_schemas import BaseToolInput, BaseToolOutput
+
+
+class EntraIDSecurityAnalyzerInput(BaseToolInput):
+    """Input schema for the Entra ID Security Analyzer tool"""
+
+    tenant_id: Optional[str] = Field(
+        None,
+        description=(
+            "Entra ID (Azure AD) tenant ID. Falls back to the "
+            "ENTRA_TENANT_ID environment variable if not provided."
+        ),
+    )
+    client_id: Optional[str] = Field(
+        None,
+        description=(
+            "App registration client ID with admin-consented "
+            "User.Read.All, AuditLog.Read.All and Reports.Read.All "
+            "application permissions. Falls back to ENTRA_CLIENT_ID."
+        ),
+    )
+    client_secret: Optional[str] = Field(
+        None,
+        description=(
+            "App registration client secret. Falls back to "
+            "ENTRA_CLIENT_SECRET. Never echoed back in the output."
+        ),
+    )
+    stale_threshold_days: int = Field(
+        default=90,
+        ge=1,
+        le=365,
+        description="Number of days of inactivity before an account is flagged as stale",
+    )
+    check_stale_accounts: bool = Field(
+        default=True, description="Enumerate accounts with no recent sign-in activity"
+    )
+    check_mfa_gaps: bool = Field(
+        default=True,
+        description="Enumerate enabled accounts that are not registered for MFA",
+    )
+    include_disabled_accounts: bool = Field(
+        default=False,
+        description="Include disabled accounts in the stale-account and MFA results",
+    )
+    max_users: int = Field(
+        default=999,
+        ge=1,
+        le=5000,
+        description="Maximum number of users to retrieve from Microsoft Graph",
+    )
+
+
+class StaleAccount(BaseModel):
+    user_principal_name: str
+    display_name: Optional[str] = None
+    account_enabled: bool
+    last_sign_in_date_time: Optional[str] = None
+    days_inactive: Optional[int] = None
+    severity: str  # Critical, High, Medium, Low
+
+
+class MfaGap(BaseModel):
+    user_principal_name: str
+    is_mfa_registered: bool
+    is_mfa_capable: bool
+    is_sspr_registered: bool
+    is_admin: bool = False
+    severity: str  # Critical, High, Medium, Low
+
+
+class EntraIDSecurityAnalyzerOutput(BaseToolOutput):
+    """Output schema for the Entra ID Security Analyzer tool"""
+
+    tenant_id: Optional[str] = None
+    total_users_scanned: int = 0
+    stale_accounts: List[StaleAccount] = Field(default_factory=list)
+    mfa_gaps: List[MfaGap] = Field(default_factory=list)
+    critical_issues: int = 0
+    high_issues: int = 0
+    medium_issues: int = 0
+    low_issues: int = 0
+    recommendations: List[str] = Field(default_factory=list)

--- a/open-security-tools/tests/unit/test_entra_id_security_analyzer.py
+++ b/open-security-tools/tests/unit/test_entra_id_security_analyzer.py
@@ -1,0 +1,162 @@
+"""Unit tests for the Entra ID Security Analyzer tool.
+
+Mocks the Microsoft Graph HTTP calls (token endpoint, /users with
+signInActivity, and /reports/authenticationMethods/userRegistrationDetails)
+so the tests run without real Entra ID credentials or network access.
+"""
+import asyncio
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("API_KEY", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+
+APP_DIR = Path(__file__).resolve().parents[2] / "app"
+TOOL_DIR = APP_DIR / "tools" / "entra_id_security_analyzer"
+
+sys.path.insert(0, str(APP_DIR))
+sys.path.insert(0, str(TOOL_DIR))
+
+import main as entra_main  # noqa: E402
+from schemas import EntraIDSecurityAnalyzerInput  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, status, payload):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeSession:
+    def __init__(self, post_response, get_responses):
+        self._post_response = post_response
+        self._get_responses = list(get_responses)
+        self._get_call_count = 0
+
+    def post(self, url, data=None, ssl=None):
+        return self._post_response
+
+    def get(self, url, headers=None, ssl=None):
+        response = self._get_responses[self._get_call_count]
+        self._get_call_count += 1
+        return response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _stale_iso(days_ago: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_missing_credentials_returns_failure():
+    for var in ("ENTRA_TENANT_ID", "ENTRA_CLIENT_ID", "ENTRA_CLIENT_SECRET"):
+        os.environ.pop(var, None)
+
+    data = EntraIDSecurityAnalyzerInput()
+    result = asyncio.run(entra_main.execute_tool(data))
+
+    assert result.success is False
+    assert "credentials" in result.error_message.lower()
+
+
+def test_execute_tool_flags_stale_accounts_and_mfa_gaps(monkeypatch):
+    token_response = FakeResponse(200, {"access_token": "fake-token"})
+
+    users_payload = {
+        "value": [
+            {
+                "userPrincipalName": "alice@contoso.com",
+                "displayName": "Alice",
+                "accountEnabled": True,
+                "signInActivity": {"lastSignInDateTime": _stale_iso(400)},
+            },
+            {
+                "userPrincipalName": "bob@contoso.com",
+                "displayName": "Bob",
+                "accountEnabled": True,
+                "signInActivity": {"lastSignInDateTime": _stale_iso(5)},
+            },
+        ]
+    }
+    registration_payload = {
+        "value": [
+            {
+                "userPrincipalName": "alice@contoso.com",
+                "isMfaRegistered": False,
+                "isMfaCapable": False,
+                "isSsprRegistered": False,
+                "isAdmin": True,
+            },
+            {
+                "userPrincipalName": "bob@contoso.com",
+                "isMfaRegistered": True,
+                "isMfaCapable": True,
+                "isSsprRegistered": True,
+                "isAdmin": False,
+            },
+        ]
+    }
+
+    get_responses = [
+        FakeResponse(200, users_payload),
+        FakeResponse(200, registration_payload),
+    ]
+    fake_session = FakeSession(token_response, get_responses)
+
+    monkeypatch.setattr(entra_main.aiohttp, "ClientSession", lambda timeout=None: fake_session)
+
+    data = EntraIDSecurityAnalyzerInput(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="client-secret",
+        stale_threshold_days=90,
+    )
+    result = asyncio.run(entra_main.execute_tool(data))
+
+    assert result.success is True
+    assert result.total_users_scanned == 2
+
+    assert len(result.stale_accounts) == 1
+    assert result.stale_accounts[0].user_principal_name == "alice@contoso.com"
+    assert result.stale_accounts[0].severity in {"Critical", "High", "Medium"}
+
+    assert len(result.mfa_gaps) == 1
+    assert result.mfa_gaps[0].user_principal_name == "alice@contoso.com"
+    assert result.mfa_gaps[0].is_admin is True
+    assert result.mfa_gaps[0].severity == "Critical"
+
+    assert result.critical_issues >= 1
+    assert any("MFA" in rec or "admin" in rec.lower() for rec in result.recommendations)
+
+
+def test_token_failure_is_reported(monkeypatch):
+    token_response = FakeResponse(401, {"error_description": "invalid_client"})
+    fake_session = FakeSession(token_response, [])
+
+    monkeypatch.setattr(entra_main.aiohttp, "ClientSession", lambda timeout=None: fake_session)
+
+    data = EntraIDSecurityAnalyzerInput(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="wrong-secret",
+    )
+    result = asyncio.run(entra_main.execute_tool(data))
+
+    assert result.success is False
+    assert "invalid_client" in result.error_message


### PR DESCRIPTION
feat(tools): add Entra ID security analyzer module

---

## What this does

Adds a new wildbox security tool, **Entra ID Security Analyzer**, under
`open-security-tools/app/tools/entra_id_security_analyzer/`. It connects to
Microsoft Graph using an app-registration's client-credentials flow and flags
two common identity-hygiene gaps in a Microsoft Entra ID (Azure AD) tenant:

- **Stale accounts** — enabled users with no sign-in activity within a
  configurable threshold (default 90 days), or no recorded sign-in at all.
- **MFA gaps** — enabled users not registered for multi-factor authentication,
  with privileged/admin accounts escalated to `Critical` severity.

Results come back as structured findings (per-account severity, recommendations,
issue counts) on the standard tool output schema.

## How it fits the existing architecture

It follows the established `open-security-tools` auto-discovery pattern exactly,
so no wiring/registration changes are needed — dropping the directory in is
enough:

```
entra_id_security_analyzer/
├── __init__.py
├── main.py      # execute_tool() + TOOL_INFO, async aiohttp HTTP
└── schemas.py   # Pydantic input/output extending BaseToolInput/BaseToolOutput
```

- Credentials resolve per-request **or** from `ENTRA_TENANT_ID` /
  `ENTRA_CLIENT_ID` / `ENTRA_CLIENT_SECRET` environment variables — the same
  `os.getenv` convention used by e.g. `malware_hash_checker`. Secrets are never
  echoed back in the output.
- Missing credentials and Graph/auth failures return a structured
  `success=False` output rather than raising, matching the other tools.

## Required Microsoft Graph permissions

The app registration needs these **application** permissions (admin consent
required):

- `User.Read.All`
- `AuditLog.Read.All`
- `Reports.Read.All`

## Tests

`open-security-tools/tests/unit/test_entra_id_security_analyzer.py` — 3 unit
tests that mock the Graph HTTP calls (token endpoint, `/users` with
`signInActivity`, and the MFA `userRegistrationDetails` report), so they run
with no real tenant or network access. Covers the happy path (stale + MFA-gap
detection and severity), the missing-credentials guard, and auth-failure
reporting.

```
3 passed
```
