### PR TITLE
fix(dashboard): derive auth-cookie secure flag from page protocol (fixes login on http origins)

### DIFF
--- a/open-security-dashboard/src/components/auth-provider.tsx
+++ b/open-security-dashboard/src/components/auth-provider.tsx
@@ -18,6 +18,18 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
+// Cookie options for the auth token. `secure` is derived from the actual
+// page protocol instead of being hardcoded true: a Secure cookie is dropped
+// by the browser on a plain-HTTP origin (local dev, and the CI E2E harness
+// on http://localhost), which silently broke login there — the token was
+// never stored, so the post-login /users/me call and redirect never ran. In
+// production the dashboard is served over HTTPS, so this stays true.
+function authCookieOptions(): Cookies.CookieAttributes {
+  const secure =
+    typeof window !== 'undefined' && window.location.protocol === 'https:'
+  return { expires: 7, secure, sameSite: 'strict' }
+}
+
 export function useAuth() {
   const context = useContext(AuthContext)
   
@@ -61,7 +73,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       // Store token in cookie only (no localStorage to reduce XSS attack surface)
       if (typeof window !== 'undefined') {
-        Cookies.set('auth_token', access_token, { expires: 7, secure: true, sameSite: 'strict' })
+        Cookies.set('auth_token', access_token, authCookieOptions())
       }
 
       // Fetch user data separately using the correct FastAPI Users endpoint
@@ -82,7 +94,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       // Store token in cookie only (no localStorage to reduce XSS attack surface)
       if (typeof window !== 'undefined') {
-        Cookies.set('auth_token', access_token, { expires: 7, secure: true, sameSite: 'strict' })
+        Cookies.set('auth_token', access_token, authCookieOptions())
       }
 
       // Fetch user data separately using the correct FastAPI Users endpoint


### PR DESCRIPTION
Fix di prodotto (metà client del finding **MB-06** dellaudit) + prerequisito per far passare lharness E2E full-stack #103.

## Il bug

`auth-provider.tsx` impostava il cookie del token con `secure: true` hardcoded. Un cookie **Secure** viene scartato dal browser su unorigine plain-HTTP — quindi su dev locale e nellharness E2E in CI (browser su `http://localhost:3000`) il token **non veniva mai salvato**: il login ritornava 200, ma la chiamata successiva a `/users/me` e il `router.replace("/dashboard")` non venivano mai eseguiti, e il login sembrava bloccarsi.

Verificato dallaccess log dellE2E: la POST di login ritorna `200 OK`, ma nessuna richiesta `/users/me` arriva mai a identity — perché senza cookie lintero flusso post-login si ferma.

## Il fix

`secure` derivato da `window.location.protocol === "https:"` tramite un helper condiviso `authCookieOptions()` usato sia dal login che dalla registrazione. In produzione il dashboard è servito su HTTPS, quindi il flag resta `true`; le origini http (dev, E2E) possono ora persistere il cookie e completare il login.

È il fix di correttezza minimo. Lhardening più ampio di MB-06 (spostare il token in un cookie `httpOnly` impostato server-side, così una XSS non possa leggerlo) è un cambiamento più grande, tracciato a parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)