### PR TITLE
fix(gateway): emit real CORS headers so split-origin dashboard login works

### DIFF
--- a/open-security-gateway/Dockerfile.test
+++ b/open-security-gateway/Dockerfile.test
@@ -20,6 +20,10 @@ RUN cd /usr/local/openresty/lualib/resty \
 # Copy Lua scripts
 COPY nginx/lua /usr/local/openresty/lualib/
 
+# Shared include snippets (cors_params.conf and friends) referenced by the
+# test config's auth locations.
+COPY nginx/includes /etc/nginx/includes
+
 # Copy test configuration (kept out of nginx/conf.d so the production image,
 # which COPYs the whole conf.d, doesn't load it alongside wildbox_gateway.conf)
 COPY nginx/test/wildbox_gateway_test.conf /etc/nginx/conf.d/default.conf

--- a/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
+++ b/open-security-gateway/nginx/conf.d/wildbox_gateway.conf
@@ -124,9 +124,6 @@ server {
     http2 on;
     server_name api.wildbox.local wildbox.local *.wildbox.local;
 
-    # Include CORS configuration
-    include /etc/nginx/includes/cors_params.conf;
-
     # SSL Configuration
     ssl_certificate /etc/ssl/wildbox/wildbox.crt;
     ssl_certificate_key /etc/ssl/wildbox/wildbox.key;
@@ -183,24 +180,6 @@ server {
         add_header Content-Type application/json;
     }
 
-    # CORS preflight handler for all API routes (temporarily disabled)
-    # location ~ ^/api.*$ {
-    #     if ($request_method = 'OPTIONS') {
-    #         add_header 'Access-Control-Allow-Origin' '$cors_origin' always;
-    #         add_header 'Access-Control-Allow-Credentials' '$cors_creds' always;
-    #         add_header 'Access-Control-Allow-Methods' '$cors_methods' always;
-    #         add_header 'Access-Control-Allow-Headers' '$cors_headers' always;
-    #         add_header 'Access-Control-Max-Age' 1728000 always;
-    #         add_header 'Content-Type' 'text/plain; charset=utf-8' always;
-    #         add_header 'Content-Length' 0 always;
-    #         return 204;
-    #     }
-    #     
-    #     # This location is a fallback - specific API routes are handled below
-    #     return 404 '{"error":"endpoint_not_found","message":"The requested API endpoint does not exist"}';
-    #     add_header Content-Type application/json;
-    # }
-
     # Public endpoints (no authentication required)
     location /public/ {
         # Serve static content or documentation
@@ -230,6 +209,8 @@ server {
 
     # User endpoints (identity service, requires auth) - use ^~ for precedence over regex
     location ^~ /auth/users/ {
+        # CORS for the dashboard when served from a different origin.
+        include /etc/nginx/includes/cors_params.conf;
         # Proxy to identity service with correct API path  
         proxy_pass http://identity_service/api/v1/users/;
         include /etc/nginx/includes/proxy_params.conf;
@@ -237,6 +218,8 @@ server {
     
     # Authentication API endpoints (identity service, no gateway auth) - use ^~ for precedence
     location ^~ /auth/jwt/ {
+        # CORS for the dashboard when served from a different origin.
+        include /etc/nginx/includes/cors_params.conf;
         # Rate limiting for auth endpoints (brute-force protection)
         limit_req zone=auth burst=3 nodelay;
         limit_req_status 429;
@@ -248,6 +231,8 @@ server {
 
     # Registration API endpoint (identity service, no gateway auth) - use ^~ for precedence
     location ^~ /auth/register {
+        # CORS for the dashboard when served from a different origin.
+        include /etc/nginx/includes/cors_params.conf;
         limit_req zone=auth burst=2 nodelay;
         limit_req_status 429;
 
@@ -322,6 +307,8 @@ server {
 
     # Identity Service API - Authentication endpoints (no auth required)
     location /api/v1/identity/auth/ {
+        # CORS for the dashboard when served from a different origin.
+        include /etc/nginx/includes/cors_params.conf;
         # No authentication required for auth endpoints
         proxy_pass http://identity_service/api/v1/auth/;
         include /etc/nginx/includes/proxy_params.conf;
@@ -334,6 +321,8 @@ server {
     # producing a 401 even for valid tokens. Pass the request through unchanged;
     # identity enforces auth (and returns 401 itself for missing/invalid JWTs).
     location /api/v1/identity/ {
+        # CORS for the dashboard when served from a different origin.
+        include /etc/nginx/includes/cors_params.conf;
         proxy_pass http://identity_service/api/v1/;
         include /etc/nginx/includes/proxy_params.conf;
     }

--- a/open-security-gateway/nginx/includes/cors_params.conf
+++ b/open-security-gateway/nginx/includes/cors_params.conf
@@ -1,10 +1,26 @@
-# CORS Configuration for Wildbox Security Suite
-# Handles Cross-Origin Resource Sharing for dashboard integration
-# Note: CORS maps are defined in nginx.conf (http context)
+# CORS headers for credentialed cross-origin requests from the dashboard.
+#
+# Include this inside a location that the browser calls cross-origin (the
+# auth/identity API routes). It emits Access-Control-* headers ONLY when the
+# request Origin is on the allowlist defined by $cors_allow_origin in
+# nginx.conf; a non-allowlisted origin gets no ACAO header and the browser
+# blocks the response.
+#
+# `Vary: Origin` is required because the response depends on the Origin
+# header, so shared caches must not serve one origin's response to another.
 
-# No additional configuration needed here - 
-# CORS variables are available through maps defined in nginx.conf:
-# - $cors_origin
-# - $cors_creds  
-# - $cors_methods
-# - $cors_headers
+add_header 'Access-Control-Allow-Origin' $cors_allow_origin always;
+add_header 'Access-Control-Allow-Credentials' 'true' always;
+add_header 'Vary' 'Origin' always;
+
+# Preflight: answer OPTIONS here without proxying upstream.
+if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Allow-Origin' $cors_allow_origin always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' $cors_allow_headers always;
+    add_header 'Access-Control-Max-Age' 1728000 always;
+    add_header 'Vary' 'Origin' always;
+    add_header 'Content-Length' 0 always;
+    return 204;
+}

--- a/open-security-gateway/nginx/nginx.conf
+++ b/open-security-gateway/nginx/nginx.conf
@@ -103,45 +103,30 @@ http {
     lua_shared_dict rate_limit_cache 10m;     # Rate limiting counters
     lua_shared_dict config_cache 1m;          # Gateway configuration cache
 
-    # CORS Maps (must be in http context)
-    map $request_method $cors_origin {
+    # CORS (must be in http context).
+    #
+    # The dashboard talks to the gateway with credentialed requests
+    # (cookies / Authorization). A credentialed CORS response must echo the
+    # SPECIFIC requesting origin, never "*", and doing so for an arbitrary
+    # origin would let any site make authenticated calls on a logged-in
+    # user's behalf. So $cors_allow_origin is an ALLOWLIST keyed on the
+    # request Origin: an origin that is not listed gets an empty value, and
+    # no Access-Control-Allow-Origin header is emitted (the browser then
+    # blocks the cross-origin response, which is the safe default).
+    #
+    # Same-origin deployments (dashboard served by this gateway) need none of
+    # this. Add your dashboard origin below for split-origin deployments.
+    map $http_origin $cors_allow_origin {
         default "";
-        OPTIONS $http_origin;
-        GET $http_origin;
-        POST $http_origin;
-        PUT $http_origin;
-        DELETE $http_origin;
-        PATCH $http_origin;
+        "~^https?://localhost(:[0-9]+)?$"      $http_origin;
+        "~^https?://127\.0\.0\.1(:[0-9]+)?$"  $http_origin;
+        # "https://dashboard.example.com"      $http_origin;
     }
 
-    map $request_method $cors_creds {
+    # Allowed request headers and methods for CORS (fixed policy).
+    map $http_origin $cors_allow_headers {
         default "";
-        OPTIONS "true";
-        GET "true";
-        POST "true";
-        PUT "true";
-        DELETE "true";
-        PATCH "true";
-    }
-
-    map $request_method $cors_methods {
-        default "";
-        OPTIONS "GET, POST, PUT, DELETE, PATCH, OPTIONS";
-        GET "GET, POST, PUT, DELETE, PATCH, OPTIONS";
-        POST "GET, POST, PUT, DELETE, PATCH, OPTIONS";
-        PUT "GET, POST, PUT, DELETE, PATCH, OPTIONS";
-        DELETE "GET, POST, PUT, DELETE, PATCH, OPTIONS";
-        PATCH "GET, POST, PUT, DELETE, PATCH, OPTIONS";
-    }
-
-    map $request_method $cors_headers {
-        default "";
-        OPTIONS "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
-        GET "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
-        POST "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
-        PUT "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
-        DELETE "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
-        PATCH "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
+        "~."  "Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,X-Wildbox-Team-ID,X-API-Key";
     }
 
     # Initialize Lua modules

--- a/open-security-gateway/nginx/test/wildbox_gateway_test.conf
+++ b/open-security-gateway/nginx/test/wildbox_gateway_test.conf
@@ -40,8 +40,17 @@ server {
         add_header Content-Type text/plain;
     }
 
+    # Public login route with CORS (mirrors the production /auth/jwt/ path).
+    # No auth so the CORS preflight/headers can be tested directly.
+    location /auth/jwt/ {
+        include /etc/nginx/includes/cors_params.conf;
+        proxy_pass http://identity_service/api/v1/auth/jwt/;
+        proxy_set_header Host $host;
+    }
+
     # Identity service routes (authentication required)
     location /api/v1/auth/ {
+        include /etc/nginx/includes/cors_params.conf;
         limit_req zone=auth burst=20 nodelay;
 
         access_by_lua_block {

--- a/open-security-gateway/test/ci_auth_tests.sh
+++ b/open-security-gateway/test/ci_auth_tests.sh
@@ -118,6 +118,40 @@ BIGTOKEN=$(printf 'a%.0s' $(seq 1 5000))
 request "oversized token rejected" 400 \
     -H "Authorization: Bearer $BIGTOKEN" "$GATEWAY_URL/api/v1/auth/me"
 
+# --- CORS (dashboard on a separate origin) ---------------------------------
+echo "== CORS =="
+# 13. Preflight from an ALLOWED origin (localhost): echoed origin.
+ACAO=$(curl -sk -o /dev/null -D - -X OPTIONS \
+    -H "Origin: http://localhost:3000" \
+    -H "Access-Control-Request-Method: POST" \
+    "$GATEWAY_URL/auth/jwt/login" 2>/dev/null | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-origin"{print $2}')
+if [ "$ACAO" = "http://localhost:3000" ]; then
+    pass "CORS preflight echoes an allowed origin"
+else
+    fail "CORS preflight: expected origin echoed, got '$ACAO'"
+fi
+
+# 14. Credentials flag present on the preflight.
+ACAC=$(curl -sk -o /dev/null -D - -X OPTIONS \
+    -H "Origin: http://localhost:3000" "$GATEWAY_URL/auth/jwt/login" 2>/dev/null \
+    | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-credentials"{print $2}')
+if [ "$ACAC" = "true" ]; then
+    pass "CORS allows credentials"
+else
+    fail "CORS: expected Allow-Credentials true, got '$ACAC'"
+fi
+
+# 15. A DISALLOWED origin gets NO Access-Control-Allow-Origin header (the
+#     security-critical case: the browser then blocks the response).
+EVIL=$(curl -sk -o /dev/null -D - -X OPTIONS \
+    -H "Origin: https://evil.example" "$GATEWAY_URL/auth/jwt/login" 2>/dev/null \
+    | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-origin"{print $2}')
+if [ -z "$EVIL" ]; then
+    pass "CORS does not echo a disallowed origin"
+else
+    fail "CORS LEAK: echoed disallowed origin '$EVIL'"
+fi
+
 echo
 echo "== Results: $PASS passed, $FAIL failed =="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Il gateway **non emetteva alcun header CORS**: `includes/cors_params.conf` era uno stub di soli commenti e gli `add_header Access-Control-*` in `wildbox_gateway.conf` erano commentati ("temporarily disabled"). Qualsiasi deployment con la dashboard su unorigine diversa dal gateway aveva quindi **ogni chiamata API autenticata — login incluso — silenziosamente bloccata dal browser**. (Emerso costruendo lharness E2E full-stack #103, dove le chiamate browser→gateway fallivano esattamente per questo.)

## Implementato correttamente, con il vincolo di sicurezza del CORS credenzialato

- Le vecchie map facevano eco a `$http_origin` per **qualsiasi** origine **e** inviavano `Access-Control-Allow-Credentials: true`. Quella combinazione permette a **qualsiasi sito** di fare richieste autenticate per conto di un utente loggato. Sostituite con una **allowlist**: `$cors_allow_origin` (nginx.conf) confronta lOrigin della richiesta con una lista (localhost/127.0.0.1 di default, slot documentato per lorigine reale della dashboard) e restituisce `""` per tutto il resto — nessun header ACAO emesso, il browser blocca la risposta.
- `includes/cors_params.conf` ora porta gli header veri (ACAO dallallowlist, Allow-Credentials, `Vary: Origin`) più un preflight OPTIONS che risponde 204 con Allow-Methods/Headers/Max-Age.
- Linclude è cablato nelle location auth/identity che la dashboard chiama cross-origin (`/auth/jwt/`, `/auth/users/`, `/auth/register`, `/api/v1/identity/auth/`, `/api/v1/identity/`). Rimossi il blocco commentato morto e linclude-stub no-op a livello server.

I deployment **same-origin** (dashboard proxata dal gateway) sono invariati — niente header Origin, niente header CORS.

## Verifica

Esteso lharness di auth-test del gateway (workflow **Gateway Tests**, che builda il gateway reale e fa girare `ci_auth_tests.sh`): il gateway ora risponde a un preflight OPTIONS da origine consentita con origine echeggiata + credentials, e — **caso critico di sicurezza** — **non invia alcun `Access-Control-Allow-Origin` per unorigine non consentita**. 3 nuove asserzioni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)