### PR TITLE
ci: unblock fork/dependabot PRs — CI-only fallbacks for secret-less Integration Tests runs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,16 +13,26 @@ env:
   # SECURITY: All secrets sourced from GitHub Secrets.
   # Configure these in repo Settings > Secrets and variables > Actions.
   # For initial setup, generate random values with: openssl rand -hex 32
-  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-  API_KEY: ${{ secrets.API_KEY }}
-  POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-  DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/identity
+  #
+  # Every reference carries a `|| 'ci-fallback-...'` default: fork PRs and
+  # dependabot runs never receive repo Actions secrets, so without a fallback
+  # this job fails deterministically for every external contribution (empty
+  # JWT_SECRET_KEY fails identity's min_length=32 validation during alembic
+  # migrations — same class as the POSTGRES_HOST_AUTH_METHOD: trust
+  # accommodation below). The stack is ephemeral CI-only, like the hardcoded
+  # test SECRET_KEYs already used for the data/cspm services. Fallbacks meet
+  # the services' validators: >=32 chars, and tools' API_KEY must not contain
+  # password/secret/key/admin/test/demo/123/abc/default/wildbox/api-key.
+  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY || 'ci-fallback-jwt-signing-string-for-fork-runs' }}
+  API_KEY: ${{ secrets.API_KEY || 'ci-fallback-tools-auth-value-for-fork-runs' }}
+  POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD || 'ci-fallback-postgres-pw' }}
+  DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD || 'ci-fallback-postgres-pw' }}@postgres:5432/identity
   REDIS_URL: redis://redis:6379/0
-  GATEWAY_INTERNAL_SECRET: ${{ secrets.GATEWAY_INTERNAL_SECRET }}
+  GATEWAY_INTERNAL_SECRET: ${{ secrets.GATEWAY_INTERNAL_SECRET || 'ci-fallback-gateway-proof-of-origin-value' }}
   N8N_BASIC_AUTH_USER: admin
-  N8N_BASIC_AUTH_PASSWORD: ${{ secrets.N8N_BASIC_AUTH_PASSWORD }}
-  GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
-  NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+  N8N_BASIC_AUTH_PASSWORD: ${{ secrets.N8N_BASIC_AUTH_PASSWORD || 'ci-fallback-n8n-pw' }}
+  GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD || 'ci-fallback-grafana-pw' }}
+  NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'ci-fallback-nextauth-string-for-fork-runs' }}
 
 jobs:
   integration-tests:
@@ -35,7 +45,7 @@ jobs:
         image: postgres:15
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD || 'ci-fallback-postgres-pw' }}
           POSTGRES_DB: identity
           # Allow startup even when the secret is empty (e.g. fork PRs from the
           # fabgpt bot, which never receive repo secrets). Ephemeral CI DB only.
@@ -107,7 +117,7 @@ jobs:
           cd open-security-identity
           alembic upgrade head
         env:
-          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
+          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD || 'ci-fallback-postgres-pw' }}@localhost:5432/identity
 
       - name: Start Identity Service
         run: |
@@ -116,9 +126,9 @@ jobs:
           IDENTITY_PID=$!
           echo "IDENTITY_PID=$IDENTITY_PID" >> $GITHUB_ENV
         env:
-          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
+          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.POSTGRES_PASSWORD || 'ci-fallback-postgres-pw' }}@localhost:5432/identity
           REDIS_URL: redis://localhost:6379/0
-          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY || 'ci-fallback-jwt-signing-string-for-fork-runs' }}
           CREATE_INITIAL_ADMIN: "false"
 
       - name: Install Tools Service Dependencies
@@ -134,7 +144,7 @@ jobs:
           TOOLS_PID=$!
           echo "TOOLS_PID=$TOOLS_PID" >> $GITHUB_ENV
         env:
-          API_KEY: ${{ secrets.API_KEY }}
+          API_KEY: ${{ secrets.API_KEY || 'ci-fallback-tools-auth-value-for-fork-runs' }}
           REDIS_URL: redis://localhost:6379/2
 
       - name: Install Data Service Dependencies
@@ -158,7 +168,7 @@ jobs:
         env:
           # Reuse the postgres "identity" database in CI (no separate DB needed);
           # data's create_tables() lifespan hook adds its own tables on startup.
-          DATABASE_URL: postgresql://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
+          DATABASE_URL: postgresql://postgres:${{ secrets.POSTGRES_PASSWORD || 'ci-fallback-postgres-pw' }}@localhost:5432/identity
           REDIS_URL: redis://localhost:6379/1
           SECRET_KEY: test-secret-key-for-ci-only
           ENVIRONMENT: test
@@ -238,8 +248,8 @@ jobs:
           CSPM_SERVICE_URL: http://localhost:8019
           # psycopg2 DSN for the data DB, used to seed the cross-tenant test
           # (data has no create API). Same DB the data service runs against.
-          DATA_DB_DSN: postgresql://postgres:${{ secrets.POSTGRES_PASSWORD }}@localhost:5432/identity
-          TEST_API_KEY: ${{ secrets.API_KEY }}
+          DATA_DB_DSN: postgresql://postgres:${{ secrets.POSTGRES_PASSWORD || 'ci-fallback-postgres-pw' }}@localhost:5432/identity
+          TEST_API_KEY: ${{ secrets.API_KEY || 'ci-fallback-tools-auth-value-for-fork-runs' }}
         timeout-minutes: 10
 
       - name: Dump CSPM logs on failure


### PR DESCRIPTION
## What this does

**Every fork PR and every dependabot PR currently fails the required `Run Integration Tests` check deterministically**, because those runs never receive repo Actions secrets: `JWT_SECRET_KEY` evaluates to `""` and fails identity's `min_length=32` pydantic validation when `alembic/env.py` imports `app.config` during `alembic upgrade head`. Verified on PR #249 (run 28477566334, identical failure on re-run) and on every dependabot PR (log shows `Secret source: Dependabot` / `None`); the same job is green on pushes to main and same-repo PRs.

This gives every `secrets.*` reference in `integration-tests.yml` a readable `ci-fallback-*` default — the same accommodation the workflow already makes with `POSTGRES_HOST_AUTH_METHOD: trust` and the hardcoded `test-secret-key-for-ci-only` values for the data/cspm services. The stack is ephemeral CI-only.

Fallbacks satisfy the service validators:
- identity `jwt_secret_key`: ≥32 chars ✓
- tools `api_key`: ≥32 chars and none of the weak substrings (`password/secret/key/admin/test/demo/123/abc/default/wildbox/api-key`) ✓
- consistent per-secret literal everywhere (service container, DSNs, `TEST_API_KEY`), so intra-run auth stays coherent ✓

Runs with real secrets configured are unaffected (`||` only kicks in when the secret is empty).

## Why it matters
This is the single blocker preventing green CI on all 37 open dependabot PRs and on external contributions (#249, #250). Note: fork PRs may additionally be blocked by the required `CodeQL` context never reporting on fork head SHAs — that is a branch-protection matter, not fixable in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)