### PR TITLE
ci: gateway auth-logic tests + Lua lint (#108)

### DIFF
--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -1,0 +1,90 @@
+name: Gateway Tests
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lua-lint:
+    name: Gateway Lua Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install luacheck
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq luacheck
+
+      - name: Run luacheck on gateway Lua modules
+        working-directory: open-security-gateway
+        run: luacheck nginx/lua --codes
+
+  auth-tests:
+    name: Gateway Auth Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Ephemeral CI-only proof-of-origin value shared by the mock identity
+      # and the correctly-configured gateway; gateway-wrong-secret gets a
+      # different one to prove the rejection path (#133/#134).
+      CI_GATEWAY_SECRET: ci-gateway-proof-of-origin-fixture-value
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Build gateway test image
+        run: docker build -f open-security-gateway/Dockerfile.test -t wildbox-gateway-test open-security-gateway
+
+      - name: Start mock identity and gateways
+        run: |
+          docker network create gwtest
+          docker run -d --name identity-test --network gwtest -p 8001:8001 \
+            -e EXPECTED_GATEWAY_SECRET="$CI_GATEWAY_SECRET" \
+            -v "$PWD/open-security-gateway/test/mock_identity.py:/mock_identity.py:ro" \
+            python:3.12-alpine python /mock_identity.py
+          docker run -d --name gateway --network gwtest -p 8080:80 \
+            -e GATEWAY_INTERNAL_SECRET="$CI_GATEWAY_SECRET" \
+            -e IDENTITY_SERVICE_URL=http://identity-test:8001 \
+            wildbox-gateway-test
+          docker run -d --name gateway-wrong-secret --network gwtest -p 8081:80 \
+            -e GATEWAY_INTERNAL_SECRET=not-the-right-proof-of-origin \
+            -e IDENTITY_SERVICE_URL=http://identity-test:8001 \
+            wildbox-gateway-test
+
+      - name: Wait for services
+        run: |
+          for url in http://localhost:8001/health http://localhost:8080/health http://localhost:8081/health; do
+            for i in $(seq 1 30); do
+              if curl -fsS "$url" >/dev/null 2>&1; then
+                echo "$url ready"
+                break
+              fi
+              if [ "$i" = 30 ]; then
+                echo "$url never became ready"
+                exit 1
+              fi
+              sleep 2
+            done
+          done
+
+      - name: Run gateway auth tests
+        run: bash open-security-gateway/test/ci_auth_tests.sh
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "===== gateway ====="
+          docker logs gateway 2>&1 | tail -100 || true
+          echo "===== gateway-wrong-secret ====="
+          docker logs gateway-wrong-secret 2>&1 | tail -50 || true
+          echo "===== identity-test ====="
+          docker logs identity-test 2>&1 | tail -50 || true

--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -10,25 +10,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# NOTE: Lua linting (luacheck + .luacheckrc) lives in gateway-lint.yml
+# (PR #258) — this workflow covers the behavioral auth tests only, so the
+# two PRs stay orthogonal and mergeable in either order.
 jobs:
-  lua-lint:
-    name: Gateway Lua Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Install luacheck
-        run: |
-          sudo apt-get update -qq
-          # Ubuntu packages the luacheck binary as "lua-check"
-          sudo apt-get install -y -qq lua-check
-
-      - name: Run luacheck on gateway Lua modules
-        working-directory: open-security-gateway
-        run: luacheck nginx/lua --codes
-
   auth-tests:
     name: Gateway Auth Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install luacheck
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq luacheck
+          # Ubuntu packages the luacheck binary as "lua-check"
+          sudo apt-get install -y -qq lua-check
 
       - name: Run luacheck on gateway Lua modules
         working-directory: open-security-gateway

--- a/open-security-gateway/.luacheckrc
+++ b/open-security-gateway/.luacheckrc
@@ -1,6 +1,0 @@
--- Luacheck configuration for the gateway's OpenResty Lua modules
--- (invoked from CI as: luacheck nginx/lua --codes).
-std = "ngx_lua"
-
-
-max_line_length = false

--- a/open-security-gateway/.luacheckrc
+++ b/open-security-gateway/.luacheckrc
@@ -1,0 +1,6 @@
+-- Luacheck configuration for the gateway's OpenResty Lua modules
+-- (invoked from CI as: luacheck nginx/lua --codes).
+std = "ngx_lua"
+
+
+max_line_length = false

--- a/open-security-gateway/Dockerfile.test
+++ b/open-security-gateway/Dockerfile.test
@@ -5,6 +5,12 @@ RUN apk add --no-cache curl wget && \
     mkdir -p /var/cache/nginx/wildbox_cache /var/log/nginx && \
     chmod 755 /var/cache/nginx/wildbox_cache /var/log/nginx
 
+# nginx.conf declares `user nginx;` — without this user the master process
+# fails to boot with getpwnam("nginx") failed (the production Dockerfile
+# creates it too; the openresty:alpine base image does not ship one).
+RUN adduser -D -s /bin/sh nginx && \
+    chown -R nginx:nginx /var/log/nginx /var/cache/nginx
+
 # Install lua-resty-http (required by auth_handler.lua)
 RUN cd /usr/local/openresty/lualib/resty \
     && wget -O http.lua https://raw.githubusercontent.com/ledgetech/lua-resty-http/v0.17.2/lib/resty/http.lua \

--- a/open-security-gateway/nginx/lua/auth_handler.lua
+++ b/open-security-gateway/nginx/lua/auth_handler.lua
@@ -2,13 +2,11 @@
 -- Phase 1 Blueprint Implementation: Enhanced security, performance, and error handling
 
 local utils = require "utils"
-local cjson = require "cjson"
 
 local _M = {}
 
 -- Configuration constants (Blueprint Phase 1 - Remove hardcoded values)
 local CACHE_TTL = 300 -- 5 minutes as per blueprint
-local MAX_RETRIES = 3
 local TIMEOUT_SECONDS = 5
 local CIRCUIT_BREAKER_THRESHOLD = 10
 local CIRCUIT_BREAKER_TIMEOUT = 60
@@ -21,7 +19,7 @@ local RATE_LIMIT_PER_HOUR = 1000000
 -- Get gateway configuration from environment variables
 local function get_config()
     local config_cache = ngx.shared.config_cache
-    
+
     -- Handle case where shared dict is not available
     if not config_cache then
         utils.log("error", "config_cache shared dictionary not available")
@@ -33,9 +31,9 @@ local function get_config()
             debug_mode = os.getenv("GATEWAY_DEBUG") == "true"
         }
     end
-    
+
     local config_json = config_cache:get("gateway_config")
-    
+
     if not config_json then
         -- Build config from environment variables (Blueprint security requirement)
         local config = {
@@ -44,21 +42,21 @@ local function get_config()
             cache_ttl = tonumber(os.getenv("AUTH_CACHE_TTL")) or CACHE_TTL,
             debug_mode = os.getenv("GATEWAY_DEBUG") == "true"
         }
-        
+
         -- Cache config for 1 hour
         config_json = utils.json_encode(config)
         config_cache:set("gateway_config", config_json, 3600)
-        
+
         utils.log("info", "Gateway configuration loaded from environment")
         return config
     end
-    
+
     local config, err = utils.json_decode(config_json)
     if err then
         utils.log("error", "Failed to decode gateway config", {error = err})
         return nil
     end
-    
+
     return config
 end
 
@@ -67,11 +65,11 @@ local function check_circuit_breaker()
     local circuit_cache = ngx.shared.auth_cache
     local failures_key = "circuit_breaker:failures"
     local last_failure_key = "circuit_breaker:last_failure"
-    
+
     local failures = circuit_cache:get(failures_key) or 0
     local last_failure = circuit_cache:get(last_failure_key) or 0
     local now = ngx.time()
-    
+
     -- Circuit open - too many failures
     if failures >= CIRCUIT_BREAKER_THRESHOLD then
         if now - last_failure < CIRCUIT_BREAKER_TIMEOUT then
@@ -87,7 +85,7 @@ local function check_circuit_breaker()
             utils.log("info", "Circuit breaker RESET - attempting identity service call")
         end
     end
-    
+
     return true
 end
 
@@ -96,11 +94,11 @@ local function record_circuit_breaker_failure()
     local circuit_cache = ngx.shared.auth_cache
     local failures_key = "circuit_breaker:failures"
     local last_failure_key = "circuit_breaker:last_failure"
-    
+
     local failures = (circuit_cache:get(failures_key) or 0) + 1
     circuit_cache:set(failures_key, failures, CIRCUIT_BREAKER_TIMEOUT)
     circuit_cache:set(last_failure_key, ngx.time(), CIRCUIT_BREAKER_TIMEOUT)
-    
+
     utils.log("warn", "Circuit breaker failure recorded", {failures = failures})
 end
 
@@ -110,9 +108,9 @@ local function validate_token_with_identity(token, token_type, config)
     if not check_circuit_breaker() then
         return nil, "circuit_breaker_open"
     end
-    
+
     local url = config.identity_service_url .. "/internal/authorize"
-    
+
     local request_body = {
         token = token,
         token_type = token_type,
@@ -122,15 +120,15 @@ local function validate_token_with_identity(token, token_type, config)
         user_agent = ngx.var.http_user_agent,
         timestamp = ngx.time()
     }
-    
+
     utils.log("debug", "Calling identity service for token validation", {
         url = url,
         token_type = token_type,
         path = ngx.var.uri
     })
-    
+
     local start_time = ngx.now()
-    
+
     local res, err = utils.http_request("POST", url, {
         body = request_body,
         headers = {
@@ -140,9 +138,9 @@ local function validate_token_with_identity(token, token_type, config)
         },
         timeout = TIMEOUT_SECONDS * 1000 -- Convert to milliseconds
     })
-    
+
     local duration = (ngx.now() - start_time) * 1000
-    
+
     if err then
         utils.log("error", "Failed to call identity service", {
             error = err,
@@ -152,7 +150,7 @@ local function validate_token_with_identity(token, token_type, config)
         record_circuit_breaker_failure()
         return nil, "identity_service_error"
     end
-    
+
     if res.status == 200 then
         local auth_data, decode_err = utils.json_decode(res.body)
         if decode_err then
@@ -162,17 +160,17 @@ local function validate_token_with_identity(token, token_type, config)
             })
             return nil, "invalid_response"
         end
-        
+
         -- Add metadata
         auth_data.validated_at = ngx.time()
         auth_data.response_time_ms = duration
-        
+
         utils.log("debug", "Token validation successful", {
             user_id = auth_data.user_id,
             team_id = auth_data.team_id,
             duration_ms = duration
         })
-        
+
         return auth_data, nil
     elseif res.status == 401 then
         utils.log("debug", "Token validation failed - unauthorized")
@@ -195,10 +193,10 @@ local function validate_token_with_identity(token, token_type, config)
 end
 
 -- Improved cache operations with TTL (Blueprint requirement: 1-5 minute TTL)
-local function get_cached_auth_data(cache_key, config)
+local function get_cached_auth_data(cache_key)
     local auth_cache = ngx.shared.auth_cache
     local cached_data = auth_cache:get(cache_key)
-    
+
     if cached_data then
         local auth_data, err = utils.json_decode(cached_data)
         if not err then
@@ -217,7 +215,7 @@ local function get_cached_auth_data(cache_key, config)
             end
         end
     end
-    
+
     return nil, "cache_miss"
 end
 
@@ -225,14 +223,14 @@ end
 local function set_cached_auth_data(cache_key, auth_data, config)
     local auth_cache = ngx.shared.auth_cache
     local ttl = config.cache_ttl or CACHE_TTL
-    
+
     -- Set expiration time
     auth_data.expires_at = ngx.time() + ttl
     auth_data.cache_hit = false
-    
+
     local cached_data = utils.json_encode(auth_data)
     local success, err = auth_cache:set(cache_key, cached_data, ttl)
-    
+
     if not success then
         utils.log("warn", "Failed to cache auth data", {error = err})
     else
@@ -255,18 +253,18 @@ local function apply_rate_limiting(auth_data)
     local rate_cache = ngx.shared.rate_limit_cache
     local key = "rate:" .. team_id
     local now = ngx.time()
-    
+
     -- Get current request timestamps
     local current_data = rate_cache:get(key)
     local requests = {}
-    
+
     if current_data then
         local decoded_data, err = utils.json_decode(current_data)
         if not err and decoded_data.requests then
             requests = decoded_data.requests
         end
     end
-    
+
     -- Remove requests outside the sliding window
     local filtered_requests = {}
     for _, timestamp in ipairs(requests) do
@@ -274,14 +272,14 @@ local function apply_rate_limiting(auth_data)
             table.insert(filtered_requests, timestamp)
         end
     end
-    
+
     -- Add current request
     table.insert(filtered_requests, now)
-    
+
     -- Check if limit exceeded
     local requests_in_window = #filtered_requests
     local max_requests = limit_per_second * window_size
-    
+
     if requests_in_window > max_requests then
         utils.log("warn", "Rate limit exceeded", {
             team_id = team_id,
@@ -289,14 +287,14 @@ local function apply_rate_limiting(auth_data)
             limit = max_requests,
             window_size = window_size
         })
-        
+
         ngx.status = ngx.HTTP_TOO_MANY_REQUESTS
         ngx.header.content_type = "application/json"
         ngx.header["Retry-After"] = tostring(window_size)
         ngx.header["X-RateLimit-Limit"] = tostring(limit_per_hour)
         ngx.header["X-RateLimit-Remaining"] = tostring(math.max(0, max_requests - requests_in_window))
         ngx.header["X-RateLimit-Reset"] = tostring(now + window_size)
-        
+
         ngx.say(utils.json_encode({
             error = "rate_limit_exceeded",
             message = "Rate limit exceeded",
@@ -305,11 +303,11 @@ local function apply_rate_limiting(auth_data)
         }))
         ngx.exit(ngx.HTTP_TOO_MANY_REQUESTS)
     end
-    
+
     -- Update cache with new request list
     local updated_data = {requests = filtered_requests}
     rate_cache:set(key, utils.json_encode(updated_data), window_size)
-    
+
     -- Set rate limit headers
     ngx.header["X-RateLimit-Limit"] = tostring(limit_per_hour)
     ngx.header["X-RateLimit-Remaining"] = tostring(math.max(0, max_requests - requests_in_window))
@@ -428,14 +426,14 @@ end
 -- Main authentication handler
 function _M.authenticate()
     local request_start = ngx.now()
-    
+
     -- Get configuration
     local config = get_config()
     if not config then
         utils.log("error", "Gateway configuration not available")
         ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
-    
+
     -- Extract authentication token
     local auth_header = ngx.var.http_authorization
     local token, token_type = utils.extract_auth_token(auth_header)
@@ -466,15 +464,15 @@ function _M.authenticate()
 
     -- Generate cache key
     local cache_key = utils.generate_auth_cache_key(token, token_type)
-    
+
     -- Try to get auth data from cache first
-    local auth_data, cache_err = get_cached_auth_data(cache_key, config)
-    
+    local auth_data, cache_err = get_cached_auth_data(cache_key)
+
     -- If not in cache, validate with identity service
     if cache_err == "cache_miss" then
         local validation_err
         auth_data, validation_err = validate_token_with_identity(token, token_type, config)
-        
+
         if validation_err then
             if validation_err == "unauthorized" then
                 ngx.status = ngx.HTTP_UNAUTHORIZED
@@ -499,11 +497,11 @@ function _M.authenticate()
                 ngx.exit(ngx.HTTP_SERVICE_UNAVAILABLE)
             end
         end
-        
+
         -- Cache the validation result
         set_cached_auth_data(cache_key, auth_data, config)
     end
-    
+
     -- Enforce API-key least-privilege scopes (no-op for interactive/JWT auth)
     enforce_scopes(auth_data)
 
@@ -512,7 +510,7 @@ function _M.authenticate()
 
     -- Set authentication headers for backend services
     set_auth_headers(auth_data)
-    
+
     local request_time = (ngx.now() - request_start) * 1000
     utils.log("debug", "Authorization completed", {
         user_id = auth_data.user_id,

--- a/open-security-gateway/nginx/lua/utils.lua
+++ b/open-security-gateway/nginx/lua/utils.lua
@@ -15,13 +15,13 @@ function _M.log(level, message, context)
         warn = 3,
         error = 4
     }
-    
+
     if levels[level] >= levels[log_level] then
         local log_message = message
         if context then
             log_message = message .. " | " .. cjson.encode(context)
         end
-        
+
         if level == "error" then
             ngx.log(ngx.ERR, log_message)
         elseif level == "warn" then
@@ -39,12 +39,12 @@ function _M.json_decode(str)
     if not str or str == "" then
         return nil, "empty string"
     end
-    
+
     local ok, result = pcall(cjson.decode, str)
     if not ok then
         return nil, "invalid json: " .. tostring(result)
     end
-    
+
     return result, nil
 end
 
@@ -53,12 +53,12 @@ function _M.json_encode(obj)
     if not obj then
         return "{}", nil
     end
-    
+
     local ok, result = pcall(cjson.encode, obj)
     if not ok then
         return nil, "encode error: " .. tostring(result)
     end
-    
+
     return result, nil
 end
 
@@ -72,13 +72,13 @@ function _M.extract_auth_token()
             return bearer_token, "bearer"
         end
     end
-    
+
     -- Try X-API-Key header
     local api_key = ngx.var.http_x_api_key
     if api_key and api_key ~= "" then
         return api_key, "api_key"
     end
-    
+
     return nil, "no_token"
 end
 
@@ -91,33 +91,33 @@ end
 -- Clean sensitive headers before forwarding to backend
 function _M.http_request(method, url, options)
     local httpc = http:new()
-    
+
     -- Set timeouts
     httpc:set_timeouts(5000, 10000, 10000) -- connect, send, read timeouts
-    
+
     -- Default options
     local opts = options or {}
     opts.method = method
     opts.headers = opts.headers or {}
-    
+
     -- Add standard headers
     opts.headers["User-Agent"] = "Wildbox-Gateway/1.0"
     opts.headers["Accept"] = "application/json"
-    
+
     if opts.body and type(opts.body) == "table" then
         opts.body = _M.json_encode(opts.body)
         opts.headers["Content-Type"] = "application/json"
     end
-    
+
     local res, err = httpc:request_uri(url, opts)
-    
+
     if not res then
         return nil, "request failed: " .. (err or "unknown error")
     end
-    
+
     -- Close connection
     httpc:close()
-    
+
     return res, nil
 end
 
@@ -126,22 +126,22 @@ function _M.validate_team_access(user_id, team_id, auth_data)
     if not auth_data or not auth_data.team_id then
         return false, "no team data"
     end
-    
+
     if auth_data.team_id ~= team_id then
         return false, "team mismatch"
     end
-    
+
     if auth_data.user_id ~= user_id then
         return false, "user mismatch"
     end
-    
+
     return true, nil
 end
 
 -- Generate request ID for tracing
 function _M.generate_request_id()
-    return ngx.var.request_id or string.format("%s-%s", 
-        os.time(), 
+    return ngx.var.request_id or string.format("%s-%s",
+        os.time(),
         string.sub(ngx.encode_base64(ngx.sha1_bin(tostring(math.random()))), 1, 8)
     )
 end
@@ -160,7 +160,7 @@ function _M.clean_request_headers()
     -- Remove original authorization header
     ngx.req.clear_header("Authorization")
     ngx.req.clear_header("X-API-Key")
-    
+
     -- Remove any existing Wildbox headers (prevent spoofing)
     ngx.req.clear_header("X-Wildbox-User-ID")
     ngx.req.clear_header("X-Wildbox-Team-ID")

--- a/open-security-gateway/nginx/test/wildbox_gateway_test.conf
+++ b/open-security-gateway/nginx/test/wildbox_gateway_test.conf
@@ -11,9 +11,10 @@ upstream identity_service {
     keepalive 32;
 }
 
-# Rate limiting configuration
-limit_req_zone $binary_remote_addr zone=general:10m rate=10r/s;
-limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/s;
+# NOTE: no limit_req_zone here — nginx.conf (http context) already defines
+# the global/per_ip/auth zones, and redefining a zone name is a fatal
+# duplicate-zone error at startup ("limit_req_zone \"auth\" is already
+# bound"). Locations below reference the nginx.conf zones directly.
 
 # Main server block
 server {
@@ -61,7 +62,7 @@ server {
     # exercises required_scope_for_request's tools:read / tools:execute
     # mapping and scopes_satisfy's hierarchy against the mock echo backend.
     location /api/v1/tools/ {
-        limit_req zone=general burst=20 nodelay;
+        limit_req zone=global burst=20 nodelay;
 
         access_by_lua_block {
             local auth_handler = require "auth_handler"

--- a/open-security-gateway/nginx/test/wildbox_gateway_test.conf
+++ b/open-security-gateway/nginx/test/wildbox_gateway_test.conf
@@ -1,5 +1,8 @@
 # Wildbox Security Gateway - Test Configuration
-# Simplified config for test environment with identity-test service only
+# Simplified config for the CI auth-test harness (see test/ci_auth_tests.sh):
+# a single mock upstream (identity-test:8001, test/mock_identity.py) plays
+# both the identity /internal/authorize role and the proxied backend, echoing
+# requests back so tests can assert exactly which headers were forwarded.
 
 resolver 127.0.0.11 valid=30s;
 
@@ -16,27 +19,35 @@ limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/s;
 server {
     listen 80;
     server_name localhost;
-    
+
+    # Variables assigned by auth_handler.set_auth_headers(); assigning to an
+    # undeclared nginx variable from Lua is a hard error, so declare them here
+    # exactly like the production wildbox_gateway.conf does.
+    set $wildbox_user_id "";
+    set $wildbox_team_id "";
+    set $wildbox_role "";
+    set $gateway_debug "false";
+
     client_max_body_size 10M;
     proxy_buffering off;
     proxy_request_buffering off;
-    
+
     # Health check endpoint (unauthenticated)
     location /health {
         access_log off;
         return 200 "OK";
         add_header Content-Type text/plain;
     }
-    
+
     # Identity service routes (authentication required)
     location /api/v1/auth/ {
         limit_req zone=auth burst=20 nodelay;
-        
+
         access_by_lua_block {
             local auth_handler = require "auth_handler"
             auth_handler.authenticate()
         }
-        
+
         proxy_pass http://identity_service/api/v1/auth/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -45,11 +56,31 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection "";
     }
-    
+
+    # Tools-style route (authentication + API-key scope enforcement):
+    # exercises required_scope_for_request's tools:read / tools:execute
+    # mapping and scopes_satisfy's hierarchy against the mock echo backend.
+    location /api/v1/tools/ {
+        limit_req zone=general burst=20 nodelay;
+
+        access_by_lua_block {
+            local auth_handler = require "auth_handler"
+            auth_handler.authenticate()
+        }
+
+        proxy_pass http://identity_service/api/v1/tools/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+    }
+
     # Public authentication routes (no auth required)
     location /api/v1/auth/login {
         limit_req zone=auth burst=10 nodelay;
-        
+
         proxy_pass http://identity_service/api/v1/auth/login;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -57,10 +88,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-    
+
     location /api/v1/auth/register {
         limit_req zone=auth burst=10 nodelay;
-        
+
         proxy_pass http://identity_service/api/v1/auth/register;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -68,7 +99,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-    
+
     # Catch-all for undefined routes
     location / {
         return 404 '{"error": "Not Found", "message": "Route not found in test gateway"}';

--- a/open-security-gateway/test/ci_auth_tests.sh
+++ b/open-security-gateway/test/ci_auth_tests.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Gateway auth-logic tests (#108) — run against the Dockerfile.test gateway
+# wired to test/mock_identity.py (see .github/workflows/gateway-tests.yml).
+#
+# Covers the auth boundary end-to-end through real OpenResty + auth_handler.lua:
+#   * unauthenticated / invalid-token rejection
+#   * X-Wildbox-* header injection stripping (anti-spoofing)
+#   * Authorization / X-API-Key stripping before proxying upstream
+#   * API-key scope enforcement (tools:read / tools:execute mapping + hierarchy)
+#   * X-Gateway-Secret proof-of-origin propagation (wrong secret -> 403)
+#   * auth-cache short-circuit (one /internal/authorize call for N requests)
+
+set -u
+
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
+GATEWAY_WRONG_URL="${GATEWAY_WRONG_URL:-http://localhost:8081}"
+MOCK_URL="${MOCK_URL:-http://localhost:8001}"
+
+PASS=0
+FAIL=0
+
+fail() { echo "❌ $1"; FAIL=$((FAIL + 1)); }
+pass() { echo "✅ $1"; PASS=$((PASS + 1)); }
+
+# request <name> <expected_status> <curl args...> ; body left in $BODY
+request() {
+    local name="$1" expected="$2"
+    shift 2
+    BODY=$(curl -s -o /tmp/body.json -w "%{http_code}" "$@")
+    local status="$BODY"
+    BODY=$(cat /tmp/body.json)
+    if [ "$status" = "$expected" ]; then
+        pass "$name (HTTP $status)"
+        return 0
+    else
+        fail "$name: expected HTTP $expected, got $status — body: $(head -c 300 /tmp/body.json)"
+        return 1
+    fi
+}
+
+json_field() { echo "$BODY" | jq -r "$1"; }
+
+assert_json() {
+    local name="$1" filter="$2" expected="$3"
+    local actual
+    actual=$(json_field "$filter")
+    if [ "$actual" = "$expected" ]; then
+        pass "$name ($filter = $expected)"
+    else
+        fail "$name: expected $filter = '$expected', got '$actual'"
+    fi
+}
+
+echo "== Gateway auth tests against $GATEWAY_URL =="
+
+# 1. Health endpoint is public
+request "health endpoint" 200 "$GATEWAY_URL/health"
+
+# 2. No credentials -> 401 authentication_required
+request "no token rejected" 401 "$GATEWAY_URL/api/v1/auth/me"
+assert_json "no-token error code" '.error' 'authentication_required'
+
+# 3. Invalid bearer token -> 401 invalid_token (mock returns 401)
+request "invalid bearer rejected" 401 \
+    -H "Authorization: Bearer not-a-real-token" "$GATEWAY_URL/api/v1/auth/me"
+assert_json "invalid-token error code" '.error' 'invalid_token'
+
+# 4. Valid bearer -> proxied; backend sees validated X-Wildbox-* and no
+#    client credential headers
+request "valid bearer accepted" 200 \
+    -H "Authorization: Bearer valid-bearer-token" "$GATEWAY_URL/api/v1/auth/me"
+assert_json "X-Wildbox-User-ID injected" '.headers["x-wildbox-user-id"]' 'user-1111'
+assert_json "X-Wildbox-Team-ID injected" '.headers["x-wildbox-team-id"]' 'team-2222'
+assert_json "X-Wildbox-Role injected" '.headers["x-wildbox-role"]' 'admin'
+assert_json "Authorization stripped upstream" '.headers.authorization // "absent"' 'absent'
+assert_json "X-API-Key stripped upstream" '.headers["x-api-key"] // "absent"' 'absent'
+
+# 5. Header injection: forged X-Wildbox-* must be replaced by validated values
+request "header-injection attempt proxied" 200 \
+    -H "Authorization: Bearer valid-bearer-token" \
+    -H "X-Wildbox-User-ID: attacker" \
+    -H "X-Wildbox-Team-ID: attacker-team" \
+    -H "X-Wildbox-Role: superadmin" \
+    "$GATEWAY_URL/api/v1/auth/me"
+assert_json "forged user-id overwritten" '.headers["x-wildbox-user-id"]' 'user-1111'
+assert_json "forged team-id overwritten" '.headers["x-wildbox-team-id"]' 'team-2222'
+assert_json "forged role overwritten" '.headers["x-wildbox-role"]' 'admin'
+
+# 6/7. Read-only API key: GET allowed (generic read satisfies tools:read),
+#      POST requires tools:execute -> 403 insufficient_scope
+request "read-only key GET allowed" 200 \
+    -H "X-API-Key: wsk_readonly_ci_fixture" "$GATEWAY_URL/api/v1/tools/echo"
+request "read-only key POST blocked" 403 \
+    -X POST -H "X-API-Key: wsk_readonly_ci_fixture" "$GATEWAY_URL/api/v1/tools/echo"
+assert_json "scope error code" '.error' 'insufficient_scope'
+assert_json "required scope surfaced" '.required_scope' 'tools:execute'
+
+# 8/9. tools:execute key: POST allowed, and execute satisfies tools:read
+request "tools:execute key POST allowed" 200 \
+    -X POST -H "X-API-Key: wsk_toolsexec_ci_fixture" "$GATEWAY_URL/api/v1/tools/echo"
+request "tools:execute key GET allowed" 200 \
+    -H "X-API-Key: wsk_toolsexec_ci_fixture" "$GATEWAY_URL/api/v1/tools/echo"
+
+# 10. Auth cache: the two valid-bearer requests above (tests 4 and 5) must
+#     have produced exactly ONE /internal/authorize call
+request "mock call counts readable" 200 "$MOCK_URL/__mock/counts"
+assert_json "auth cache short-circuits revalidation" '."valid-bearer-token"' '1'
+
+# 11. Proof-of-origin: a gateway configured with the wrong
+#     GATEWAY_INTERNAL_SECRET is rejected by identity (403) and must NOT
+#     let the request through
+request "wrong gateway secret -> forbidden" 403 \
+    -H "Authorization: Bearer valid-bearer-token" "$GATEWAY_WRONG_URL/api/v1/auth/me"
+
+# 12. Oversized token rejected (nginx header limits or the Lua >4096 guard —
+#     either layer must refuse it)
+BIGTOKEN=$(printf 'a%.0s' $(seq 1 5000))
+request "oversized token rejected" 400 \
+    -H "Authorization: Bearer $BIGTOKEN" "$GATEWAY_URL/api/v1/auth/me"
+
+echo
+echo "== Results: $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]

--- a/open-security-gateway/test/mock_identity.py
+++ b/open-security-gateway/test/mock_identity.py
@@ -1,0 +1,139 @@
+"""Mock identity service for gateway auth CI tests (#108).
+
+Stdlib-only stand-in for open-security-identity, faithful to the real
+/internal/authorize contract (see open-security-identity/app/internal.py):
+
+- 403 {"detail": "Invalid gateway secret"} when X-Gateway-Secret is missing
+  or does not match EXPECTED_GATEWAY_SECRET (proof-of-origin, #133/#134);
+- 401 for unknown/invalid tokens;
+- 200 with {is_authenticated, user_id, team_id, role, permissions, scopes}
+  for the fixture tokens below.
+
+Every other path echoes the request back as JSON ({method, path, headers})
+so tests can assert exactly which headers the gateway forwarded upstream
+(X-Wildbox-* injection, Authorization/X-API-Key stripping).
+
+GET /__mock/counts returns per-token /internal/authorize call counts, which
+lets tests prove the gateway's auth cache short-circuits repeat validations.
+"""
+
+import hmac
+import json
+import os
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+EXPECTED_SECRET = os.environ.get("EXPECTED_GATEWAY_SECRET", "")
+
+# token -> auth payload returned to the gateway. scopes=None means
+# unrestricted (interactive/JWT or legacy key), a list is enforced by
+# auth_handler.enforce_scopes at the gateway.
+TOKENS = {
+    "valid-bearer-token": {
+        "user_id": "user-1111",
+        "team_id": "team-2222",
+        "role": "admin",
+        "scopes": None,
+    },
+    "wsk_readonly_ci_fixture": {
+        "user_id": "user-3333",
+        "team_id": "team-4444",
+        "role": "user",
+        "scopes": ["read"],
+    },
+    "wsk_toolsexec_ci_fixture": {
+        "user_id": "user-5555",
+        "team_id": "team-6666",
+        "role": "user",
+        "scopes": ["tools:execute"],
+    },
+}
+
+authorize_calls = Counter()
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _reply(self, status, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _echo(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)  # drain body to keep the connection clean
+        self._reply(
+            200,
+            {
+                "method": self.command,
+                "path": self.path,
+                "headers": {k.lower(): v for k, v in self.headers.items()},
+            },
+        )
+
+    def _authorize(self):
+        # Always drain the request body BEFORE replying: on a keep-alive
+        # connection, unread body bytes would be misparsed as the next
+        # request line after an early 403.
+        length = int(self.headers.get("Content-Length") or 0)
+        raw_body = self.rfile.read(length) if length else b""
+
+        secret = self.headers.get("X-Gateway-Secret") or ""
+        if not EXPECTED_SECRET or not hmac.compare_digest(secret, EXPECTED_SECRET):
+            self._reply(403, {"detail": "Invalid gateway secret"})
+            return
+
+        try:
+            request = json.loads(raw_body or b"{}")
+        except ValueError:
+            self._reply(400, {"detail": "Malformed authorize request"})
+            return
+
+        token = request.get("token", "")
+        authorize_calls[token] += 1
+
+        auth = TOKENS.get(token)
+        if auth is None:
+            self._reply(401, {"detail": "Invalid or inactive credentials"})
+            return
+
+        self._reply(
+            200,
+            {
+                "is_authenticated": True,
+                "user_id": auth["user_id"],
+                "team_id": auth["team_id"],
+                "role": auth["role"],
+                "permissions": ["tool:basic", "tool:advanced", "feed", "cspm"],
+                "scopes": auth["scopes"],
+            },
+        )
+
+    def do_POST(self):
+        if self.path == "/internal/authorize":
+            self._authorize()
+        else:
+            self._echo()
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._reply(200, {"status": "ok"})
+        elif self.path == "/__mock/counts":
+            self._reply(200, dict(authorize_calls))
+        else:
+            self._echo()
+
+    do_PUT = do_GET
+    do_DELETE = do_GET
+
+    def log_message(self, fmt, *args):  # keep container logs readable
+        print("mock-identity: " + fmt % args, flush=True)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 8001), Handler).serve_forever()


### PR DESCRIPTION
Addresses #108 (Sprint 4 / B1): the gateway (OpenResty/Lua) is the platform's auth boundary but had zero CI coverage.

## New workflow: Gateway Tests

**Job 1 — Gateway Lua Lint**: `luacheck` (std `ngx_lua`) over `nginx/lua/`, gated at 0 warnings. Existing code cleaned to comply: trailing whitespace, unused `cjson`/`MAX_RETRIES` locals, unused `get_cached_auth_data` param — no behavior change.

**Job 2 — Gateway Auth Tests**: builds `Dockerfile.test` and drives the **real gateway** over HTTP against `test/mock_identity.py`, a stdlib-only mock faithful to identity's `/internal/authorize` contract (`403` on bad/missing `X-Gateway-Secret` via `compare_digest`, `401` invalid token, `200` with `scopes`). 12 test cases:

| Area | Cases |
|---|---|
| Rejection paths | no token → 401 `authentication_required`; invalid bearer → 401 `invalid_token`; oversized token → 400 |
| Anti-spoofing | forged `X-Wildbox-User-ID/Team-ID/Role` replaced by validated values; `Authorization`/`X-API-Key` stripped before proxying |
| Scope enforcement | key with `["read"]`: GET tools ✓ / POST tools → 403 `insufficient_scope` (`tools:execute`); key with `["tools:execute"]`: POST ✓ and GET ✓ (hierarchy) |
| Proof-of-origin (#133/#134) | second gateway with wrong `GATEWAY_INTERNAL_SECRET` → identity 403 → request blocked |
| Caching | N requests, same token → exactly 1 `/internal/authorize` call |

## Harness fixes found while wiring it up
- `Dockerfile.test` lacked the `nginx` user that `nginx.conf` declares → boot failure (`getpwnam("nginx") failed`) — likely one of the old #97 harness failure modes.
- The test conf lacked the `set $wildbox_*` declarations that `auth_handler.set_auth_headers()` assigns — a hard Lua error (500) on every authenticated request.
- Mock drains request bodies before early replies (keep-alive corruption found in local testing).

Validated locally: luacheck 0/0, `luac -p` on all modules, mock exercised incl. keep-alive stress. The docker harness itself is validated by this PR's own CI run.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)