### PR TITLE
test: add unit tests for cspm, data, responder and identity services

### DIFF
--- a/open-security-cspm/pytest.ini
+++ b/open-security-cspm/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Don't inherit the repo-root addopts (--html needs a plugin not installed in
+# the per-service unit-test job).
+addopts =
+testpaths = tests

--- a/open-security-cspm/tests/unit/test_utils.py
+++ b/open-security-cspm/tests/unit/test_utils.py
@@ -4,9 +4,14 @@ Pure-logic, no cloud credentials/DB/Redis needed. Locks in the compliance
 scoring and remediation-roadmap math so a refactor can't silently change
 what counts as "compliant" or how findings get prioritized.
 """
+import sys
+from pathlib import Path
+
 import pytest
 
-from app.utils import (
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from app.utils import (  # noqa: E402
     _calculate_compliance_score,
     _estimate_scan_duration,
     _generate_remediation_roadmap,

--- a/open-security-cspm/tests/unit/test_utils.py
+++ b/open-security-cspm/tests/unit/test_utils.py
@@ -1,0 +1,158 @@
+"""Unit tests for pure-logic CSPM scoring/summary helpers in app/utils.py.
+
+Pure-logic, no cloud credentials/DB/Redis needed. Locks in the compliance
+scoring and remediation-roadmap math so a refactor can't silently change
+what counts as "compliant" or how findings get prioritized.
+"""
+import pytest
+
+from app.utils import (
+    _calculate_compliance_score,
+    _estimate_scan_duration,
+    _generate_remediation_roadmap,
+    _get_resource_inventory_summary,
+)
+
+
+def test_calculate_compliance_score_empty_results_is_zero():
+    assert _calculate_compliance_score({"results": []}) == 0.0
+    assert _calculate_compliance_score({}) == 0.0
+
+
+def test_calculate_compliance_score_all_passed_is_100():
+    results = {"results": [{"status": "passed"}, {"status": "passed"}]}
+    assert _calculate_compliance_score(results) == 100.0
+
+
+def test_calculate_compliance_score_mixed_pass_fail():
+    results = {"results": [{"status": "passed"}, {"status": "failed"}, {"status": "passed"}]}
+    assert _calculate_compliance_score(results) == pytest.approx(66.67, abs=0.01)
+
+
+def test_calculate_compliance_score_excludes_unevaluated_statuses():
+    # skipped/errored/not-implemented checks should not count toward or
+    # against the score - only "passed"/"failed" verdicts are evaluated.
+    results = {
+        "results": [
+            {"status": "passed"},
+            {"status": "failed"},
+            {"status": "skipped"},
+            {"status": "error"},
+            {"status": "not_implemented"},
+        ]
+    }
+    assert _calculate_compliance_score(results) == 50.0
+
+
+def test_calculate_compliance_score_only_unevaluated_is_zero():
+    results = {"results": [{"status": "skipped"}, {"status": "error"}]}
+    assert _calculate_compliance_score(results) == 0.0
+
+
+@pytest.mark.parametrize("provider,expected", [
+    ("aws", 15),
+    ("AWS", 15),
+    ("gcp", 10),
+    ("azure", 12),
+    ("unknown", 15),
+])
+def test_estimate_scan_duration_base_by_provider(provider, expected):
+    assert _estimate_scan_duration(provider) == expected
+
+
+def test_estimate_scan_duration_scales_with_extra_regions():
+    base = _estimate_scan_duration("aws")
+    with_regions = _estimate_scan_duration("aws", regions=["us-east-1", "us-west-1", "eu-west-1", "ap-south-1"])
+    assert with_regions == base + 2  # one region beyond the 3 included
+
+
+def test_estimate_scan_duration_halves_for_specific_checks():
+    duration = _estimate_scan_duration("aws", check_ids=["AWS_S3_001"])
+    assert duration == max(5, 15 // 2)
+
+
+def test_estimate_scan_duration_floor_is_five_minutes():
+    duration = _estimate_scan_duration("gcp", check_ids=["GCP_CHECK_001"])
+    assert duration >= 5
+
+
+def test_resource_inventory_summary_empty():
+    summary = _get_resource_inventory_summary({"results": []})
+    assert summary["total_resources"] == 0
+    assert summary["resources_by_type"] == {}
+
+
+def test_resource_inventory_summary_counts_unique_resources_and_extracts_service():
+    scan_results = {
+        "results": [
+            {"resource_id": "bucket-1", "resource_type": "S3Bucket", "region": "us-east-1", "check_id": "AWS_S3_001"},
+            {"resource_id": "bucket-1", "resource_type": "S3Bucket", "region": "us-east-1", "check_id": "AWS_S3_002"},
+            {"resource_id": "vm-1", "resource_type": "EC2Instance", "region": "us-west-1", "check_id": "AWS_EC2_001"},
+        ]
+    }
+    summary = _get_resource_inventory_summary(scan_results)
+
+    assert summary["total_resources"] == 2  # bucket-1 counted once
+    assert summary["total_findings"] == 3
+    assert summary["resources_by_type"]["S3Bucket"] == 2
+    assert summary["resources_by_service"]["S3"] == 2
+    assert summary["resources_by_service"]["EC2"] == 1
+
+
+def test_remediation_roadmap_empty_results():
+    assert _generate_remediation_roadmap({"results": []}) == []
+
+
+def test_remediation_roadmap_groups_by_remediation_and_ranks_by_impact():
+    scan_results = {
+        "results": [
+            {
+                "status": "failed",
+                "remediation": "Enable encryption",
+                "resource_id": "bucket-1",
+                "resource_type": "S3Bucket",
+                "region": "us-east-1",
+                "check_id": "AWS_S3_001",
+                "compliance_frameworks": ["CIS"],
+            },
+            {
+                "status": "failed",
+                "remediation": "Enable encryption",
+                "resource_id": "bucket-2",
+                "resource_type": "S3Bucket",
+                "region": "us-east-1",
+                "check_id": "AWS_S3_001",
+                "compliance_frameworks": ["CIS", "NIST"],
+            },
+            {
+                "status": "failed",
+                "remediation": "Restrict security group",
+                "resource_id": "vm-1",
+                "resource_type": "EC2Instance",
+                "region": "us-west-1",
+                "check_id": "AWS_EC2_001",
+                "compliance_frameworks": [],
+            },
+            {
+                # passed findings should be excluded entirely
+                "status": "passed",
+                "remediation": "Enable encryption",
+                "resource_id": "bucket-3",
+                "resource_type": "S3Bucket",
+                "region": "us-east-1",
+                "check_id": "AWS_S3_001",
+            },
+        ]
+    }
+
+    roadmap = _generate_remediation_roadmap(scan_results)
+
+    assert len(roadmap) == 2
+    # The item affecting more resources (2 buckets) should be ranked first.
+    assert roadmap[0]["remediation"] == "Enable encryption"
+    assert len(roadmap[0]["affected_resources"]) == 2
+    assert set(roadmap[0]["compliance_impact"]) == {"CIS", "NIST"}
+    assert roadmap[0]["order"] == 1
+
+    assert roadmap[1]["remediation"] == "Restrict security group"
+    assert len(roadmap[1]["affected_resources"]) == 1

--- a/open-security-data/pytest.ini
+++ b/open-security-data/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Don't inherit the repo-root addopts (--html needs a plugin not installed in
+# the per-service unit-test job).
+addopts =
+testpaths = tests

--- a/open-security-data/tests/unit/test_normalizers.py
+++ b/open-security-data/tests/unit/test_normalizers.py
@@ -1,0 +1,189 @@
+"""Unit tests for the indicator normalization helpers.
+
+Pure-logic, no DB/service needed. Locks in the value-canonicalization rules
+that downstream dedup/fingerprinting (create_fingerprint) and tenancy-scoped
+querying rely on producing stable, comparable values.
+"""
+from datetime import datetime, timezone
+
+import pytest
+
+from app.utils.normalizers import (
+    create_fingerprint,
+    merge_indicators,
+    normalize_asn,
+    normalize_cve,
+    normalize_domain,
+    normalize_email,
+    normalize_file_hash,
+    normalize_indicator,
+    normalize_ip_address,
+    normalize_timestamp,
+    normalize_url,
+)
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("8.8.8.8", "8.8.8.8"),
+    (" 1.1.1.1 ", "1.1.1.1"),
+    ("::1", "::1"),
+])
+def test_normalize_ip_address_valid(value, expected):
+    assert normalize_ip_address(value) == expected
+
+
+def test_normalize_ip_address_invalid_passthrough():
+    # Not a parseable IP -> returned stripped, not raised
+    assert normalize_ip_address(" not-an-ip ") == "not-an-ip"
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("EXAMPLE.com", "example.com"),
+    ("https://Example.COM/path", "example.com"),
+    ("example.com.", "example.com"),
+    ("example.com:8080", "example.com"),
+])
+def test_normalize_domain(value, expected):
+    assert normalize_domain(value) == expected
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("example.com/path", "http://example.com/path"),
+    ("HTTP://Example.com:80/", "http://example.com/"),
+    ("https://Example.com:443/a", "https://example.com/a"),
+    ("https://example.com:8443/a", "https://example.com:8443/a"),
+])
+def test_normalize_url(value, expected):
+    assert normalize_url(value) == expected
+
+
+def test_normalize_file_hash_strips_known_prefix():
+    assert normalize_file_hash("SHA256:AABBCC") == "aabbcc"
+
+
+def test_normalize_file_hash_rejects_non_hex_passthrough():
+    original = " not-hex! "
+    assert normalize_file_hash(original) == original.strip()
+
+
+def test_normalize_email_lowercases_and_strips():
+    assert normalize_email(" User@Example.COM ") == "user@example.com"
+
+
+def test_normalize_asn_adds_prefix():
+    assert normalize_asn("15169") == "AS15169"
+    assert normalize_asn("as15169") == "AS15169"
+
+
+def test_normalize_cve_uppercases():
+    assert normalize_cve("cve-2024-12345") == "CVE-2024-12345"
+
+
+@pytest.mark.parametrize("raw,expected_year", [
+    ("2024-01-15T10:30:00Z", 2024),
+    ("2024-01-15 10:30:00", 2024),
+    ("2024-01-15", 2024),
+])
+def test_normalize_timestamp_parses_common_formats(raw, expected_year):
+    dt = normalize_timestamp(raw)
+    assert dt is not None
+    assert dt.year == expected_year
+    assert dt.tzinfo is not None
+
+
+def test_normalize_timestamp_handles_unix_epoch():
+    dt = normalize_timestamp("1700000000")
+    assert dt is not None
+    assert dt.tzinfo is not None
+
+
+def test_normalize_timestamp_returns_none_for_garbage():
+    assert normalize_timestamp("not-a-date") is None
+    assert normalize_timestamp("") is None
+
+
+def test_normalize_timestamp_naive_datetime_gets_utc():
+    naive = datetime(2024, 1, 1, 12, 0, 0)
+    result = normalize_timestamp(naive)
+    assert result.tzinfo == timezone.utc
+
+
+def test_normalize_indicator_domain_sets_value_and_normalized_value():
+    raw = {"indicator_type": "domain", "value": "HTTPS://Example.COM/x"}
+    result = normalize_indicator(raw)
+    assert result["normalized_value"] == "example.com"
+    assert result["value"] == "example.com"
+
+
+def test_normalize_indicator_ip_keeps_original_value_field():
+    # IP normalization only populates normalized_value, not value, per the
+    # normalizer dispatch table in normalize_indicator.
+    raw = {"indicator_type": "ip_address", "value": "8.8.8.8"}
+    result = normalize_indicator(raw)
+    assert result["normalized_value"] == "8.8.8.8"
+    assert result["value"] == "8.8.8.8"
+
+
+def test_normalize_indicator_defaults_severity_on_bad_value():
+    raw = {"indicator_type": "domain", "value": "example.com", "severity": "not-a-number"}
+    result = normalize_indicator(raw)
+    assert result["severity"] == 5
+
+
+def test_normalize_indicator_lowercases_tags_and_threat_types():
+    raw = {
+        "indicator_type": "domain",
+        "value": "example.com",
+        "tags": "Malware, C2",
+        "threat_types": ["Botnet", "Phishing"],
+    }
+    result = normalize_indicator(raw)
+    assert result["tags"] == ["malware", "c2"]
+    assert result["threat_types"] == ["botnet", "phishing"]
+
+
+def test_create_fingerprint_is_deterministic():
+    data = {"indicator_type": "domain", "normalized_value": "example.com", "source_id": "src-1"}
+    assert create_fingerprint(data) == create_fingerprint(dict(data))
+
+
+def test_create_fingerprint_differs_on_value_change():
+    base = {"indicator_type": "domain", "normalized_value": "example.com", "source_id": "src-1"}
+    other = {**base, "normalized_value": "other.com"}
+    assert create_fingerprint(base) != create_fingerprint(other)
+
+
+def test_merge_indicators_keeps_latest_last_seen_and_earliest_first_seen():
+    existing = {
+        "first_seen": "2024-01-10",
+        "last_seen": "2024-01-10",
+        "threat_types": ["botnet"],
+        "tags": ["a"],
+        "confidence": "low",
+        "severity": 3,
+    }
+    new = {
+        "first_seen": "2024-01-01",
+        "last_seen": "2024-02-01",
+        "threat_types": ["phishing"],
+        "tags": ["b"],
+        "confidence": "high",
+        "severity": 7,
+    }
+    merged = merge_indicators(existing, new)
+
+    assert merged["first_seen"] == normalize_timestamp("2024-01-01")
+    assert merged["last_seen"] == normalize_timestamp("2024-02-01")
+    assert set(merged["threat_types"]) == {"botnet", "phishing"}
+    assert set(merged["tags"]) == {"a", "b"}
+    assert merged["confidence"] == "high"
+    assert merged["severity"] == 7
+
+
+def test_merge_indicators_does_not_downgrade_confidence_or_severity():
+    existing = {"confidence": "high", "severity": 8}
+    new = {"confidence": "low", "severity": 2}
+    merged = merge_indicators(existing, new)
+
+    assert merged["confidence"] == "high"
+    assert merged["severity"] == 8

--- a/open-security-data/tests/unit/test_normalizers.py
+++ b/open-security-data/tests/unit/test_normalizers.py
@@ -4,11 +4,15 @@ Pure-logic, no DB/service needed. Locks in the value-canonicalization rules
 that downstream dedup/fingerprinting (create_fingerprint) and tenancy-scoped
 querying rely on producing stable, comparable values.
 """
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
-from app.utils.normalizers import (
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from app.utils.normalizers import (  # noqa: E402
     create_fingerprint,
     merge_indicators,
     normalize_asn,

--- a/open-security-identity/pytest.ini
+++ b/open-security-identity/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Don't inherit the repo-root addopts (--html needs a plugin not installed in
+# the per-service unit-test job).
+addopts =
+testpaths = tests

--- a/open-security-identity/tests/unit/test_auth_tokens.py
+++ b/open-security-identity/tests/unit/test_auth_tokens.py
@@ -1,0 +1,106 @@
+"""Unit tests for token/credential helpers in app/auth.py.
+
+Pure-logic, no DB needed - the existing tests/test_basic.py exercises full
+HTTP+Postgres flows and can't run in the unit-test matrix job (no DB
+service there), so this file covers the underlying JWT/API-key/password
+logic directly instead, per the migration guidance in #245.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+os.environ.setdefault("JWT_SECRET_KEY", "a" * 32)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from fastapi import HTTPException  # noqa: E402
+
+from app.auth import (  # noqa: E402
+    create_access_token,
+    generate_api_key,
+    get_password_hash,
+    hash_api_key,
+    verify_access_token,
+    verify_password,
+)
+
+
+def test_password_hash_roundtrip():
+    hashed = get_password_hash("correct horse battery staple")
+    assert verify_password("correct horse battery staple", hashed) is True
+
+
+def test_password_hash_rejects_wrong_password():
+    hashed = get_password_hash("correct horse battery staple")
+    assert verify_password("wrong password", hashed) is False
+
+
+def test_password_hash_is_not_plaintext():
+    password = "correct horse battery staple"
+    assert get_password_hash(password) != password
+
+
+def test_hash_api_key_is_deterministic():
+    assert hash_api_key("wsk_abcd.deadbeef") == hash_api_key("wsk_abcd.deadbeef")
+
+
+def test_hash_api_key_differs_per_key():
+    assert hash_api_key("wsk_abcd.aaa") != hash_api_key("wsk_abcd.bbb")
+
+
+def test_generate_api_key_has_expected_shape():
+    full_key, prefix, hashed_key = generate_api_key()
+
+    assert full_key.startswith("wsk_")
+    assert prefix.startswith("wsk_")
+    assert full_key.startswith(prefix + ".")
+    assert hashed_key == hash_api_key(full_key)
+
+
+def test_generate_api_key_is_unique_per_call():
+    first_key, _, _ = generate_api_key()
+    second_key, _, _ = generate_api_key()
+    assert first_key != second_key
+
+
+def test_create_and_verify_access_token_roundtrip():
+    token = create_access_token({"sub": "user-123", "aud": "fastapi-users:auth"})
+    payload = verify_access_token(token)
+
+    assert payload["sub"] == "user-123"
+    assert "jti" in payload
+    assert "exp" in payload
+
+
+def test_create_access_token_includes_unique_jti_each_call():
+    token_a = create_access_token({"sub": "user-123", "aud": "fastapi-users:auth"})
+    token_b = create_access_token({"sub": "user-123", "aud": "fastapi-users:auth"})
+
+    payload_a = verify_access_token(token_a)
+    payload_b = verify_access_token(token_b)
+    assert payload_a["jti"] != payload_b["jti"]
+
+
+def test_verify_access_token_rejects_garbage_token():
+    with pytest.raises(HTTPException) as exc_info:
+        verify_access_token("not-a-real-jwt")
+    assert exc_info.value.status_code == 401
+
+
+def test_verify_access_token_rejects_wrong_audience():
+    # The identity service's verifier pins audience="fastapi-users:auth";
+    # a token without that audience must be rejected, not silently accepted.
+    token = create_access_token({"sub": "user-123"})
+    with pytest.raises(HTTPException) as exc_info:
+        verify_access_token(token)
+    assert exc_info.value.status_code == 401
+
+
+def test_verify_access_token_rejects_tampered_signature():
+    token = create_access_token({"sub": "user-123", "aud": "fastapi-users:auth"})
+    tampered = token[:-4] + ("0" * 4 if token[-4:] != "0000" else "1111")
+    with pytest.raises(HTTPException):
+        verify_access_token(tampered)

--- a/open-security-responder/pytest.ini
+++ b/open-security-responder/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Don't inherit the repo-root addopts (--html needs a plugin not installed in
+# the per-service unit-test job).
+addopts =
+testpaths = tests

--- a/open-security-responder/tests/unit/test_workflow_engine_ownership.py
+++ b/open-security-responder/tests/unit/test_workflow_engine_ownership.py
@@ -1,0 +1,92 @@
+"""Unit tests for WorkflowEngine's run-owner (tenancy) key logic.
+
+Pure-logic, no live Redis needed - the engine's redis_client is swapped for
+an in-memory fake. Locks in the tenant-scoping behavior that gates whether a
+team can read/cancel another team's playbook run (set_run_owner /
+get_run_owner / is_run_owner in app/workflow_engine.py).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from app.workflow_engine import WorkflowEngine  # noqa: E402
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for the subset of redis-py used here."""
+
+    def __init__(self):
+        self.store = {}
+        self.expirations = {}
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def get(self, key):
+        value = self.store.get(key)
+        if value is None:
+            return None
+        # redis-py returns bytes by default; exercise that decode path.
+        return value.encode() if isinstance(value, str) else value
+
+    def expire(self, key, seconds):
+        self.expirations[key] = seconds
+
+
+@pytest.fixture
+def engine():
+    eng = WorkflowEngine()
+    eng.redis_client = FakeRedis()
+    return eng
+
+
+def test_get_run_owner_unknown_run_returns_none(engine):
+    assert engine.get_run_owner("missing-run") is None
+
+
+def test_set_then_get_run_owner_roundtrips(engine):
+    engine.set_run_owner("run-1", "team-42")
+    assert engine.get_run_owner("run-1") == "team-42"
+
+
+def test_set_run_owner_accepts_non_string_team_id(engine):
+    engine.set_run_owner("run-1", 42)
+    assert engine.get_run_owner("run-1") == "42"
+
+
+def test_is_run_owner_true_for_matching_team(engine):
+    engine.set_run_owner("run-1", "team-42")
+    assert engine.is_run_owner("run-1", "team-42") is True
+
+
+def test_is_run_owner_false_for_other_team(engine):
+    engine.set_run_owner("run-1", "team-42")
+    assert engine.is_run_owner("run-1", "team-99") is False
+
+
+def test_is_run_owner_false_for_unknown_run(engine):
+    # A run with no recorded owner must never be treated as owned - this is
+    # the fail-closed default that protects cross-tenant reads/cancels.
+    assert engine.is_run_owner("never-set", "team-42") is False
+
+
+def test_is_run_owner_compares_as_strings(engine):
+    engine.set_run_owner("run-1", 42)
+    assert engine.is_run_owner("run-1", "42") is True
+    assert engine.is_run_owner("run-1", 42) is True
+
+
+def test_set_run_owner_sets_expiration(engine):
+    engine.set_run_owner("run-1", "team-42")
+    key = engine._get_owner_key("run-1")
+    assert key in engine.redis_client.expirations
+    assert engine.redis_client.expirations[key] > 0
+
+
+def test_owner_key_is_distinct_from_execution_and_logs_keys(engine):
+    run_id = "run-1"
+    assert engine._get_owner_key(run_id) != engine._get_execution_key(run_id)
+    assert engine._get_owner_key(run_id) != engine._get_logs_key(run_id)


### PR DESCRIPTION
test: add unit tests for cspm, data, responder and identity services

---

## What this does

Closes #245 by adding **real, pure-logic unit tests** to the four services that
had a `tests/unit/` gap in the `Unit Tests` CI matrix. `tools` already had
`tests/unit/test_ssrf_guard.py`, so this PR covers the remaining four:

| Service | New test file | Tests | Covers |
|---------|---------------|-------|--------|
| **cspm** | `tests/unit/test_utils.py` | 17 | `_calculate_compliance_score` (only `passed`/`failed` count toward the score), `_estimate_scan_duration`, `_get_resource_inventory_summary`, `_generate_remediation_roadmap` ranking |
| **data** | `tests/unit/test_normalizers.py` | 31 | indicator value normalization (IP/domain/URL/hash/ASN/CVE), `normalize_timestamp` formats, `create_fingerprint` determinism, `merge_indicators` (no confidence/severity downgrade) |
| **responder** | `tests/unit/test_workflow_engine_ownership.py` | 9 | `WorkflowEngine` run-owner tenancy key logic (`set_run_owner` / `get_run_owner` / `is_run_owner`), fail-closed default for unknown runs — exercised against an in-memory fake Redis |
| **identity** | `tests/unit/test_auth_tokens.py` | 12 | `app/auth.py` JWT create/verify (including audience pinning + tampered-signature rejection), password hashing, API-key generation/hashing |

All four are **standalone**: no DB, Redis, or cloud credentials required, so they
run in the unit-test matrix job exactly as the issue asks.

## Why a `pytest.ini` per service (the important bit)

Each new `tests/unit/` directory ships its own minimal `pytest.ini` that empties
`addopts` and sets `testpaths = tests` — mirroring the one already present in
`open-security-tools`.

This is necessary, not cosmetic: the **repo-root `pytest.ini`** puts
`--html=tests/integration/reports/report.html` in `addopts`, which requires the
`pytest-html` plugin. None of these four services install that plugin. Without
the per-service override, the moment a `tests/unit/` directory appears the
matrix job would flip from *"no tests, skipped with a visible `::warning::`"* to
*"pytest fails to start with `unrecognized arguments: --html`"* — i.e. the gate
would go red for the wrong reason. The override keeps each service's unit job
self-contained.

## Notes for review

- **identity**: I did **not** move the existing `tests/test_basic.py` into
  `tests/unit/`. That file drives full HTTP + Postgres flows
  (`postgresql+asyncpg://…/identity_test`) and can't run in the credential-free
  matrix job. Per the issue's suggestion ("…or add focused token/role tests"),
  I added direct unit tests for the underlying auth helpers instead, leaving
  `test_basic.py` untouched.
- No production code was changed — this PR is tests + the four `pytest.ini`
  overrides only.

## How I verified

Ran each suite locally against the real service `app` package:

```
cspm       17 passed
data       31 passed
responder   9 passed
identity   12 passed
```
