### PR TITLE
privacy: correct the processor list (Cloudflare not involved)

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -40,7 +40,7 @@
     <h2>Processors &amp; international transfers</h2>
     <ul>
         <li><strong>GitHub, Inc.</strong> (USA) — static hosting (GitHub Pages).</li>
-        <li><strong>Cloudflare, Inc.</strong> (USA) — CDN, HTTPS and edge security.</li>
+        <li><strong>Name.com, Inc.</strong> (USA) — domain registration and authoritative DNS only; it does not serve this site's content.</li>
     </ul>
     <p>Serving the site transfers technical data (such as your IP) to the USA, covered by the providers' DPAs and the EU–US Data Privacy Framework / Standard Contractual Clauses.</p>
     <h2>Your rights</h2>
@@ -60,7 +60,7 @@
     <h2>Responsabili e trasferimenti extra-UE</h2>
     <ul>
         <li><strong>GitHub, Inc.</strong> (USA) — hosting statico (GitHub Pages).</li>
-        <li><strong>Cloudflare, Inc.</strong> (USA) — CDN, HTTPS e sicurezza edge.</li>
+        <li><strong>Name.com, Inc.</strong> (USA) — registrazione del dominio e DNS autoritativo; non eroga i contenuti di questo sito.</li>
     </ul>
     <p>L'erogazione trasferisce dati tecnici (come l'IP) verso gli USA, coperti dagli accordi sul trattamento e dal Data Privacy Framework UE–USA / SCC.</p>
     <h2>I tuoi diritti</h2>


### PR DESCRIPTION
Follow-up accuracy fix to the privacy notice.

**Finding:** `wildbox.io` is served **directly by GitHub Pages** (`server: GitHub.com`) and its nameservers are **name.com** — Cloudflare is **not involved at all**. The notice listed "Cloudflare, Inc. — CDN, HTTPS and edge security", which was simply wrong.

**Fix:** replaced with *"Name.com, Inc. (USA) — domain registration and authoritative DNS only; it does not serve this site's content"* (EN + IT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)