### PR TITLE
privacy: /privacy notice + footer link + meta-CSP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'">
     <title>Wildbox — Open-Source Security Operations Platform</title>
     <meta name="description" content="Self-hosted, open-source security operations platform: threat intelligence, cloud security (CSPM), vulnerability management, automated response, and LLM analysis. MIT licensed.">
     <meta name="keywords" content="security operations, CSPM, threat intelligence, vulnerability management, SOAR, open-source security, self-hosted, SOC">
@@ -352,6 +353,7 @@
                         <li><a href="https://github.com/fabriziosalmi/wildbox/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="nav-link">MIT License</a></li>
                         <li><a href="https://github.com/fabriziosalmi/wildbox/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer" class="nav-link">Security policy</a></li>
                         <li><a href="https://github.com/fabriziosalmi/wildbox/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="nav-link">Contributing</a></li>
+                        <li><a href="/privacy.html" class="nav-link">Privacy &amp; legal</a></li>
                     </ul>
                 </div>
             </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'self'">
+    <meta name="robots" content="noindex, follow">
+    <title>Privacy &amp; Legal Notice — Wildbox</title>
+    <style>
+        :root { color-scheme: light dark; --bg:#fff; --fg:#16181d; --muted:#666; --accent:#0a7d5a; --border:#e6e6e6; --code:#f2f2f2; }
+        @media (prefers-color-scheme: dark){ :root{ --bg:#0b0d10; --fg:#e6edf3; --muted:#9aa4ad; --accent:#3ddc97; --border:#1e2228; --code:#14171c; } }
+        *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;line-height:1.6;font-size:16px}
+        .wrap{max-width:760px;margin:0 auto;padding:2.5rem 1.25rem 4rem}
+        h1{font-size:1.8rem;margin:0 0 .25rem} h2{font-size:1.15rem;margin:2.25rem 0 .5rem;color:var(--accent);border-bottom:1px solid var(--border);padding-bottom:.3rem}
+        .lang-label{font-size:.7rem;text-transform:uppercase;letter-spacing:2px;color:var(--accent);margin:3rem 0 0}
+        .updated{color:var(--muted);font-size:.85rem;margin:0 0 1.5rem}
+        a{color:var(--accent)} code{background:var(--code);padding:.1rem .35rem;border-radius:3px;font-size:.85em}
+        ul{padding-left:1.25rem} li{margin:.35rem 0}
+        .home{display:inline-block;margin-bottom:2rem;color:var(--muted);text-decoration:none;font-size:.85rem}
+        hr{border:0;border-top:1px solid var(--border);margin:3rem 0 0} .muted{color:var(--muted);font-size:.85rem}
+    </style>
+</head>
+<body>
+<div class="wrap">
+    <a class="home" href="/">← wildbox.io</a>
+    <h1>Privacy &amp; Legal Notice</h1>
+    <p class="updated">Last updated: 20 July 2026 · wildbox.io</p>
+
+    <p class="lang-label">English</p>
+    <h2>Data controller</h2>
+    <p><strong>Fabrizio Salmi</strong> — Genoa, Italy. wildbox.io is the website of the open-source, MIT-licensed Wildbox project (personal, non-commercial). Contact: <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a>.</p>
+    <h2>What we process, and why</h2>
+    <ul>
+        <li><strong>Your IP and basic request data</strong> are processed transiently by our infrastructure providers to deliver the page and protect it against abuse. Legal basis: legitimate interest (Art. 6(1)(f) GDPR). We do not store this data.</li>
+        <li><strong>No analytics</strong>, no tracking pixels, no advertising — first- or third-party.</li>
+        <li><strong>No accounts, no forms, no newsletter</strong> on this marketing site.</li>
+    </ul>
+    <h2>Cookies &amp; device storage</h2>
+    <p>This site sets <strong>no cookies</strong> and stores <strong>nothing</strong> on your device. No cookie-consent banner is required.</p>
+    <h2>Processors &amp; international transfers</h2>
+    <ul>
+        <li><strong>GitHub, Inc.</strong> (USA) — static hosting (GitHub Pages).</li>
+        <li><strong>Cloudflare, Inc.</strong> (USA) — CDN, HTTPS and edge security.</li>
+    </ul>
+    <p>Serving the site transfers technical data (such as your IP) to the USA, covered by the providers' DPAs and the EU–US Data Privacy Framework / Standard Contractual Clauses.</p>
+    <h2>Your rights</h2>
+    <p>Access, rectification, erasure, restriction, objection, portability (Arts. 15–22 GDPR) — email <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a>. You may complain to the <a href="https://www.garanteprivacy.it" target="_blank" rel="noopener">Garante per la protezione dei dati personali</a>. No profiling, no automated decision-making.</p>
+
+    <p class="lang-label">Italiano</p>
+    <h2>Titolare del trattamento</h2>
+    <p><strong>Fabrizio Salmi</strong> — Genova, Italia. wildbox.io è il sito del progetto open-source Wildbox (licenza MIT; personale, non commerciale). Contatto: <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a>.</p>
+    <h2>Quali dati trattiamo e perché</h2>
+    <ul>
+        <li><strong>IP e dati basilari della richiesta</strong> trattati in modo transitorio dai fornitori di infrastruttura per erogare e proteggere la pagina. Base giuridica: legittimo interesse (art. 6(1)(f) GDPR). Non conserviamo questi dati.</li>
+        <li><strong>Nessuna analitica</strong>, nessun pixel, nessuna pubblicità.</li>
+        <li><strong>Nessun account, modulo o newsletter.</strong></li>
+    </ul>
+    <h2>Cookie e memoria del dispositivo</h2>
+    <p>Il sito <strong>non imposta cookie</strong> e <strong>non memorizza nulla</strong> sul dispositivo. Nessun banner di consenso richiesto.</p>
+    <h2>Responsabili e trasferimenti extra-UE</h2>
+    <ul>
+        <li><strong>GitHub, Inc.</strong> (USA) — hosting statico (GitHub Pages).</li>
+        <li><strong>Cloudflare, Inc.</strong> (USA) — CDN, HTTPS e sicurezza edge.</li>
+    </ul>
+    <p>L'erogazione trasferisce dati tecnici (come l'IP) verso gli USA, coperti dagli accordi sul trattamento e dal Data Privacy Framework UE–USA / SCC.</p>
+    <h2>I tuoi diritti</h2>
+    <p>Accesso, rettifica, cancellazione, limitazione, opposizione, portabilità (artt. 15–22 GDPR) — <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a>. Reclamo al <a href="https://www.garanteprivacy.it" target="_blank" rel="noopener">Garante</a>. Nessuna profilazione.</p>
+
+    <hr>
+    <p class="muted">Publisher / Titolare: Fabrizio Salmi — Genoa, Italy — <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a></p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds the privacy/legal layer to wildbox.io (playbook §5/§6/§9). Site was already cookieless, no analytics, self-hosted assets (incl. Tailwind).

- **docs/privacy.html** (new): bilingual EN/IT — controller *Fabrizio Salmi*, processors *GitHub + Cloudflare (US)*, no cookies/storage, rights + Garante.
- **docs/index.html**: `Privacy & legal` link in the footer Legal column · meta-CSP `default-src 'self'`.

Verified locally: full Tailwind render intact, **no CSP console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)