### PR TITLE
Remove unused import and fix type hint for session parameter

### DIFF
--- a/open-security-cspm/app/checks/azure/batch/check_certificate_encryption.py
+++ b/open-security-cspm/app/checks/azure/batch/check_certificate_encryption.py
@@ -4,7 +4,7 @@ AZURE BATCH Check: Batch Certificate Encryption
 
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.resource import ResourceManagementClient
-from typing import List, Any, Optional
+from typing import List, Optional
 import logging
 
 from ...framework import (
@@ -42,7 +42,7 @@ class CheckBatchCertificateEncryption(BaseCheck):
                        "4. Validate and apply changes."
         )
     
-    async def execute(self, session: Any, region: Optional[str] = None) -> List[CheckResult]:
+    async def execute(self, session: Optional[ResourceManagementClient], region: Optional[str] = None) -> List[CheckResult]:
         """Execute the batch certificate encryption check."""
         results = []
         


### PR DESCRIPTION
### FabGPT — code quality

**File:** `open-security-cspm/app/checks/azure/batch/check_certificate_encryption.py`

**Rationale:** The `Any` type hint for the `session` parameter violates project rule #5 (No `any` in TS/Python type hints), reducing type safety and maintainability. Additionally, the unused `typing.Any` import is dead code. Replacing `Any` with `Optional[ResourceManagementClient]` better reflects the intended usage and improves clarity.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `c5f56b1803414881` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"c5f56b1803414881","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":5.31,"prompt_sha":"0f5a8484c8b9e4bc","triage":"INFO"} -->