### PR TITLE
security: five audit fixes — fake success in responder, tool-loader crash, unauthenticated sensor API, sensor host escape, dead prod gateway

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -210,9 +210,14 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
-    # Production-specific nginx configuration
-    volumes:
-      - ./open-security-gateway/nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro
+    # No nginx config override. This used to bind-mount
+    # ./open-security-gateway/nginx/nginx.prod.conf, a file that does not
+    # exist in the repo: Docker creates an empty DIRECTORY at a missing bind
+    # source, nginx finds a directory where it expects nginx.conf and refuses
+    # to start, so the gateway crash-looped on every production deploy. The
+    # image already ships the reviewed nginx.conf — which is also where the
+    # limit_req_zone definitions live, so silently replacing it would have
+    # taken the rate limiting with it.
 
   # Dashboard - Production (frontend only, NO direct backend/data access)
   dashboard:

--- a/open-security-responder/app/connectors/api_connector.py
+++ b/open-security-responder/app/connectors/api_connector.py
@@ -67,11 +67,6 @@ class ApiConnector(BaseConnector):
                 response.raise_for_status()
                 
         except httpx.HTTPError as e:
-            # For testing, provide simulated results when API is not available
-            if "Connection" in str(e) or "refused" in str(e).lower():
-                self.logger.warning(f"API service unavailable, using simulation for tool '{tool_name}'")
-                return self._simulate_tool_execution(tool_name, params)
-            
             error_msg = f"HTTP error executing tool '{tool_name}': {str(e)}"
             self.logger.error(error_msg)
             raise ConnectorError(error_msg)
@@ -99,10 +94,6 @@ class ApiConnector(BaseConnector):
             return result
             
         except httpx.HTTPError as e:
-            if "Connection" in str(e) or "refused" in str(e).lower():
-                self.logger.warning("API service unavailable, using simulated tool list")
-                return self._get_simulated_tools()
-            
             error_msg = f"HTTP error listing tools: {str(e)}"
             self.logger.error(error_msg)
             raise ConnectorError(error_msg)
@@ -133,9 +124,6 @@ class ApiConnector(BaseConnector):
             return result
             
         except httpx.HTTPError as e:
-            if "Connection" in str(e) or "refused" in str(e).lower():
-                return self._get_simulated_tool_info(tool_name)
-            
             error_msg = f"HTTP error getting tool info for '{tool_name}': {str(e)}"
             self.logger.error(error_msg)
             raise ConnectorError(error_msg)
@@ -202,168 +190,6 @@ class ApiConnector(BaseConnector):
             error_msg = f"Failed to get execution status for '{execution_id}': {str(e)}"
             self.logger.error(error_msg)
             raise ConnectorError(error_msg)
-    
-    def _simulate_tool_execution(self, tool_name: str, params: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Simulate tool execution for testing when API is not available
-        
-        Args:
-            tool_name: Name of the tool
-            params: Tool parameters
-            
-        Returns:
-            Simulated execution results
-        """
-        import time
-        import random
-        import uuid
-        
-        # Simulate processing time
-        time.sleep(random.uniform(0.5, 2.0))
-        
-        # Generate realistic results based on tool type
-        execution_id = str(uuid.uuid4())
-        
-        if "nmap" in tool_name.lower():
-            return {
-                "execution_id": execution_id,
-                "tool": tool_name,
-                "status": "completed",
-                "results": {
-                    "open_ports": [22, 80, 443, 8080],
-                    "services": ["ssh", "http", "https", "http-proxy"],
-                    "target": params.get("target", "unknown"),
-                    "scan_type": params.get("scan_type", "quick"),
-                    "duration": random.uniform(1.0, 5.0)
-                },
-                "timestamp": datetime.utcnow().isoformat()
-            }
-        elif "whois" in tool_name.lower():
-            return {
-                "execution_id": execution_id,
-                "tool": tool_name,
-                "status": "completed",
-                "results": {
-                    "registrar": "Example Registrar Inc.",
-                    "creation_date": "2020-01-15",
-                    "expiration_date": "2025-01-15",
-                    "name_servers": ["ns1.example.com", "ns2.example.com"],
-                    "status": "active"
-                },
-                "timestamp": datetime.utcnow().isoformat()
-            }
-        elif "reputation" in tool_name.lower():
-            return {
-                "execution_id": execution_id,
-                "tool": tool_name,
-                "status": "completed",
-                "results": {
-                    "reputation_score": random.randint(1, 10),
-                    "verdict": "clean" if random.random() > 0.3 else "suspicious",
-                    "sources": ["VirusTotal", "AbuseIPDB", "URLVoid"],
-                    "confidence": random.choice(["low", "medium", "high"]),
-                    "malicious_sources": [] if random.random() > 0.3 else ["source1", "source2"]
-                },
-                "timestamp": datetime.utcnow().isoformat()
-            }
-        elif "url_analyzer" in tool_name.lower():
-            return {
-                "execution_id": execution_id,
-                "tool": tool_name,
-                "status": "completed",
-                "results": {
-                    "verdict": random.choice(["clean", "suspicious", "malicious"]),
-                    "screenshot_url": f"https://screenshots.example.com/{execution_id}.png",
-                    "analysis": {
-                        "redirects": random.randint(0, 3),
-                        "scripts_found": random.randint(0, 10),
-                        "external_links": random.randint(0, 5)
-                    },
-                    "summary": "URL analyzed successfully"
-                },
-                "timestamp": datetime.utcnow().isoformat()
-            }
-        elif "domain_reputation" in tool_name.lower():
-            return {
-                "execution_id": execution_id,
-                "tool": tool_name,
-                "status": "completed",
-                "results": {
-                    "reputation_score": random.randint(1, 10),
-                    "age_days": random.randint(30, 3650),
-                    "categories": ["technology", "business"],
-                    "security_flags": []
-                },
-                "timestamp": datetime.utcnow().isoformat()
-            }
-        else:
-            return {
-                "execution_id": execution_id,
-                "tool": tool_name,
-                "status": "completed",
-                "results": {
-                    "message": f"Tool '{tool_name}' executed successfully (simulated)",
-                    "input_params": params,
-                    "output": "Simulated execution completed"
-                },
-                "timestamp": datetime.utcnow().isoformat()
-            }
-    
-    def _get_simulated_tools(self) -> Dict[str, Any]:
-        """Get simulated list of tools for testing"""
-        return {
-            "tools": [
-                {
-                    "name": "nmap",
-                    "description": "Network port scanner",
-                    "category": "network",
-                    "parameters": ["target", "scan_type", "ports"]
-                },
-                {
-                    "name": "whois",
-                    "description": "Domain/IP WHOIS lookup",
-                    "category": "intelligence",
-                    "parameters": ["target"]
-                },
-                {
-                    "name": "reputation_check",
-                    "description": "Reputation checker",
-                    "category": "intelligence",
-                    "parameters": ["ip", "url", "sources"]
-                },
-                {
-                    "name": "url_analyzer",
-                    "description": "URL analysis tool",
-                    "category": "web",
-                    "parameters": ["url", "deep_scan", "screenshot"]
-                },
-                {
-                    "name": "domain_reputation",
-                    "description": "Domain reputation checker",
-                    "category": "intelligence",
-                    "parameters": ["domain"]
-                }
-            ],
-            "total": 5
-        }
-    
-    def _get_simulated_tool_info(self, tool_name: str) -> Dict[str, Any]:
-        """Get simulated tool info for testing"""
-        tools = self._get_simulated_tools()["tools"]
-        tool_info = next((t for t in tools if t["name"] == tool_name), None)
-        
-        if tool_info:
-            return {
-                "tool": tool_info,
-                "version": "1.0.0",
-                "status": "available",
-                "last_updated": datetime.utcnow().isoformat()
-            }
-        else:
-            return {
-                "error": f"Tool '{tool_name}' not found",
-                "available_tools": [t["name"] for t in tools]
-            }
     
     def __del__(self):
         """Cleanup HTTP client"""

--- a/open-security-responder/demo_final.py
+++ b/open-security-responder/demo_final.py
@@ -61,7 +61,8 @@ def demo_connectors():
     
     print("\n🧪 Testing API Connector:")
     
-    # List available tools (with fallback to simulation)
+    # List available tools. The connector no longer falls back to fabricated
+    # data when the tools service is down: report the outage instead.
     try:
         result = connector_registry.execute_action("api", "list_tools", {})
         tools = result.get('tools', [])
@@ -69,17 +70,8 @@ def demo_connectors():
         for tool in tools[:3]:  # Show first 3
             print(f"    - {tool['name']}: {tool['description']}")
     except Exception as e:
-        print(f"  ⚠️  API service not available, using simulation mode")
-        # Use the simulated tools method directly
-        from app.connectors.api_connector import ApiConnector
-        api_conn = ApiConnector()
-        result = api_conn._get_simulated_tools()
-        tools = result.get('tools', [])
-        print(f"  ✅ Available Tools (simulated): {len(tools)} tools")
-        for tool in tools[:3]:
-            print(f"    - {tool['name']}: {tool['description']}")
-    
-    # Simulate tool execution (will use simulation mode automatically)
+        print(f"  ⚠️  Tools service unavailable, cannot list tools: {e}")
+
     try:
         result = connector_registry.execute_action("api", "run_tool", {
             "tool_name": "nmap",

--- a/open-security-sensor/config.docker.yaml
+++ b/open-security-sensor/config.docker.yaml
@@ -56,7 +56,9 @@ logging:
 
 # Network Configuration
 network:
-  bind_address: "0.0.0.0"  # Listen on all interfaces in container
+  # 0.0.0.0 is required inside a container, but the compose file must
+  # publish the port on 127.0.0.1 only (never 0.0.0.0:8004).
+  bind_address: "0.0.0.0"
   bind_port: 8899
   enable_api: true
   api_key: null  # Set to require API key authentication

--- a/open-security-sensor/config.yaml
+++ b/open-security-sensor/config.yaml
@@ -56,7 +56,10 @@ logging:
 
 # Network Configuration
 network:
-  bind_address: "0.0.0.0"  # Bind to all interfaces for Docker
+  # Loopback only. This API can read host telemetry, mutate the agent
+  # config and run osquery: never expose it on all interfaces. Put a
+  # reverse proxy in front of it if remote access is genuinely needed.
+  bind_address: "127.0.0.1"
   bind_port: 8004
   enable_api: true
   api_key: null  # Set to require API key authentication

--- a/open-security-sensor/docker-compose.dev.yml
+++ b/open-security-sensor/docker-compose.dev.yml
@@ -23,28 +23,29 @@ services:
       - ./config.yaml.example:/etc/security-sensor/config.yaml:ro
       - sensor_dev_logs:/var/log/security-sensor
       - sensor_dev_data:/var/lib/security-sensor
-      # Host monitoring
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /etc:/host/etc:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Host monitoring: only the files the collectors consume. A full /proc
+      # + /etc bind is host-wide read access and docker.sock is host root —
+      # not something a dev container needs either.
+      - /proc/stat:/host/proc/stat:ro
+      - /proc/meminfo:/host/proc/meminfo:ro
+      - /proc/loadavg:/host/proc/loadavg:ro
+      - /sys/class/net:/host/sys/class/net:ro
     
     # Network configuration
     ports:
-      - "8899:8899"  # Local API port
-      - "5678:5678"  # Debug port
+      - "127.0.0.1:8899:8899"  # Local API port
+      - "127.0.0.1:5678:5678"  # Debug port
     
     # Security context (relaxed for development)
     security_opt:
       - no-new-privileges:true
     
-    # Capabilities for system monitoring
-    cap_add:
-      - SYS_PTRACE
-      - DAC_READ_SEARCH
+    # No added capabilities. SYS_PTRACE allowed dumping the memory of any
+    # host process (with pid: host) and DAC_READ_SEARCH bypassed every
+    # filesystem read permission check on the mounted host paths.
+    cap_drop:
+      - ALL
     
-    # PID namespace for process monitoring
-    pid: host
     
     # Networks
     networks:

--- a/open-security-sensor/docker-compose.yml
+++ b/open-security-sensor/docker-compose.yml
@@ -24,27 +24,32 @@ services:
       - ./config.yaml:/etc/security-sensor/config.yaml:ro
       - sensor_logs:/var/log/security-sensor
       - sensor_data:/var/lib/security-sensor
-      # Host monitoring (required for system telemetry)
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /etc:/host/etc:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Host monitoring: only the specific read-only files the collectors
+      # consume, mirroring the root docker-compose.yml. A full /proc + /etc
+      # bind is equivalent to host-wide read access, and /var/run/docker.sock
+      # is root on the host (":ro" restricts the file, not the Docker API).
+      # Verified: nothing under sensor/ references /host or docker.sock.
+      - /proc/stat:/host/proc/stat:ro
+      - /proc/meminfo:/host/proc/meminfo:ro
+      - /proc/loadavg:/host/proc/loadavg:ro
+      - /sys/class/net:/host/sys/class/net:ro
     
     # Network configuration
     ports:
-      - "8004:8004"  # Local API port
+      # Loopback only: the local API can read host telemetry, mutate the
+      # agent config and run osquery.
+      - "127.0.0.1:8004:8004"
     
     # Security context
     security_opt:
       - no-new-privileges:true
     
-    # Capabilities for system monitoring
-    cap_add:
-      - SYS_PTRACE
-      - DAC_READ_SEARCH
+    # No added capabilities. SYS_PTRACE allowed dumping the memory of any
+    # host process (with pid: host) and DAC_READ_SEARCH bypassed every
+    # filesystem read permission check on the mounted host paths.
+    cap_drop:
+      - ALL
     
-    # PID namespace for process monitoring
-    pid: host
     
     # Networks
     networks:

--- a/open-security-sensor/sensor/api/local_api.py
+++ b/open-security-sensor/sensor/api/local_api.py
@@ -97,30 +97,35 @@ class LocalAPI:
     def _setup_routes(self):
         """Setup API routes"""
         
-        # Health and status endpoints
+        # Health is the only unauthenticated endpoint: container and load
+        # balancer probes need it, and it exposes nothing but liveness.
         self.app.router.add_get('/health', self._health_handler)
-        self.app.router.add_get('/status', self._status_handler)
-        self.app.router.add_get('/api/v1/status', self._status_handler)
-        
+
+        # Everything else requires the API key. These endpoints read host
+        # telemetry, mutate the agent configuration and run osquery, so an
+        # unauthenticated caller on the same network would own the endpoint.
+        self.app.router.add_get('/status', self._require_auth(self._status_handler))
+        self.app.router.add_get('/api/v1/status', self._require_auth(self._status_handler))
+
         # Configuration endpoints
-        self.app.router.add_get('/api/v1/config', self._get_config_handler)
-        self.app.router.add_put('/api/v1/config', self._update_config_handler)
-        self.app.router.add_post('/api/v1/config/reload', self._reload_config_handler)
-        self.app.router.add_post('/api/v1/config/validate', self._validate_config_handler)
-        
+        self.app.router.add_get('/api/v1/config', self._require_auth(self._get_config_handler))
+        self.app.router.add_put('/api/v1/config', self._require_auth(self._update_config_handler))
+        self.app.router.add_post('/api/v1/config/reload', self._require_auth(self._reload_config_handler))
+        self.app.router.add_post('/api/v1/config/validate', self._require_auth(self._validate_config_handler))
+
         # Query endpoints
-        self.app.router.add_post('/api/v1/query', self._execute_query_handler)
-        self.app.router.add_get('/api/v1/queries', self._list_queries_handler)
-        
+        self.app.router.add_post('/api/v1/query', self._require_auth(self._execute_query_handler))
+        self.app.router.add_get('/api/v1/queries', self._require_auth(self._list_queries_handler))
+
         # Component endpoints
-        self.app.router.add_get('/api/v1/components', self._components_status_handler)
-        self.app.router.add_get('/api/v1/stats', self._stats_handler)
-        
+        self.app.router.add_get('/api/v1/components', self._require_auth(self._components_status_handler))
+        self.app.router.add_get('/api/v1/stats', self._require_auth(self._stats_handler))
+
         # Dashboard endpoint
-        self.app.router.add_get('/api/v1/dashboard/metrics', self._dashboard_metrics_handler)
-        
+        self.app.router.add_get('/api/v1/dashboard/metrics', self._require_auth(self._dashboard_metrics_handler))
+
         # Control endpoints
-        self.app.router.add_post('/api/v1/test-connection', self._test_connection_handler)
+        self.app.router.add_post('/api/v1/test-connection', self._require_auth(self._test_connection_handler))
         
         # Static documentation (only in development)
         if os.getenv("ENVIRONMENT", "development") != "production":
@@ -130,7 +135,15 @@ class LocalAPI:
     def _require_auth(self, handler):
         """Decorator to require API key authentication"""
         async def wrapper(request):
-            if self.config.network.api_key:
+            if not self.config.network.api_key:
+                # Fail closed. Previously a missing api_key silently disabled
+                # authentication for every endpoint below.
+                logger.error("Local API called but network.api_key is not configured")
+                return web.json_response(
+                    {'error': 'API authentication is not configured on this sensor'},
+                    status=503
+                )
+            if True:
                 auth_header = request.headers.get('Authorization', '')
                 api_key = request.headers.get('X-API-Key', '')
                 

--- a/open-security-tools/app/main.py
+++ b/open-security-tools/app/main.py
@@ -130,9 +130,23 @@ def discover_tools() -> Dict[str, Any]:
             tools[tool_name] = main_module
             logger.info(f"Successfully loaded tool: {tool_name}")
             
-        except (ValueError, KeyError, TypeError, ConnectionError, TimeoutError, ModuleNotFoundError, ImportError) as e:
-            logger.error(f"Failed to load tool {tool_name}: {str(e)}")
+        except Exception as e:
+            # Loading a tool runs third-party module-level code via
+            # exec_module, so any exception type is reachable — SyntaxError,
+            # IndentationError, AttributeError, NameError, OSError. None of
+            # those were caught before, and discover_tools() runs at import
+            # time inside create_app(), so a single malformed tool killed the
+            # process and took all the others down with it.
+            logger.error(
+                f"Failed to load tool {tool_name}: {type(e).__name__}: {e}",
+                exc_info=True,
+            )
             continue
+        finally:
+            # exec_module may abort midway and leave these behind, which would
+            # make the next tool import the previous tool's schemas.
+            sys.modules.pop('schemas', None)
+            sys.modules.pop('standardized_schemas', None)
     
     logger.info(f"Discovered {len(tools)} tools: {list(tools.keys())}")
     return tools


### PR DESCRIPTION
Cinque fix indipendenti dall'audit pre-release, un commit atomico ciascuno. Sono raggruppati in una sola PR perché la branch protection è `strict`: mergiarli in sequenza costerebbe cinque cicli CI completi per ~180 righe di modifiche meccaniche.

| Commit | Finding | Perché conta |
|---|---|---|
| `67db9cf` | **P3-05** 🔴 | Il Responder riportava `status: "completed"` su azioni di contenimento **mai eseguite** |
| `c09f28d` | **P3-06** 🔴 | Un solo tool malformato mandava in CrashLoop **tutti i 58** |
| `44ba8cc` | **MC-01** 🔴 | L'API del sensor eseguiva **osquery arbitrario senza autenticazione** |
| `530c996` | **MD-06** 🔴 | Il compose del sensor concedeva **escape verso l'host** |
| `109f7d2` | **MC-13** 🟠 | Il gateway **non poteva partire in produzione** |

---

### 1. Responder: successo riportato su azioni mai eseguite (`67db9cf`)

`ApiConnector` ricadeva su `_simulate_tool_execution()` ogni volta che il servizio tools rifiutava la connessione:

```python
except httpx.HTTPError as e:
    if "Connection" in str(e) or "refused" in str(e).lower():
        return self._simulate_tool_execution(tool_name, params)   # status: "completed"
```

Questo è il percorso di **incident response automatizzata**. Il fallback si attiva esattamente quando la piattaforma è degradata — cioè durante un incidente — quindi uno step di playbook che dovrebbe isolare un host o bloccare un IP riporta successo mentre non è successo nulla, il workflow engine prosegue, e l'incidente risulta remediato. L'unica traccia era un `logger.warning`.

Rimossi tutti e tre i fallback (`run_tool`, `list_tools`, `get_tool_info`) e le ~160 righe di dati fabbricati dietro di essi. `ConnectorError` è già sollevata su ogni altro path di errore, quindi i chiamanti la gestiscono. `demo_final.py` chiamava `_get_simulated_tools()` direttamente: ora riporta l'indisponibilità invece di stampare tool inventati.

### 2. Un tool rotto abbatteva tutto il servizio (`c09f28d`)

`discover_tools()` catturava solo `(ValueError, KeyError, TypeError, ConnectionError, TimeoutError, ModuleNotFoundError, ImportError)` attorno a tre `spec.loader.exec_module()` che eseguono codice a livello di modulo di 58 package di terze parti. `SyntaxError`, `IndentationError`, `AttributeError`, `NameError`, `OSError` non sono nessuna di quelle — e sono i guasti **più probabili** per un tool contribuito.

`discover_tools()` è chiamata da `create_app()` a import-time, quindi l'eccezione usciva dal processo: container in CrashLoopBackOff e tutti i 58 tool giù. Il `continue` sotto l'handler dimostra che l'isolamento per-tool era l'intento; la tupla stretta lo vanificava proprio nei casi comuni.

Aggiunto anche un `finally` che ripulisce le voci temporanee in `sys.modules`: su un `exec_module` abortito sopravvivevano, e il tool successivo poteva importare gli schemi di quello precedente.

### 3. API del sensor senza autenticazione (`44ba8cc`)

`_require_auth()` era **scritto e mai applicato**: tutte le rotte registrate nude, incluse `PUT /api/v1/config`, `POST /api/v1/config/reload` e `POST /api/v1/query`, il cui body finisce in

```python
cmd = ["osqueryi", "--json", query]        # osquery_manager.py:331
```

Non è command injection (lista argv, nessuna shell), ma osquery è un motore di introspezione dell'host: tabelle come `file`, `shell_history`, `users`, `shadow` trasformano una POST non autenticata in lettura arbitraria dell'endpoint monitorato. Il `config.yaml` spedito bindava su `0.0.0.0`, quindi in un deploy standalone qualunque host della rete poteva farlo.

- `_require_auth` applicato a ogni rotta tranne `/health`.
- Reso **fail-closed**: prima restituiva l'handler intatto se `network.api_key` non era configurata — nessuna chiave significava nessuna autenticazione.
- `config.yaml` (deploy standalone) ora binda `127.0.0.1`; `config.docker.yaml` mantiene `0.0.0.0` (necessario dentro un container) con la nota che la porta va pubblicata solo su loopback.

### 4. Escape verso l'host nel compose del sensor (`530c996`)

Il compose standalone — cioè come il sensor arriva sugli endpoint dei clienti — concedeva **quattro percorsi indipendenti** verso il compromesso totale dell'host, su un servizio che espone anche un'API HTTP:

| Concessione | Effetto |
|---|---|
| `DAC_READ_SEARCH` | Bypassa **ogni** controllo di permesso in lettura → con `/etc` montato: `shadow`, chiavi TLS private, chiavi SSH |
| `SYS_PTRACE` + `pid: host` | ptrace di qualsiasi processo host, incluso il dump della memoria di chi detiene segreti |
| `/var/run/docker.sock` | Il `:ro` limita il **file**, non l'API Docker: `docker run -v /:/host --privileged` è comunque root |
| `ports: 8004:8004` | API raggiungibile da tutta la rete |

`no-new-privileges: true` non mitiga nulla di tutto ciò: le capability sono concesse all'avvio, non acquisite via setuid.

**Verificato prima di rimuoverle**: nulla sotto `open-security-sensor/` referenzia `/host` o `docker.sock` — `resource_monitor.py` usa `psutil` sul proprio processo. Il `docker-compose.yml` root fa già la cosa giusta (monta solo `/proc/stat`, `/proc/meminfo`, `/proc/loadavg`, `/sys/class/net` e binda `127.0.0.1`): entrambi i file per-servizio sono allineati a quello, con `cap_drop: ALL`.

### 5. Il gateway non poteva partire in produzione (`109f7d2`)

```yaml
volumes:
  - ./open-security-gateway/nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro
```

Quel file **non esiste** nel repo. Docker, di fronte a un bind source mancante, crea una **directory vuota**: nginx trova una directory dove si aspetta `nginx.conf` e si rifiuta di partire. Il gateway andava in crash loop a ogni deploy di produzione, portandosi dietro l'intera piattaforma.

Oltre all'interruzione, il dettaglio preoccupante: `nginx.conf` è dove vivono le `limit_req_zone` (`global`/`per_ip`/`auth`), quindi qualunque cosa fosse finita a quel path avrebbe determinato in silenzio l'intera postura di rate limiting.

---

Nessuna modifica richiede migrazioni o cambi di configurazione lato utente, tranne una conseguenza voluta: un sensor senza `network.api_key` configurata ora risponde `503` invece di servire l'API in chiaro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
