### PR TITLE
ci: make "make test" truthful — stop swallowing test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ health:
 
 test:
 	@echo "$(BLUE)Running integration tests...$(NC)"
-	@docker-compose exec -T identity pytest tests/ || true
-	@docker-compose exec -T guardian python manage.py test || true
+	@docker-compose exec -T identity pytest tests/
+	@docker-compose exec -T guardian python manage.py test
 	@echo "$(GREEN)✓ Tests complete$(NC)"
 
 clean:


### PR DESCRIPTION
## What this does

Sprint 3 (CI truth) follow-up, item A2 of the plan: the `test:` target in the root `Makefile` ran both suites with `|| true`, so `make test` always exited 0 and printed "✓ Tests complete" even when the identity or guardian suites failed — the same vacuous-green class fixed in the CI matrix (#245 / #247).

```diff
-	@docker-compose exec -T identity pytest tests/ || true
-	@docker-compose exec -T guardian python manage.py test || true
+	@docker-compose exec -T identity pytest tests/
+	@docker-compose exec -T guardian python manage.py test
```

With the suppression gone, make stops on the first failing suite and propagates its exit code, and the success message only prints when both suites actually passed. No behavior change on the green path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)