### PR TITLE
feat(tools): WAF bypass tester sends real requests (was hash(payload) %% 100)

### DIFF
--- a/open-security-tools/app/tools/web_application_firewall_bypass/main.py
+++ b/open-security-tools/app/tools/web_application_firewall_bypass/main.py
@@ -1,10 +1,35 @@
 import asyncio
+import logging
+import os
 import time
-import re
 import urllib.parse
 import base64
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# A WAF-bypass tester sends attack payloads to a live target. It only runs
+# against hosts the operator has explicitly authorised: the built-in list
+# below (safe public test endpoints) plus anything in the
+# WAF_BYPASS_AUTHORIZED_DOMAINS environment variable (comma-separated). This
+# is not security theatre — without it the tool is an attack proxy.
+_ENV_AUTHORIZED = [
+    d.strip().lower()
+    for d in os.getenv("WAF_BYPASS_AUTHORIZED_DOMAINS", "").split(",")
+    if d.strip()
+]
+
+# Requests that carry a WAF block are commonly one of these, in addition to
+# any response matched by the signature/pattern detector.
+_BLOCK_STATUS_CODES = {403, 406, 429, 501, 503}
+
+# Cap the real request volume: the payload x encoding x obfuscation grid can
+# be large, and this hits a live host.
+_MAX_REQUESTS = 200
+_CONCURRENCY = 5
 
 try:
     from schemas import (
@@ -21,10 +46,15 @@ except ImportError:
 TOOL_INFO = {
     "name": "web_application_firewall_bypass",
     "display_name": "WAF Bypass Tester",
-    "description": "Tests various techniques to bypass Web Application Firewall (WAF) protections",
+    "description": (
+        "Sends real encoded/obfuscated attack payloads to a target and reports "
+        "which get through its WAF, based on the actual HTTP responses. Only "
+        "runs against authorised hosts (built-in test endpoints plus "
+        "WAF_BYPASS_AUTHORIZED_DOMAINS)."
+    ),
     "category": "web_security",
     "author": "Wildbox Security",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "input_schema": WAFBypassRequest.model_json_schema(),
     "output_schema": WAFBypassResponse.model_json_schema(),
     "requires_api_key": False,
@@ -170,74 +200,49 @@ class WAFBypassTester:
         
         return False, None
     
-    def _simulate_request(self, url: str, payload: str, 
-                         headers: Optional[Dict[str, str]] = None) -> Dict:
-        """Simulate HTTP request and response"""
-        # Simulate response based on payload characteristics
-        payload_lower = payload.lower()
-        
-        # Determine if WAF would trigger
-        waf_triggered = False
-        response_code = 200
-        
-        # Basic WAF rules simulation
-        suspicious_patterns = [
-            "script", "union", "select", "drop", "insert", "update",
-            "delete", "exec", "eval", "alert", "onload", "onerror",
-            "../", "etc/passwd", "system32", "cmd.exe"
-        ]
-        
-        # Check for obvious attack patterns
-        for pattern in suspicious_patterns:
-            if pattern in payload_lower:
-                # Simulate WAF detection based on encoding/obfuscation
-                detection_probability = 0.8
-                
-                # Reduce detection for encoded payloads
-                if "%3c" in payload or "&#x" in payload or "\\u" in payload:
-                    detection_probability *= 0.6
-                
-                # Reduce detection for obfuscated payloads
-                if "/**/" in payload or "<!---->" in payload:
-                    detection_probability *= 0.7
-                
-                if hash(payload) % 100 < detection_probability * 100:
-                    waf_triggered = True
-                    response_code = 403
-                    break
-        
-        # Simulate response
-        response_size = 1500 + (hash(payload) % 5000)
-        
-        # Simulate headers
-        simulated_headers = {
-            "server": "nginx/1.18.0",
-            "content-type": "text/html",
-            "content-length": str(response_size)
+    async def _send_request(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        payload: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Dict:
+        """Send the payload to the real target as a query parameter.
+
+        Returns the real status code, headers, body and size — or an error
+        string if the request could not be completed. WAFs inspect the query
+        string, so injecting the payload there is the standard way to test
+        whether it gets through.
+        """
+        parsed = urllib.parse.urlparse(url)
+        query = dict(urllib.parse.parse_qsl(parsed.query))
+        query["q"] = payload
+        target = parsed._replace(query=urllib.parse.urlencode(query)).geturl()
+
+        request_headers = {
+            "User-Agent": "Wildbox-WAF-Bypass-Tester/2.0",
+            **(headers or {}),
         }
-        
-        # Add WAF headers if triggered
-        if waf_triggered:
-            waf_type = list(self.waf_signatures.keys())[hash(url) % len(self.waf_signatures)]
-            if waf_type == "cloudflare":
-                simulated_headers["cf-ray"] = "abc123-SJC"
-                simulated_headers["server"] = "cloudflare"
-            elif waf_type == "akamai":
-                simulated_headers["server"] = "AkamaiGHost"
-        
-        # Simulate response body
-        if waf_triggered:
-            response_body = "<html><body><h1>Access Denied</h1><p>Security violation detected.</p></body></html>"
-        else:
-            response_body = "<html><body><h1>Welcome</h1><p>Request processed successfully.</p></body></html>"
-        
-        return {
-            "status_code": response_code,
-            "headers": simulated_headers,
-            "body": response_body,
-            "size": response_size
-        }
-    
+
+        try:
+            async with session.get(
+                target, headers=request_headers, allow_redirects=False
+            ) as response:
+                body = await response.text(errors="replace")
+                return {
+                    "status_code": response.status,
+                    "headers": {k.lower(): v for k, v in response.headers.items()},
+                    "body": body,
+                    "size": len(body),
+                    "error": None,
+                }
+        except asyncio.TimeoutError:
+            return {"status_code": 0, "headers": {}, "body": "", "size": 0,
+                    "error": "request timed out"}
+        except aiohttp.ClientError as exc:
+            return {"status_code": 0, "headers": {}, "body": "", "size": 0,
+                    "error": f"request failed: {exc}"}
+
     def _generate_technique_stats(self, payloads: List[WAFBypassPayload]) -> List[WAFBypassTechnique]:
         """Generate statistics for each technique"""
         techniques = {}
@@ -361,8 +366,8 @@ class WAFBypassTester:
             if ':' in domain:
                 domain = domain.split(':')[0]
             
-            # Check against authorized domains
-            for authorized in self.authorized_domains:
+            # Check against authorized domains (built-in + operator-supplied)
+            for authorized in self.authorized_domains + _ENV_AUTHORIZED:
                 if domain == authorized or domain.endswith(f".{authorized}"):
                     return True
             
@@ -403,74 +408,88 @@ async def execute_tool(request: WAFBypassRequest) -> WAFBypassResponse:
             bypass_recommendations=["Only test against authorized targets"],
             waf_improvement_suggestions=["Ensure proper authorization before testing"],
             timestamp=datetime.now().isoformat(),
-            processing_time_ms=int((time.time() - start_time) * 1000)
+            processing_time_ms=int((time.time() - start_time) * 1000),
+            success=False,
+            summary="Target not authorised for WAF bypass testing",
         )
     
-    payload_results = []
-    
-    # Test different combinations of payloads, encodings, and obfuscations
+    # Build the full payload grid up front so it can be capped and run with
+    # bounded concurrency against the live target.
+    jobs = []
     for payload_type in request.payload_types:
         if payload_type not in tester.base_payloads:
             continue
-            
         for base_payload in tester.base_payloads[payload_type]:
             for encoding in request.encoding_techniques:
                 for obfuscation in request.obfuscation_methods:
-                    # Apply encoding and obfuscation
-                    modified_payload = tester._encode_payload(base_payload, encoding)
-                    modified_payload = tester._obfuscate_payload(modified_payload, obfuscation)
-                    
-                    # Simulate request
-                    response = tester._simulate_request(
-                        request.target_url, 
-                        modified_payload, 
-                        request.custom_headers
-                    )
-                    
-                    # Detect WAF
-                    waf_triggered, _ = tester._detect_waf(
-                        response["headers"], 
-                        response["body"]
-                    )
-                    
-                    # Determine bypass success
-                    bypass_success = response["status_code"] == 200 and not waf_triggered
-                    
-                    # Extract detection signatures
-                    detection_signatures = []
-                    if waf_triggered:
-                        for waf_name, signatures in tester.waf_signatures.items():
-                            for sig in signatures:
-                                if sig.lower() in str(response["headers"]).lower():
-                                    detection_signatures.append(f"{waf_name}:{sig}")
-                    
-                    payload_results.append(WAFBypassPayload(
-                        original_payload=base_payload,
-                        modified_payload=modified_payload,
-                        technique=payload_type,
-                        encoding=encoding,
-                        obfuscation=obfuscation,
-                        bypass_success=bypass_success,
-                        response_code=response["status_code"],
-                        response_size=response["size"],
-                        waf_triggered=waf_triggered,
-                        detection_signatures=detection_signatures
-                    ))
-                    
-                    # Add delay to simulate real testing
-                    await asyncio.sleep(0.01)
-    
+                    modified = tester._encode_payload(base_payload, encoding)
+                    modified = tester._obfuscate_payload(modified, obfuscation)
+                    jobs.append((payload_type, base_payload, encoding, obfuscation, modified))
+
+    truncated = len(jobs) > _MAX_REQUESTS
+    jobs = jobs[:_MAX_REQUESTS]
+
+    payload_results: List[WAFBypassPayload] = []
+    timeout = aiohttp.ClientTimeout(total=request.timeout)
+    connector = aiohttp.TCPConnector(ssl=request.verify_ssl)
+    semaphore = asyncio.Semaphore(_CONCURRENCY)
+
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+
+        async def run_job(job):
+            payload_type, base_payload, encoding, obfuscation, modified = job
+            async with semaphore:
+                response = await tester._send_request(
+                    session, request.target_url, modified, request.custom_headers
+                )
+            waf_triggered, _ = tester._detect_waf(response["headers"], response["body"])
+
+            # A bypass means the attack payload reached the app without being
+            # blocked: a real 2xx/3xx AND no WAF block signature. A failed
+            # request (error / status 0) is never counted as a bypass.
+            blocked = (
+                response["error"] is not None
+                or response["status_code"] in _BLOCK_STATUS_CODES
+                or response["status_code"] == 0
+                or waf_triggered
+            )
+            bypass_success = (not blocked) and 200 <= response["status_code"] < 400
+
+            detection_signatures = []
+            if waf_triggered:
+                headers_str = str(response["headers"]).lower()
+                for waf_name, signatures in tester.waf_signatures.items():
+                    for sig in signatures:
+                        if sig.lower() in headers_str:
+                            detection_signatures.append(f"{waf_name}:{sig}")
+
+            return WAFBypassPayload(
+                original_payload=base_payload,
+                modified_payload=modified,
+                technique=payload_type,
+                encoding=encoding,
+                obfuscation=obfuscation,
+                bypass_success=bypass_success,
+                response_code=response["status_code"],
+                response_size=response["size"],
+                waf_triggered=waf_triggered,
+                detection_signatures=detection_signatures,
+            )
+
+        payload_results = await asyncio.gather(*(run_job(j) for j in jobs))
+
     # Analyze results
     successful_bypasses = sum(1 for p in payload_results if p.bypass_success)
     total_payloads = len(payload_results)
     bypass_rate = successful_bypasses / total_payloads if total_payloads > 0 else 0
     
-    # Detect WAF from initial request
-    initial_response = tester._simulate_request(request.target_url, "test")
-    waf_detected, waf_type = tester._detect_waf(
-        initial_response["headers"], 
-        initial_response["body"]
-    )
+    # Detect the WAF from a clean baseline request to the real target.
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=request.timeout),
+        connector=aiohttp.TCPConnector(ssl=request.verify_ssl),
+    ) as session:
+        baseline = await tester._send_request(session, request.target_url, "wildbox-baseline")
+    waf_detected, waf_type = tester._detect_waf(baseline["headers"], baseline["body"])
     
     # Generate technique statistics
     techniques_tested = tester._generate_technique_stats(payload_results)
@@ -491,6 +510,10 @@ async def execute_tool(request: WAFBypassRequest) -> WAFBypassResponse:
     risk_level = tester._assess_risk_level(bypass_rate, successful_bypasses)
     
     vulnerability_summary = f"WAF bypass success rate: {bypass_rate:.1%}. "
+    if truncated:
+        vulnerability_summary += (
+            f"Note: the payload grid was capped at {_MAX_REQUESTS} requests. "
+        )
     if risk_level in ["Critical", "High"]:
         vulnerability_summary += "Significant bypass vulnerabilities detected."
     elif risk_level == "Medium":
@@ -517,16 +540,20 @@ async def execute_tool(request: WAFBypassRequest) -> WAFBypassResponse:
         payload_results=payload_results[:50],  # Limit results
         blocked_patterns=blocked_patterns,
         allowed_patterns=allowed_patterns,
-        filtering_rules=[
-            "SQL injection pattern detection",
-            "XSS script tag filtering",
-            "Command injection prevention",
-            "Path traversal blocking"
-        ],
+        filtering_rules=sorted({
+            f"{p.technique} payloads blocked ({p.encoding}/{p.obfuscation})"
+            for p in payload_results
+            if p.waf_triggered or p.response_code in _BLOCK_STATUS_CODES
+        }) or ["No payloads were blocked by the target"],
         risk_level=risk_level,
         vulnerability_summary=vulnerability_summary,
         bypass_recommendations=bypass_recommendations,
         waf_improvement_suggestions=waf_improvements,
         timestamp=datetime.now().isoformat(),
-        processing_time_ms=processing_time
+        processing_time_ms=processing_time,
+        success=True,
+        summary=(
+            f"Tested {total_payloads} payloads against {request.target_url}: "
+            f"{successful_bypasses} reached the application"
+        )
     )

--- a/open-security-tools/tests/unit/test_web_application_firewall_bypass.py
+++ b/open-security-tools/tests/unit/test_web_application_firewall_bypass.py
@@ -1,0 +1,202 @@
+"""Unit tests for the WAF Bypass Tester.
+
+The tool sends real HTTP requests to a target; these tests stub aiohttp so
+they run offline. The suite locks in that bypass verdicts come from the real
+response (status + WAF signatures), not from hash(payload) % 100 as the
+previous _simulate_request did, and that the tool refuses unauthorised
+targets.
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("API_KEY", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+
+APP_DIR = Path(__file__).resolve().parents[2] / "app"
+TOOL_DIR = APP_DIR / "tools" / "web_application_firewall_bypass"
+
+sys.path.insert(0, str(APP_DIR))
+
+
+def _load(name, path, extra_modules=None):
+    """Load a tool module under a unique name (see test_ct_log_scanner)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    injected = list((extra_modules or {}).items())
+    for key, value in injected:
+        sys.modules[key] = value
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for key, _ in injected:
+            sys.modules.pop(key, None)
+    return module
+
+
+_std = _load("waf_standardized_schemas", APP_DIR / "standardized_schemas.py")
+_schemas = _load("waf_schemas", TOOL_DIR / "schemas.py", {"standardized_schemas": _std})
+waf = _load("waf_main", TOOL_DIR / "main.py", {"schemas": _schemas})
+
+
+class FakeResponse:
+    def __init__(self, status, headers=None, body=""):
+        self.status = status
+        self.headers = headers or {}
+        self._body = body
+
+    async def text(self, errors="replace"):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    """Maps a substring of the request URL to a FakeResponse."""
+
+    def __init__(self, responder):
+        self._responder = responder
+
+    def get(self, url, **kwargs):
+        return self._responder(url)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def request_factory():
+    def _make(url="https://test.local/app", **overrides):
+        params = dict(
+            target_url=url,
+            payload_types=["xss"],
+            encoding_techniques=["none"],
+            obfuscation_methods=["none"],
+        )
+        params.update(overrides)
+        return _schemas.WAFBypassRequest(**params)
+
+    return _make
+
+
+def _patch_session(monkeypatch, responder):
+    """Make every aiohttp.ClientSession the tool opens a FakeSession."""
+    monkeypatch.setattr(
+        waf.aiohttp, "ClientSession", lambda *a, **k: FakeSession(responder)
+    )
+    monkeypatch.setattr(waf.aiohttp, "TCPConnector", lambda *a, **k: None)
+    monkeypatch.setattr(waf.aiohttp, "ClientTimeout", lambda *a, **k: None)
+
+
+class TestAuthorization:
+    def test_unauthorised_target_is_refused_without_any_request(self, request_factory, monkeypatch):
+        called = {"n": 0}
+
+        def responder(url):
+            called["n"] += 1
+            return FakeResponse(200)
+
+        _patch_session(monkeypatch, responder)
+        out = asyncio.run(waf.execute_tool(request_factory(url="https://not-mine.example/")))
+        assert out.success is False
+        assert out.total_payloads_tested == 0
+        assert called["n"] == 0                       # never touched the target
+        assert "not authorised" in out.summary.lower()
+
+    def test_env_allowlist_authorises_a_target(self, request_factory, monkeypatch):
+        monkeypatch.setattr(waf, "_ENV_AUTHORIZED", ["mytarget.example"])
+        _patch_session(monkeypatch, lambda url: FakeResponse(200, body="ok"))
+        out = asyncio.run(waf.execute_tool(request_factory(url="https://mytarget.example/x")))
+        assert out.success is True
+        assert out.total_payloads_tested > 0
+
+
+class TestBypassVerdicts:
+    def test_a_real_200_with_no_waf_signature_is_a_bypass(self, request_factory, monkeypatch):
+        _patch_session(monkeypatch, lambda url: FakeResponse(200, body="welcome"))
+        out = asyncio.run(waf.execute_tool(request_factory()))
+        assert out.successful_bypasses == out.total_payloads_tested
+        assert all(p.bypass_success for p in out.payload_results)
+
+    def test_a_403_is_never_a_bypass(self, request_factory, monkeypatch):
+        _patch_session(monkeypatch, lambda url: FakeResponse(403, body="blocked"))
+        out = asyncio.run(waf.execute_tool(request_factory()))
+        assert out.successful_bypasses == 0
+        assert all(p.waf_triggered or not p.bypass_success for p in out.payload_results)
+
+    def test_a_200_carrying_a_waf_signature_is_not_a_bypass(self, request_factory, monkeypatch):
+        # 200 status but a Cloudflare block signature in the body.
+        _patch_session(
+            monkeypatch,
+            lambda url: FakeResponse(200, headers={"cf-ray": "abc-SJC"}, body="access denied"),
+        )
+        out = asyncio.run(waf.execute_tool(request_factory()))
+        assert out.successful_bypasses == 0
+        assert all(p.waf_triggered for p in out.payload_results)
+        assert any("cloudflare" in sig for p in out.payload_results for sig in p.detection_signatures)
+
+    def test_a_failed_request_is_not_counted_as_a_bypass(self, request_factory, monkeypatch):
+        def responder(url):
+            raise waf.aiohttp.ClientError("connection reset")
+
+        _patch_session(monkeypatch, responder)
+        out = asyncio.run(waf.execute_tool(request_factory()))
+        assert out.successful_bypasses == 0
+        assert all(p.response_code == 0 and not p.bypass_success for p in out.payload_results)
+
+
+class TestPayloadTransformationsAreReal:
+    def test_the_payload_actually_sent_is_encoded(self, request_factory, monkeypatch):
+        seen = []
+
+        def responder(url):
+            seen.append(url)
+            return FakeResponse(200, body="ok")
+
+        monkeypatch.setattr(waf, "_ENV_AUTHORIZED", ["test.local"])
+        _patch_session(monkeypatch, responder)
+        asyncio.run(
+            waf.execute_tool(
+                request_factory(
+                    payload_types=["xss"],
+                    encoding_techniques=["base64"],
+                    obfuscation_methods=["none"],
+                )
+            )
+        )
+        # Base64 of "<img src=x>" is "PGltZyBzcmM9eD4=" -> url-encoded in the query.
+        assert seen and any("PGltZy" in url for url in seen)
+
+
+class TestRequestCap:
+    def test_the_request_grid_is_capped(self, request_factory, monkeypatch):
+        sent = {"n": 0}
+
+        def responder(url):
+            sent["n"] += 1
+            return FakeResponse(200, body="ok")
+
+        monkeypatch.setattr(waf, "_MAX_REQUESTS", 3)
+        _patch_session(monkeypatch, responder)
+        out = asyncio.run(
+            waf.execute_tool(
+                request_factory(
+                    payload_types=["xss", "sql_injection"],
+                    encoding_techniques=["none", "url_encoding", "base64"],
+                    obfuscation_methods=["none", "case_variation"],
+                )
+            )
+        )
+        # The grid is far larger than 3; the baseline request is separate.
+        assert out.total_payloads_tested == 3


### PR DESCRIPTION
Quinto e ultimo tool della **categoria A** — chiude i tool riscrivibili senza dipendenze o credenziali nuove.

## Cosa faceva prima

`_simulate_request` **non contattava mai il target**. Decideva se un payload era "bloccato" con:

```python
if hash(payload) % 100 < detection_probability * 100:
    waf_triggered = True
    response_code = 403
response_size = 1500 + (hash(payload) % 5000)
waf_type = list(self.waf_signatures.keys())[hash(url) % len(self.waf_signatures)]
```

Ogni verdetto di bypass era un hash deterministico, senza alcun rapporto con un WAF reale. Un tool di WAF-bypass testing che non manda una singola richiesta al WAF.

## Cosa fa adesso

Le parti davvero utili erano già reali e le ho tenute: `_encode_payload` (url/html/unicode/base64/hex/double-url), `_obfuscate_payload` e `_detect_waf` (matching di firme e block-page su header/body). Il resto ora è vero:

- invia il payload codificato/offuscato al target reale come query parameter e giudica il bypass dalla **risposta HTTP effettiva**;
- `bypass_success` richiede un vero 2xx/3xx **e** nessuna firma di blocco WAF;
- un 403/406/429/501/503, una firma WAF, o una richiesta fallita **non è mai** un bypass — una richiesta fallita produce status 0, non un falso successo;
- la WAF detection gira su una richiesta baseline reale;
- `filtering_rules` sono derivate da cosa il target ha davvero bloccato, non da una lista hardcoded di quattro righe.

## Sicurezza: è un tool dual-use

Invia payload d'attacco a un host vivo, quindi gira **solo su target autorizzati**: gli endpoint di test sicuri built-in più tutto ciò che è in `WAF_BYPASS_AUTHORIZED_DOMAINS`. Un target non autorizzato viene rifiutato **prima di inviare una sola richiesta** (verificato nei test). La griglia di payload è limitata a `_MAX_REQUESTS` con concorrenza controllata, e il troncamento è dichiarato nell'output.

## Bug latente corretto

Nessuno dei due `return` impostava i campi `success`/`summary` richiesti da `BaseToolOutput`: `execute_tool` sollevava un `ValidationError` **a ogni chiamata**. Il tool non era mai stato eseguibile.

## Verifica

**Live contro httpbin.org**: 20 payload reali inviati, status code reali letti indietro. **8 test unitari offline** che stubbano aiohttp e coprono il gate di autorizzazione, il verdetto di bypass per risposte 200/403/con-firma/fallite, che il payload inviato sia davvero codificato, e il cap sulle richieste.

---

Con questa, la categoria A è completa: `ct_log_scanner`, `email_security_analyzer`, `pki_certificate_manager`, `vulnerability_db_scanner` (già in main) e questo. Restano le categorie B (container/iot, serve un binario), C (database/social, credenziali) e i 5 tool D da rimuovere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
