### PR TITLE
seo(docs): sitemap.xml e robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.wildbox.io/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Hand-maintained: GitHub Pages serves docs/ as-is, there is no build step that
+     could generate this. Adding a page to docs/ means adding its URL here. -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.wildbox.io/</loc></url>
+  <url><loc>https://www.wildbox.io/docs.html</loc></url>
+  <url><loc>https://www.wildbox.io/privacy.html</loc></url>
+  <url><loc>https://www.wildbox.io/api-reference.html</loc></url>
+  <url><loc>https://www.wildbox.io/api/agents-api.html</loc></url>
+  <url><loc>https://www.wildbox.io/api/responder-api.html</loc></url>
+  <url><loc>https://www.wildbox.io/api/swagger-index.html</loc></url>
+</urlset>


### PR DESCRIPTION
GitHub Pages serve `docs/` così com'è (`build_type=legacy`): non esiste un passo di build che possa generare la sitemap, quindi è un file statico.

**Le 7 pagine sono state verificate una per una in produzione**, rispondono tutte `200`:
`/` · `/docs.html` · `/privacy.html` · `/api-reference.html` · `/api/agents-api.html` · `/api/responder-api.html` · `/api/swagger-index.html`

Aggiunto anche `docs/robots.txt` con la riga `Sitemap:` — `wildbox.io` possiede la radice del suo host, quindi viene letto davvero.

⚠️ **Va aggiornato a mano** quando si aggiunge una pagina a `docs/`. Sta scritto in un commento dentro il file. Se preferisci, si può generare in CI con un workflow: dimmelo e lo faccio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
