### PR TITLE
fix(ci): Link Validation — URL Product Hunt canonico + eccezione per il suo 403

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -12,6 +12,10 @@
     {
       "comment": "LibHunt bot-blocks automated requests with HTTP 403; the badge is valid in a browser.",
       "pattern": "^https://www\\.libhunt\\.com"
+    },
+    {
+      "comment": "Product Hunt bot-blocks automated requests with HTTP 403 from CI runners; the badge and its link are valid in a browser (verified 04/09/2026).",
+      "pattern": "^https://www\\.producthunt\\.com"
     }
   ],
   "replacementPatterns": [
@@ -22,7 +26,9 @@
   ],
   "httpHeaders": [
     {
-      "urls": ["https://github.com"],
+      "urls": [
+        "https://github.com"
+      ],
       "headers": {
         "Accept": "text/html"
       }
@@ -32,5 +38,12 @@
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "5s",
-  "aliveStatusCodes": [200, 206, 301, 302, 307, 308]
+  "aliveStatusCodes": [
+    200,
+    206,
+    301,
+    302,
+    307,
+    308
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Self-hosted, open-source security operations platform. Threat monitoring, analys
 
 [![Featured on Self-Host Weekly](https://img.shields.io/badge/Featured%20on-Self--Host%20Weekly-green)](https://selfh.st/weekly/2025-11-07/)
 [![Listed on LibHunt](https://img.shields.io/badge/Listed%20on-LibHunt-blue)](https://www.libhunt.com/r/wildbox)
-[![Featured on Product Hunt](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=wildbox&theme=light)](https://www.producthunt.com/posts/wildbox)
+[![Featured on Product Hunt](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=wildbox&theme=light)](https://www.producthunt.com/products/wildbox)
 
 ---
 


### PR DESCRIPTION
Lo step "Check links in README" segnalava
https://www.producthunt.com/posts/wildbox come link morto (403).

Due cose distinte:

1. Quell'URL e' la forma vecchia: fa 308 verso
   https://www.producthunt.com/products/wildbox. Ora il README punta
   direttamente alla forma canonica (200, verificato).

2. Il 403 non e' un link rotto: Product Hunt blocca le richieste automatiche
   dai runner CI. Misurato oggi: dal browser/da una rete normale l'URL risponde,
   dalla CI no. E' lo stesso caso di LibHunt, gia' presente in ignorePatterns
   di questo file con la stessa identica motivazione — aggiunto accanto, con il
   commento che dice perche'.

Verificato con markdown-link-check e la config del repo: 43 link, 0 morti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)