### PR TITLE
feat(tools): IoT scanner does real TCP discovery (was random.random() < 0.3)

### DIFF
--- a/open-security-tools/app/tools/iot_security_scanner/main.py
+++ b/open-security-tools/app/tools/iot_security_scanner/main.py
@@ -1,394 +1,470 @@
-from typing import Dict, Any, List
-import ipaddress
-import asyncio
-import random
-import logging
-import os
-import json
+"""
+IoT Security Scanner
 
-# Configure logging
+Discovers IoT devices by really connecting to the ports their device classes
+listen on, grabs service banners, and reports the security issues that follow
+from what is actually open — plaintext management protocols, missing
+transport encryption, exposed unauthenticated industrial protocols.
+
+Every field is observed. The previous version invented everything: a device
+was "found" with random.random() < 0.3, and its type, open ports,
+credentials, encryption, manufacturer, model and firmware were all
+random.choice/randint, with CVE-2023-<random> ids attached to a fabricated
+"outdated firmware" finding.
+
+What this tool deliberately does NOT do: it does not attempt logins, so it
+never claims default credentials are in use without evidence. An exposed
+management interface is reported as an exposure; credential testing is left
+to a tool run with explicit authorisation.
+"""
+
+import asyncio
+import ipaddress
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from schemas import (
+    IoTDevice,
+    IoTSecurityScannerInput,
+    IoTSecurityScannerOutput,
+    IoTVulnerability,
+    NetworkProtocolAnalysis,
+)
+
 logger = logging.getLogger(__name__)
 
-try:
-    from schemas import (
-        IoTSecurityScannerInput, 
-        IoTSecurityScannerOutput, 
-        IoTDevice, 
-        IoTVulnerability,
-        NetworkProtocolAnalysis
-    )
-except ImportError:
-    from schemas import (
-        IoTSecurityScannerInput, 
-        IoTSecurityScannerOutput, 
-        IoTDevice, 
-        IoTVulnerability,
-        NetworkProtocolAnalysis
-    )
+# Port -> (service name, encrypted?). "encrypted" means the protocol provides
+# transport security by default.
+PORT_SERVICES: Dict[int, Tuple[str, bool]] = {
+    21: ("FTP", False),
+    22: ("SSH", True),
+    23: ("Telnet", False),
+    53: ("DNS", False),
+    80: ("HTTP", False),
+    81: ("HTTP-Alt", False),
+    139: ("NetBIOS", False),
+    443: ("HTTPS", True),
+    445: ("SMB", False),
+    502: ("Modbus", False),
+    515: ("LPD", False),
+    554: ("RTSP", False),
+    631: ("IPP", False),
+    993: ("IMAPS", True),
+    995: ("POP3S", True),
+    1883: ("MQTT", False),
+    1911: ("Fox/Niagara", False),
+    2404: ("IEC-104", False),
+    4840: ("OPC-UA", False),
+    5683: ("CoAP", False),
+    8080: ("HTTP-Alt", False),
+    8081: ("HTTP-Alt", False),
+    8443: ("HTTPS-Alt", True),
+    8883: ("MQTT-TLS", True),
+    9100: ("JetDirect", False),
+    9999: ("HTTP-Alt", False),
+    20000: ("DNP3", False),
+}
+
+# Industrial/OT protocols with no authentication or encryption by design —
+# exposing them on a reachable network is itself the finding.
+UNAUTH_INDUSTRIAL = {502: "Modbus", 2404: "IEC-104", 4840: "OPC-UA", 20000: "DNP3", 1911: "Fox"}
+
 
 class IoTSecurityScanner:
-    """IoT Security Scanner - Comprehensive security assessment for IoT devices"""
-    
+    """IoT Security Scanner — real discovery and configuration analysis."""
+
     name = "IoT Security Scanner"
-    description = "Comprehensive security assessment tool for IoT devices including discovery, vulnerability scanning, and configuration analysis"
+    description = (
+        "Discovers IoT devices by connecting to the ports their device classes "
+        "listen on, grabs banners, and reports issues observable from the open "
+        "services (plaintext management, missing encryption, exposed OT protocols)."
+    )
     category = "iot_security"
-    
-    # Common IoT device fingerprints
+
+    # Which open ports suggest which device class. Used to classify a device
+    # from its real open-port set, not to invent one.
     DEVICE_FINGERPRINTS = {
-        "cameras": [80, 81, 554, 8080, 8081, 9999],
-        "routers": [22, 23, 53, 80, 443, 8080],
+        "camera": [554, 80, 81, 8080, 8081, 9999],
+        "router": [22, 23, 53, 80, 443, 8080],
         "smart_home": [80, 443, 1883, 5683, 8883],
         "industrial": [102, 502, 1911, 2404, 4840, 20000],
-        "printers": [515, 631, 9100],
-        "nas": [21, 22, 80, 139, 443, 445, 993, 995]
+        "printer": [515, 631, 9100],
+        "nas": [21, 22, 80, 139, 443, 445, 993, 995],
     }
-    
-    def _load_default_credentials(self) -> List[Dict[str, str]]:
-        """Load default credentials from secure configuration file."""
+
+    def _candidate_ports(self, port_range: str) -> List[int]:
+        """The known IoT service ports that fall inside the requested range."""
+        known = sorted(PORT_SERVICES)
         try:
-            # Load from secure configuration file
-            creds_file = os.getenv('IOT_DEFAULT_CREDS_FILE', '/etc/security/iot_default_creds.json')
-            if os.path.exists(creds_file):
-                with open(creds_file, 'r') as f:
-                    credentials = json.load(f)
-                    # Validate credential format
-                    for cred in credentials:
-                        if not isinstance(cred, dict) or 'username' not in cred or 'password' not in cred:
-                            logger.warning("Invalid credential format in configuration file")
-                            continue
-                    return credentials
-            else:
-                logger.warning("IoT default credentials file not found. Using minimal safe set.")
-                # Return only safe, minimal credential set for testing
-                return [
-                    {"username": "admin", "password": "admin"},
-                    {"username": "admin", "password": ""}
-                ]
-        except (ValueError, KeyError, TypeError, ConnectionError, TimeoutError) as e:
-            logger.error(f"Failed to load IoT credentials: {e}")
-            return []
-    
-    async def execute(self, input_data: IoTSecurityScannerInput) -> IoTSecurityScannerOutput:
-        """Execute IoT security scan"""
+            low, _, high = port_range.partition("-")
+            lo, hi = int(low), int(high or low)
+        except ValueError:
+            return known
+        return [p for p in known if lo <= p <= hi]
+
+    @staticmethod
+    async def _is_open(ip: str, port: int, timeout: float) -> bool:
+        """Real TCP connect: open only if the handshake completes."""
         try:
-            devices = []
-            vulnerabilities = []
-            
-            # Determine scan targets
-            if input_data.target_ip:
-                targets = [input_data.target_ip]
-            elif input_data.ip_range:
-                targets = self._expand_ip_range(input_data.ip_range)
-            else:
-                # Default local network scan
-                targets = self._get_local_network_range()
-            
-            # Scan each target
-            for target in targets:
-                device = await self._scan_device(target, input_data)
-                if device:
-                    devices.append(device)
-                    
-                    # Check for vulnerabilities
-                    device_vulns = await self._check_vulnerabilities(device, input_data)
-                    vulnerabilities.extend(device_vulns)
-            
-            # Analyze network protocols
-            protocol_analysis = await self._analyze_network_protocols(devices)
-            
-            # Generate summary
-            summary = self._generate_summary(devices, vulnerabilities)
-            
-            return IoTSecurityScannerOutput(
-                devices_found=devices,
-                vulnerabilities=vulnerabilities,
-                network_protocols=protocol_analysis,
-                scan_summary=summary,
-                total_devices=len(devices),
-                critical_vulnerabilities=len([v for v in vulnerabilities if v.severity == "Critical"]),
-                recommendations=self._generate_recommendations(devices, vulnerabilities)
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(ip, port), timeout=timeout
             )
-            
-        except (ValueError, KeyError, TypeError, ConnectionError, TimeoutError) as e:
-            return IoTSecurityScannerOutput(
-                devices_found=[],
-                vulnerabilities=[],
-                network_protocols=[],
-                scan_summary={"error": f"Scan failed: {str(e)}"},
-                total_devices=0,
-                critical_vulnerabilities=0,
-                recommendations=["Fix scan configuration and retry"]
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+            return True
+        except (asyncio.TimeoutError, ConnectionRefusedError, OSError):
+            return False
+
+    @staticmethod
+    async def _grab_banner(ip: str, port: int, timeout: float) -> Optional[str]:
+        """Read a service banner; for HTTP-ish ports send a minimal request."""
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(ip, port), timeout=timeout
             )
-    
-    def _expand_ip_range(self, ip_range: str) -> List[str]:
-        """Expand CIDR notation to individual IPs"""
+        except (asyncio.TimeoutError, ConnectionRefusedError, OSError):
+            return None
         try:
-            network = ipaddress.ip_network(ip_range, strict=False)
-            # Limit to reasonable number for demo
-            return [str(ip) for ip in list(network.hosts())[:20]]
-        except (ipaddress.AddressValueError, ValueError) as e:
-            logger.error(f"Error parsing IP range {ip_range}: {e}")
-            return [ip_range]  # Assume single IP if CIDR fails
-    
-    def _get_local_network_range(self) -> List[str]:
-        """Get common local network IPs for scanning"""
-        return [f"192.168.1.{i}" for i in range(1, 21)]
-    
-    async def _scan_device(self, ip: str, input_data: IoTSecurityScannerInput) -> IoTDevice:
-        """Scan individual IoT device"""
-        try:
-            # Simulate device discovery and fingerprinting
-            await asyncio.sleep(0.1)  # Simulate scan time
-            
-            # Random chance of finding device (simulated)
-            if random.random() < 0.3:  # 30% chance of finding device
-                device_type = random.choice(list(self.DEVICE_FINGERPRINTS.keys()))
-                open_ports = random.sample(self.DEVICE_FINGERPRINTS[device_type], 
-                                         random.randint(1, 3))
-                
-                # Generate services
-                services = {}
-                for port in open_ports:
-                    services[port] = self._identify_service(port)
-                
-                # Check for web interface
-                web_interface = None
-                if 80 in open_ports or 443 in open_ports:
-                    web_interface = f"http{'s' if 443 in open_ports else ''}://{ip}"
-                
-                # Check default credentials
-                default_creds = random.choice([True, False])
-                
-                # Determine encryption status
-                encryption = random.choice(["Strong", "Weak", "None"])
-                
-                # Calculate security score
-                score = self._calculate_security_score(open_ports, default_creds, encryption)
-                
-                return IoTDevice(
-                    ip_address=ip,
-                    hostname=f"iot-device-{random.randint(1000, 9999)}",
-                    mac_address=self._generate_mac_address(),
-                    device_type=device_type,
-                    manufacturer=self._get_manufacturer(device_type),
-                    model=f"Model-{random.randint(100, 999)}",
-                    firmware_version=f"v{random.randint(1,5)}.{random.randint(0,9)}.{random.randint(0,9)}",
-                    open_ports=open_ports,
-                    services=services,
-                    web_interface=web_interface,
-                    default_credentials=default_creds,
-                    encryption_status=encryption,
-                    security_score=score
+            try:
+                data = await asyncio.wait_for(reader.read(1024), timeout=2)
+                if data:
+                    return data.decode("utf-8", "ignore").strip()
+            except asyncio.TimeoutError:
+                pass
+            if port in (80, 81, 8080, 8081, 8000, 8888, 9999):
+                writer.write(b"GET / HTTP/1.0\r\nHost: " + ip.encode() + b"\r\n\r\n")
+                await writer.drain()
+                resp = await asyncio.wait_for(reader.read(1024), timeout=2)
+                if resp:
+                    return resp.decode("utf-8", "ignore").strip()
+            return None
+        except (asyncio.TimeoutError, OSError):
+            return None
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    @staticmethod
+    def _server_from_banner(banner: Optional[str]) -> Optional[str]:
+        """Pull the HTTP Server header value from a banner, if present."""
+        if not banner:
+            return None
+        for line in banner.splitlines():
+            if line.lower().startswith("server:"):
+                return line.split(":", 1)[1].strip() or None
+        return None
+
+    def _classify_device(self, open_ports: List[int]) -> str:
+        """Pick the device class whose fingerprint best matches the open ports."""
+        best, best_overlap = "unknown", 0
+        port_set = set(open_ports)
+        for device_type, ports in self.DEVICE_FINGERPRINTS.items():
+            overlap = len(port_set & set(ports))
+            if overlap > best_overlap:
+                best, best_overlap = device_type, overlap
+        return best
+
+    @staticmethod
+    def _encryption_status(open_ports: List[int]) -> str:
+        """Derive encryption posture from the real open ports."""
+        services = [PORT_SERVICES.get(p) for p in open_ports]
+        services = [s for s in services if s]
+        if not services:
+            return "Unknown"
+        encrypted = sum(1 for _, enc in services if enc)
+        plaintext = sum(1 for _, enc in services if not enc)
+        if encrypted and not plaintext:
+            return "Strong"
+        if encrypted and plaintext:
+            return "Weak"
+        return "None"
+
+    def _calculate_security_score(self, open_ports: List[int], encryption: str) -> float:
+        """Deterministic posture score from observed facts (0-10)."""
+        score = 10.0
+        score -= min(len(open_ports) * 0.5, 4.0)          # attack surface
+        for port in open_ports:
+            svc = PORT_SERVICES.get(port)
+            if svc and not svc[1] and port in (21, 23, 80, 554):
+                score -= 1.0                                # plaintext management
+            if port in UNAUTH_INDUSTRIAL:
+                score -= 1.5                                # exposed OT protocol
+        score -= {"None": 2.0, "Weak": 1.0}.get(encryption, 0.0)
+        return round(max(score, 0.0), 1)
+
+    async def _scan_device(
+        self, ip: str, ports: List[int], timeout: float
+    ) -> Optional[IoTDevice]:
+        """Scan one host; return a device only if at least one port is open."""
+        results = await asyncio.gather(*(self._is_open(ip, p, timeout) for p in ports))
+        open_ports = [p for p, is_open in zip(ports, results) if is_open]
+        if not open_ports:
+            return None
+
+        services = {p: PORT_SERVICES.get(p, (f"port-{p}", False))[0] for p in open_ports}
+
+        # Banner-grab the first web-ish/plaintext port for a real Server hint.
+        manufacturer = None
+        for port in open_ports:
+            if port in (80, 81, 8080, 8081, 443, 554, 23, 9999):
+                server = self._server_from_banner(
+                    await self._grab_banner(ip, port, timeout)
                 )
-            
-            return None
-            
-        except Exception:
-            return None
-    
-    def _identify_service(self, port: int) -> str:
-        """Identify service running on port"""
-        service_map = {
-            21: "FTP", 22: "SSH", 23: "Telnet", 53: "DNS",
-            80: "HTTP", 443: "HTTPS", 554: "RTSP", 631: "IPP",
-            1883: "MQTT", 5683: "CoAP", 8080: "HTTP-Alt", 8883: "MQTT-SSL",
-            9100: "JetDirect", 102: "S7", 502: "Modbus", 4840: "OPC-UA"
-        }
-        return service_map.get(port, f"Unknown-{port}")
-    
-    async def _check_vulnerabilities(self, device: IoTDevice, input_data: IoTSecurityScannerInput) -> List[IoTVulnerability]:
-        """Check device for vulnerabilities"""
-        vulnerabilities = []
-        
-        # Check default credentials
-        if input_data.check_default_credentials and device.default_credentials:
-            vulnerabilities.append(IoTVulnerability(
-                device_ip=device.ip_address,
-                severity="Critical",
-                category="Authentication",
-                title="Default Credentials",
-                description="Device is using default username/password combination",
-                remediation="Change default credentials immediately"
+                if server:
+                    manufacturer = server
+                    break
+
+        encryption = self._encryption_status(open_ports)
+        return IoTDevice(
+            ip_address=ip,
+            hostname=None,
+            mac_address=None,          # not resolvable across an L3 hop
+            device_type=self._classify_device(open_ports),
+            manufacturer=manufacturer,
+            model=None,
+            firmware_version=None,     # not obtainable without device-specific probes
+            open_ports=open_ports,
+            services=services,
+            web_interface=(
+                f"http://{ip}/" if 80 in open_ports else
+                (f"https://{ip}/" if 443 in open_ports else None)
+            ),
+            default_credentials=False,  # not tested — never claimed without evidence
+            encryption_status=encryption,
+            security_score=self._calculate_security_score(open_ports, encryption),
+        )
+
+    def _check_vulnerabilities(self, device: IoTDevice) -> List[IoTVulnerability]:
+        """Findings that follow directly from the observed open services."""
+        findings: List[IoTVulnerability] = []
+        ip = device.ip_address
+
+        plaintext_mgmt = {23: "Telnet", 21: "FTP", 80: "HTTP", 554: "RTSP"}
+        for port, svc in plaintext_mgmt.items():
+            if port in device.open_ports:
+                findings.append(IoTVulnerability(
+                    device_ip=ip,
+                    severity="High" if port in (23, 21) else "Medium",
+                    category="Cleartext Protocol",
+                    title=f"{svc} exposed on port {port}",
+                    description=(
+                        f"{svc} transmits credentials and data without encryption; "
+                        "anyone on the path can read or tamper with the session."
+                    ),
+                    port=port,
+                    service=svc,
+                    remediation=f"Disable {svc}; use an encrypted equivalent (SSH/HTTPS/SRTP).",
+                ))
+
+        for port, proto in UNAUTH_INDUSTRIAL.items():
+            if port in device.open_ports:
+                findings.append(IoTVulnerability(
+                    device_ip=ip,
+                    severity="Critical",
+                    category="Exposed OT Protocol",
+                    title=f"{proto} reachable on port {port}",
+                    description=(
+                        f"{proto} has no built-in authentication or encryption. "
+                        "Exposing it on a reachable network allows unauthenticated "
+                        "read/write to the device."
+                    ),
+                    port=port,
+                    service=proto,
+                    remediation=(
+                        "Segment OT onto an isolated network; gateway access "
+                        "through an authenticated proxy."
+                    ),
+                ))
+
+        if 1883 in device.open_ports:
+            has_tls = 8883 in device.open_ports
+            findings.append(IoTVulnerability(
+                device_ip=ip,
+                severity="High",
+                category="Cleartext Protocol",
+                title="MQTT without TLS on port 1883",
+                description=(
+                    "Plaintext MQTT is reachable alongside the TLS port."
+                    if has_tls else
+                    "Plaintext MQTT exposes topic data and any credentials in "
+                    "CONNECT packets; port 8883 (MQTT over TLS) was not observed."
+                ),
+                port=1883,
+                service="MQTT",
+                remediation="Require MQTT over TLS (8883) and disable 1883.",
             ))
-        
-        # Check encryption
-        if input_data.check_encryption and device.encryption_status == "None":
-            vulnerabilities.append(IoTVulnerability(
-                device_ip=device.ip_address,
+
+        if device.encryption_status == "None" and device.open_ports:
+            findings.append(IoTVulnerability(
+                device_ip=ip,
                 severity="High",
                 category="Encryption",
-                title="No Encryption",
-                description="Device communications are not encrypted",
-                remediation="Enable encryption for all communications"
+                title="No encrypted service observed",
+                description=(
+                    "Every open service on this device uses a plaintext protocol; "
+                    "no TLS-protected port was found."
+                ),
+                remediation="Expose management and data services over TLS only.",
             ))
-        
-        # Check for insecure services
-        insecure_ports = [21, 23, 80]  # FTP, Telnet, HTTP
-        for port in device.open_ports:
-            if port in insecure_ports:
-                vulnerabilities.append(IoTVulnerability(
-                    device_ip=device.ip_address,
-                    severity="Medium",
-                    category="Network Security",
-                    title=f"Insecure Service: {device.services.get(port, 'Unknown')}",
-                    description=f"Insecure service running on port {port}",
-                    port=port,
-                    service=device.services.get(port),
-                    remediation="Disable insecure services or use secure alternatives"
-                ))
-        
-        # Check firmware (simulated)
-        if input_data.check_firmware and random.random() < 0.4:  # 40% chance of outdated firmware
-            vulnerabilities.append(IoTVulnerability(
-                device_ip=device.ip_address,
-                severity="Medium",
-                category="Firmware",
-                title="Outdated Firmware",
-                description="Device firmware may be outdated and contain known vulnerabilities",
-                cve_id=f"CVE-2023-{random.randint(10000, 99999)}",
-                remediation="Update device firmware to latest version"
+
+        if device.web_interface:
+            is_http = device.web_interface.startswith("http://")
+            findings.append(IoTVulnerability(
+                device_ip=ip,
+                severity="Low",
+                category="Exposure",
+                title="Management web interface reachable",
+                description=(
+                    f"A web interface is exposed at {device.web_interface}. "
+                    "Default credentials were NOT tested by this scan — verify "
+                    "they have been changed."
+                ),
+                port=80 if is_http else 443,
+                service="HTTP" if is_http else "HTTPS",
+                remediation="Restrict access; confirm default credentials are changed.",
             ))
-        
-        return vulnerabilities
-    
-    async def _analyze_network_protocols(self, devices: List[IoTDevice]) -> List[NetworkProtocolAnalysis]:
-        """Analyze network protocols used by IoT devices"""
-        protocols = []
-        
+
+        return findings
+
+    def _analyze_protocols(self, devices: List[IoTDevice]) -> List[NetworkProtocolAnalysis]:
+        """Per-observed-port protocol facts (real protocol-level truths)."""
+        seen: Dict[Tuple[str, int], NetworkProtocolAnalysis] = {}
         for device in devices:
-            for port, service in device.services.items():
-                # Determine protocol security
-                encryption = port in [443, 8883, 993, 995]  # HTTPS, MQTT-SSL, etc.
-                authentication = port not in [53, 80, 554]  # DNS, HTTP, RTSP usually no auth
-                
-                vulns = []
-                if not encryption and port not in [53]:  # DNS exception
-                    vulns.append("Unencrypted communication")
-                if not authentication:
-                    vulns.append("No authentication required")
-                
-                protocols.append(NetworkProtocolAnalysis(
-                    protocol=service,
-                    port=port,
-                    encryption=encryption,
-                    authentication=authentication,
-                    vulnerabilities=vulns
-                ))
-        
-        return protocols
-    
-    def _calculate_security_score(self, open_ports: List[int], default_creds: bool, encryption: str) -> float:
-        """Calculate security score for device"""
-        score = 10.0
-        
-        # Deduct for open ports
-        score -= len(open_ports) * 0.5
-        
-        # Deduct for default credentials
-        if default_creds:
-            score -= 3.0
-        
-        # Deduct for encryption
-        if encryption == "None":
-            score -= 2.0
-        elif encryption == "Weak":
-            score -= 1.0
-        
-        # Deduct for insecure services
-        insecure_ports = [21, 23, 80]
-        for port in open_ports:
-            if port in insecure_ports:
-                score -= 1.0
-        
-        return max(0.0, min(10.0, score))
-    
-    def _generate_mac_address(self) -> str:
-        """Generate random MAC address"""
-        mac = [random.randint(0x00, 0xff) for _ in range(6)]
-        return ":".join(f"{x:02x}" for x in mac)
-    
-    def _get_manufacturer(self, device_type: str) -> str:
-        """Get manufacturer based on device type"""
-        manufacturers = {
-            "cameras": ["Hikvision", "Dahua", "Axis", "Bosch"],
-            "routers": ["Cisco", "Netgear", "TP-Link", "ASUS"],
-            "smart_home": ["Philips", "Samsung", "Amazon", "Google"],
-            "industrial": ["Siemens", "Schneider", "ABB", "Rockwell"],
-            "printers": ["HP", "Canon", "Epson", "Brother"],
-            "nas": ["Synology", "QNAP", "Buffalo", "Western Digital"]
-        }
-        return random.choice(manufacturers.get(device_type, ["Unknown"]))
-    
-    def _generate_summary(self, devices: List[IoTDevice], vulnerabilities: List[IoTVulnerability]) -> Dict[str, Any]:
-        """Generate scan summary"""
-        if not devices:
-            return {"message": "No IoT devices found in scan range"}
-        
-        device_types = {}
+            for port in device.open_ports:
+                name, encrypted = PORT_SERVICES.get(port, (f"port-{port}", False))
+                key = (name, port)
+                if key in seen:
+                    continue
+                authed = port in (22, 443, 993, 995, 8443, 8883)
+                vulns: List[str] = []
+                recs: List[str] = []
+                if not encrypted:
+                    vulns.append("No transport encryption")
+                    recs.append("Move to a TLS-protected equivalent")
+                if port in UNAUTH_INDUSTRIAL:
+                    vulns.append("Protocol has no built-in authentication")
+                    recs.append("Gateway behind an authenticated proxy; isolate the segment")
+                if port == 23:
+                    vulns.append("Telnet is deprecated and cleartext")
+                    recs.append("Replace with SSH")
+                seen[key] = NetworkProtocolAnalysis(
+                    protocol=name, port=port, encryption=encrypted,
+                    authentication=authed, vulnerabilities=vulns, recommendations=recs,
+                )
+        return list(seen.values())
+
+    def _expand_targets(self, input_data: IoTSecurityScannerInput) -> List[str]:
+        """Resolve the target(s) to a concrete, bounded list of IPs."""
+        if input_data.target_ip:
+            return [input_data.target_ip.strip()]
+        if input_data.ip_range:
+            network = ipaddress.ip_network(input_data.ip_range.strip(), strict=False)
+            # Bound the sweep so a huge range cannot be requested by accident.
+            return [str(h) for h in network.hosts()][:256]
+        return []
+
+    async def execute(self, input_data: IoTSecurityScannerInput) -> IoTSecurityScannerOutput:
+        empty = dict(
+            devices_found=[], vulnerabilities=[], network_protocols=[],
+            scan_summary={}, total_devices=0, critical_vulnerabilities=0,
+            recommendations=[],
+        )
+
+        try:
+            targets = self._expand_targets(input_data)
+        except ValueError as exc:
+            return IoTSecurityScannerOutput(**empty, success=False, summary=f"Invalid target: {exc}")
+        if not targets:
+            return IoTSecurityScannerOutput(
+                **empty, success=False, summary="Provide either target_ip or ip_range."
+            )
+
+        ports = self._candidate_ports(input_data.port_scan_range)
+        per_conn = max(0.5, min(3.0, input_data.timeout / max(len(targets), 1)))
+        semaphore = asyncio.Semaphore(32)
+
+        async def scan(ip):
+            async with semaphore:
+                return await self._scan_device(ip, ports, per_conn)
+
+        devices = [d for d in await asyncio.gather(*(scan(ip) for ip in targets)) if d]
+
+        vulnerabilities: List[IoTVulnerability] = []
         for device in devices:
-            device_types[device.device_type] = device_types.get(device.device_type, 0) + 1
-        
-        vuln_severity = {}
-        for vuln in vulnerabilities:
-            vuln_severity[vuln.severity] = vuln_severity.get(vuln.severity, 0) + 1
-        
-        avg_security_score = sum(device.security_score for device in devices) / len(devices)
-        
-        return {
-            "total_devices": len(devices),
-            "device_types": device_types,
-            "vulnerability_summary": vuln_severity,
-            "average_security_score": round(avg_security_score, 2),
-            "devices_with_default_creds": len([d for d in devices if d.default_credentials]),
-            "unencrypted_devices": len([d for d in devices if d.encryption_status == "None"])
+            vulnerabilities.extend(self._check_vulnerabilities(device))
+
+        protocols = self._analyze_protocols(devices)
+        critical = sum(1 for v in vulnerabilities if v.severity == "Critical")
+
+        summary = {
+            "hosts_scanned": len(targets),
+            "devices_found": len(devices),
+            "ports_probed_per_host": len(ports),
+            "device_types": sorted({d.device_type for d in devices}),
+            "severity_breakdown": {
+                sev: sum(1 for v in vulnerabilities if v.severity == sev)
+                for sev in ("Critical", "High", "Medium", "Low")
+            },
+            "note": (
+                "MAC address, firmware version and default-credential status are "
+                "not reported: they are not obtainable by an unauthenticated "
+                "network scan and are left unset rather than guessed."
+            ),
         }
-    
-    def _generate_recommendations(self, devices: List[IoTDevice], vulnerabilities: List[IoTVulnerability]) -> List[str]:
-        """Generate security recommendations"""
-        recommendations = []
-        
+
+        recommendations: List[str] = []
+        if any(23 in d.open_ports or 21 in d.open_ports for d in devices):
+            recommendations.append("Disable Telnet/FTP on all devices; use SSH and SFTP.")
+        if any(d.encryption_status == "None" for d in devices):
+            recommendations.append("Put every management and data service behind TLS.")
+        if any(p in UNAUTH_INDUSTRIAL for d in devices for p in d.open_ports):
+            recommendations.append("Isolate OT protocols on a segmented, gatewayed network.")
+        if not recommendations and devices:
+            recommendations.append("No cleartext or exposed-OT issues observed on the open ports.")
         if not devices:
-            return ["Ensure IoT devices are properly connected to the network"]
-        
-        # Check for default credentials
-        default_cred_devices = [d for d in devices if d.default_credentials]
-        if default_cred_devices:
-            recommendations.append(f"Change default credentials on {len(default_cred_devices)} device(s)")
-        
-        # Check for encryption
-        unencrypted_devices = [d for d in devices if d.encryption_status == "None"]
-        if unencrypted_devices:
-            recommendations.append(f"Enable encryption on {len(unencrypted_devices)} device(s)")
-        
-        # Check for firmware updates
-        if any("Firmware" in v.category for v in vulnerabilities):
-            recommendations.append("Update firmware on devices with known vulnerabilities")
-        
-        # Network segmentation
-        if len(devices) > 3:
-            recommendations.append("Consider network segmentation for IoT devices")
-        
-        # Monitor traffic
-        recommendations.append("Implement network monitoring for IoT device traffic")
-        
-        # Regular security audits
-        recommendations.append("Perform regular IoT security assessments")
-        
-        return recommendations
+            recommendations.append("No devices with open IoT ports were found in range.")
+
+        return IoTSecurityScannerOutput(
+            devices_found=devices,
+            vulnerabilities=vulnerabilities,
+            network_protocols=protocols,
+            scan_summary=summary,
+            total_devices=len(devices),
+            critical_vulnerabilities=critical,
+            recommendations=recommendations,
+            success=True,
+            summary=(
+                f"Scanned {len(targets)} host(s): {len(devices)} device(s) with "
+                f"open IoT ports, {len(vulnerabilities)} finding(s)."
+            ),
+        )
+
 
 async def execute_tool(params: IoTSecurityScannerInput) -> IoTSecurityScannerOutput:
-    """Main entry point for the IoT Security Scanner tool"""
-    scanner = IoTSecurityScanner()
-    return await scanner.execute(params)
+    """Main entry point for the IoT Security Scanner tool."""
+    return await IoTSecurityScanner().execute(params)
 
-# Tool metadata for registration
+
 TOOL_INFO = {
     "name": "IoT Security Scanner",
-    "description": "Comprehensive security assessment tool for IoT devices including discovery, vulnerability scanning, and configuration analysis",
+    "description": (
+        "Discovers IoT/OT devices by really connecting to the ports their "
+        "device classes use, grabs banners, and reports issues observable from "
+        "the open services: cleartext management (Telnet/FTP/HTTP/RTSP), missing "
+        "TLS, and exposed unauthenticated OT protocols (Modbus/DNP3/OPC-UA). "
+        "Does not attempt logins, so it never claims default credentials without "
+        "evidence."
+    ),
     "category": "iot_security",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "author": "Wildbox Security",
     "input_schema": IoTSecurityScannerInput,
     "output_schema": IoTSecurityScannerOutput,
-    "tool_class": IoTSecurityScanner
+    "tool_class": IoTSecurityScanner,
 }

--- a/open-security-tools/tests/unit/test_iot_security_scanner.py
+++ b/open-security-tools/tests/unit/test_iot_security_scanner.py
@@ -1,0 +1,162 @@
+"""Unit tests for the IoT Security Scanner.
+
+The scanner opens real TCP connections; these tests stub the connect and
+banner-grab primitives with a fixed set of "open" ports, so they run offline
+and deterministically. The suite locks in that device type, encryption
+status, findings and score are derived from the observed open ports — the
+previous version invented all of them (a device existed with probability
+random.random() < 0.3, everything else was random.choice/randint).
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("API_KEY", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+
+APP_DIR = Path(__file__).resolve().parents[2] / "app"
+TOOL_DIR = APP_DIR / "tools" / "iot_security_scanner"
+
+sys.path.insert(0, str(APP_DIR))
+
+
+def _load(name, path, extra_modules=None):
+    """Load a tool module under a unique name (see test_ct_log_scanner)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    injected = list((extra_modules or {}).items())
+    for key, value in injected:
+        sys.modules[key] = value
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for key, _ in injected:
+            sys.modules.pop(key, None)
+    return module
+
+
+_std = _load("iot_standardized_schemas", APP_DIR / "standardized_schemas.py")
+_schemas = _load("iot_schemas", TOOL_DIR / "schemas.py", {"standardized_schemas": _std})
+iot = _load("iot_main", TOOL_DIR / "main.py", {"schemas": _schemas})
+
+
+@pytest.fixture
+def open_ports(monkeypatch):
+    """Make _is_open report a fixed set of ports as open, and stub banners."""
+
+    def _install(ports, banner=None):
+        port_set = set(ports)
+
+        async def fake_is_open(ip, port, timeout):
+            return port in port_set
+
+        async def fake_banner(ip, port, timeout):
+            return banner
+
+        monkeypatch.setattr(iot.IoTSecurityScanner, "_is_open", staticmethod(fake_is_open))
+        monkeypatch.setattr(iot.IoTSecurityScanner, "_grab_banner", staticmethod(fake_banner))
+
+    return _install
+
+
+def scan(**overrides):
+    params = dict(target_ip="192.0.2.10", port_scan_range="1-65535", timeout=10)
+    params.update(overrides)
+    return asyncio.run(iot.execute_tool(_schemas.IoTSecurityScannerInput(**params)))
+
+
+class TestDiscovery:
+    def test_a_host_with_no_open_ports_yields_no_device(self, open_ports):
+        open_ports([])
+        out = scan()
+        assert out.total_devices == 0
+        assert out.success is True                     # a clean host is a success, not a failure
+
+    def test_a_host_with_open_ports_is_reported(self, open_ports):
+        open_ports([22, 80])
+        out = scan()
+        assert out.total_devices == 1
+        assert out.devices_found[0].open_ports == [22, 80]
+
+    def test_missing_target_is_rejected(self):
+        out = asyncio.run(
+            iot.execute_tool(_schemas.IoTSecurityScannerInput(port_scan_range="1-100"))
+        )
+        assert out.success is False
+        assert "target_ip or ip_range" in out.summary
+
+
+class TestClassificationFromRealPorts:
+    def test_printer_ports_classify_as_printer(self, open_ports):
+        open_ports([515, 631, 9100])
+        assert scan().devices_found[0].device_type == "printer"
+
+    def test_industrial_ports_classify_as_industrial(self, open_ports):
+        open_ports([502, 20000])
+        assert scan().devices_found[0].device_type == "industrial"
+
+    def test_manufacturer_comes_from_the_real_server_banner(self, open_ports):
+        open_ports([80], banner="HTTP/1.1 200 OK\r\nServer: Boa/0.94.13\r\n\r\n")
+        assert scan().devices_found[0].manufacturer == "Boa/0.94.13"
+
+    def test_mac_and_firmware_are_never_invented(self, open_ports):
+        open_ports([80, 443])
+        device = scan().devices_found[0]
+        assert device.mac_address is None
+        assert device.firmware_version is None
+        assert device.default_credentials is False     # not tested, never claimed
+
+
+class TestEncryptionAndScore:
+    def test_only_tls_ports_are_strong(self, open_ports):
+        open_ports([443, 8883])
+        assert scan().devices_found[0].encryption_status == "Strong"
+
+    def test_only_plaintext_ports_are_none(self, open_ports):
+        open_ports([23, 80])
+        assert scan().devices_found[0].encryption_status == "None"
+
+    def test_mixed_ports_are_weak(self, open_ports):
+        open_ports([22, 80])                            # SSH encrypted, HTTP not
+        assert scan().devices_found[0].encryption_status == "Weak"
+
+    def test_more_exposure_lowers_the_score(self, open_ports):
+        open_ports([443])
+        high = scan().devices_found[0].security_score
+        open_ports([23, 80, 502, 20000])
+        low = scan().devices_found[0].security_score
+        assert low < high
+
+
+class TestFindings:
+    def test_telnet_is_a_high_cleartext_finding(self, open_ports):
+        open_ports([23])
+        titles = [(v.severity, v.title) for v in scan().vulnerabilities]
+        assert ("High", "Telnet exposed on port 23") in titles
+
+    def test_exposed_modbus_is_critical(self, open_ports):
+        open_ports([502])
+        out = scan()
+        assert out.critical_vulnerabilities >= 1
+        assert any("Modbus" in v.title and v.severity == "Critical" for v in out.vulnerabilities)
+
+    def test_plaintext_mqtt_flags_missing_tls(self, open_ports):
+        open_ports([1883])
+        out = scan()
+        assert any("MQTT without TLS" in v.title for v in out.vulnerabilities)
+
+    def test_all_tls_host_has_no_cleartext_findings(self, open_ports):
+        open_ports([443, 8883])
+        out = scan()
+        assert not any(v.category == "Cleartext Protocol" for v in out.vulnerabilities)
+
+    def test_protocol_analysis_reports_real_facts(self, open_ports):
+        open_ports([502])
+        analysis = {p.protocol: p for p in scan().network_protocols}
+        assert "Modbus" in analysis
+        assert analysis["Modbus"].encryption is False
+        assert "Protocol has no built-in authentication" in analysis["Modbus"].vulnerabilities


### PR DESCRIPTION
Categoria B, primo tool — promosso di fatto a **categoria A** perché la scoperta reale non richiede alcuna dipendenza nuova, solo `socket` (come già fa `network_port_scanner`).

## Cosa faceva prima

`_scan_device` "trovava" un device con `random.random() < 0.3` e poi riempiva **ogni** campo dal caso:

```python
device_type = random.choice(list(self.DEVICE_FINGERPRINTS.keys()))
open_ports = random.sample(self.DEVICE_FINGERPRINTS[device_type], random.randint(1, 3))
default_creds = random.choice([True, False])
encryption = random.choice(["Strong", "Weak", "None"])
firmware_version = f"v{random.randint(1,5)}.{random.randint(0,9)}.{random.randint(0,9)}"
cve_id = f"CVE-2023-{random.randint(10000, 99999)}"   # su un finding "firmware obsoleto" inventato
```

MAC casuale, hostname/model casuali, e un CVE inventato appeso a una vulnerabilità di firmware fabbricata.

## Cosa fa adesso

Si connette davvero (`asyncio.open_connection`, concorrenza limitata) ai porti di servizio IoT/OT noti nel range richiesto, e:

- riporta un device **solo se** un porto accetta davvero la connessione;
- classifica il device dal set di porti realmente aperti (miglior overlap col fingerprint), non da un lancio di moneta;
- legge il manufacturer dal **Server header HTTP reale** quando presente;
- deriva la postura di cifratura dai porti osservati (solo TLS → Strong, misto → Weak, solo plaintext → None);
- solleva finding che seguono da ciò che è aperto: Telnet/FTP/HTTP/RTSP in chiaro, MQTT senza il porto TLS 8883, e protocolli OT non autenticati esposti (Modbus/DNP3/OPC-UA/IEC-104/Fox) come **Critical**.

### Ciò che uno scan di rete non può sapere resta `None`, non inventato
MAC address (non risolvibile oltre un hop L3), versione firmware, e **stato delle credenziali di default**. Il tool **non tenta login** — un'interfaccia web esposta è riportata come esposizione con una nota esplicita "credenziali NON testate", invece di fabbricare "Default Credentials: present". Il credential testing attivo va lasciato a uno strumento eseguito con autorizzazione esplicita.

## Verifica

**Live contro scanme.nmap.org** (host che autorizza lo scanning): porte reali 22/53/80 scoperte, manufacturer `Apache/2.4.7 (Ubuntu)` dal Server header vero, classificato router, cifratura Weak, MAC/firmware `None`. **16 test unitari offline** che stubbano il socket layer e coprono classificazione, derivazione della cifratura, scoring e ogni tipo di finding.

---

Con questa restano i tool che **richiedono davvero** qualcosa oltre la stdlib: `container_security_scanner` (binario trivy/grype, gratuito), e i due di categoria C che richiedono credenziali. `social_media_osint` resta escluso perché richiede API a pagamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
