### PR TITLE
security: fix privilege escalation on admin user endpoints (any registered user could dump and disable all accounts)

### DIFF
--- a/open-security-identity/app/api_v1/endpoints/users.py
+++ b/open-security-identity/app/api_v1/endpoints/users.py
@@ -30,6 +30,21 @@ router = APIRouter()
 # ADMIN USER MANAGEMENT ENDPOINTS
 # =============================================================================
 
+async def _require_platform_admin(current_user: User) -> None:
+    """Gate for platform-wide user administration.
+
+    Being OWNER/ADMIN of a team is NOT a platform role: on_after_register
+    creates a personal team and makes every new user its OWNER, so a
+    membership-based check passes for literally every registered account.
+    Platform administration requires is_superuser.
+    """
+    if not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Superuser access required"
+        )
+
+
 @router.get("/users", response_model=List[UserResponse])
 async def list_all_users(
     current_user: User = Depends(current_active_user),
@@ -42,23 +57,9 @@ async def list_all_users(
     """
     Admin endpoint: List all users in the system.
     
-    Requires: Admin role or higher
+    Requires: superuser (platform administrator).
     """
-    # Check if user is admin (owner/admin of any team or superuser)
-    if not current_user.is_superuser:
-        # Check if user has admin role in any team
-        admin_memberships = await db.execute(
-            select(TeamMembership)
-            .where(
-                TeamMembership.user_id == current_user.id,
-                TeamMembership.role.in_([TeamRole.OWNER, TeamRole.ADMIN])
-            )
-        )
-        if not admin_memberships.scalars().first():
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Admin access required"
-            )
+    await _require_platform_admin(current_user)
     
     # Build query with relationships to get team and subscription data
     query = select(User).options(
@@ -194,22 +195,9 @@ async def get_user_by_id(
     """
     Admin endpoint: Get detailed user information by ID.
     
-    Requires: Admin role or higher
+    Requires: superuser (platform administrator).
     """
-    # Check admin permissions
-    if not current_user.is_superuser:
-        admin_memberships = await db.execute(
-            select(TeamMembership)
-            .where(
-                TeamMembership.user_id == current_user.id,
-                TeamMembership.role.in_([TeamRole.OWNER, TeamRole.ADMIN])
-            )
-        )
-        if not admin_memberships.scalars().first():
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Admin access required"
-            )
+    await _require_platform_admin(current_user)
     
     # Get user with relationships
     result = await db.execute(
@@ -241,22 +229,9 @@ async def update_user_status(
     """
     Admin endpoint: Activate or deactivate a user account.
     
-    Requires: Admin role or higher
+    Requires: superuser (platform administrator).
     """
-    # Check admin permissions
-    if not current_user.is_superuser:
-        admin_memberships = await db.execute(
-            select(TeamMembership)
-            .where(
-                TeamMembership.user_id == current_user.id,
-                TeamMembership.role.in_([TeamRole.OWNER, TeamRole.ADMIN])
-            )
-        )
-        if not admin_memberships.scalars().first():
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Admin access required"
-            )
+    await _require_platform_admin(current_user)
     
     # Get user
     result = await db.execute(select(User).where(User.id == user_id))


### PR DESCRIPTION
Audit pre-release — **MB-01, la finding più grave dell'intero audit**. Escalation di privilegi sfruttabile da chiunque possa raggiungere la pagina di registrazione, senza alcuna credenziale preesistente.

## La catena

`UserManager.on_after_register` crea un team personale per ogni nuovo utente e lo rende **OWNER** di quel team ([user_manager.py:85-98](open-security-identity/app/user_manager.py#L85-L98)):

```python
team = Team(name=f"{user.email}'s Team", owner_id=user.id)
membership = TeamMembership(user_id=user.id, team_id=team.id, role=TeamRole.OWNER)
```

Tre endpoint "admin" di identity però non gatevano su `is_superuser`, ma sulla presenza di una membership OWNER/ADMIN **in un team qualsiasi**:

```python
if not current_user.is_superuser:
    admin_memberships = await db.execute(
        select(TeamMembership).where(
            TeamMembership.user_id == current_user.id,
            TeamMembership.role.in_([TeamRole.OWNER, TeamRole.ADMIN])))
    if not admin_memberships.scalars().first():
        raise HTTPException(403, "Admin access required")
```

Il predicato è quindi **vero per il 100% degli utenti registrati**. La registrazione è pubblica (`fastapi_users.get_register_router`, [main.py:83](open-security-identity/app/main.py#L83)) e la rotta `/api/v1/identity/*` è proxata dal gateway senza auth (identity è l'authority).

## L'impatto

Un attaccante si registra e con il JWT ottenuto:

1. `GET /api/v1/identity/admin/users?limit=1000` → **dump completo dell'utenza**: email, flag `is_superuser`, team, ruoli. Cioè anche la mappa esatta di chi sono gli amministratori.
2. `PATCH /api/v1/identity/admin/users/{id}/status?is_active=false` su ogni ID ottenuto → **disattiva ogni account della piattaforma, superadmin compresi**. `/internal/authorize` filtra su `User.is_active == True`, quindi tutti perdono l'accesso simultaneamente. L'unica guardia è "non puoi disattivare te stesso". Denial-of-service totale, reversibile solo con accesso diretto al DB.

E senza lasciare traccia: identity non ha audit logging sui path distruttivi (finding MB-04 dello stesso audit).

## Il fix

I tre gate sono sostituiti da un helper condiviso che richiede `is_superuser`:

```python
async def _require_platform_admin(current_user: User) -> None:
    """Being OWNER/ADMIN of a team is NOT a platform role: on_after_register
    makes every new user OWNER of a personal team, so a membership-based
    check passes for literally every registered account."""
    if not current_user.is_superuser:
        raise HTTPException(403, "Superuser access required")
```

**Nessuna regressione di scope**: gli endpoint vicini (delete user, promote/demote superuser, cambio ruolo) usavano già `is_superuser` correttamente, e i sei endpoint team-scoped mantengono il loro check di membership — essere OWNER di un team è un ruolo di tenant, non di piattaforma. Il diff è -46/+21 righe: rimuove tre blocchi duplicati.

## Nota correlata, non inclusa qui
L'altra criticità RBAC dell'audit (**MB-02**) resta aperta: Guardian non ha alcuna nozione di tenant — nessun modello ha un campo team, nessun queryset filtra, e `has_perm()` ritorna `True` incondizionatamente per `role in ("owner","admin")`, ruolo che ogni registrato possiede. Richiede una migrazione dati e va affrontata a parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
