### PR TITLE
docs: say which services start, and where their ports are reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,28 @@ curl http://localhost/health
 curl http://localhost:8001/health
 
 # 7. Access the platform
-# Dashboard: http://localhost:3000
-# API Documentation: http://localhost:8000/docs
-# Gateway: http://localhost
+# Gateway:           http://localhost          (the only port bound beyond localhost)
+# Dashboard:         http://localhost:3000     (127.0.0.1 only)
+# API Documentation: http://localhost:8000/docs (127.0.0.1 only)
 ```
+
+> **These addresses work on the machine running Docker, and nowhere else.**
+> Only the gateway publishes on all interfaces, on ports 80, 443 and 8080.
+> Every other service is bound to `127.0.0.1`, and PostgreSQL and Redis publish
+> nothing at all. That is deliberate: the gateway is where authentication and
+> rate limiting live, so everything from outside is meant to arrive through it.
+> To reach the dashboard from another machine, put it behind the gateway or
+> open an SSH tunnel; do not move the binding.
+
+The one service behind a profile is `automations`, which stays down until you
+ask for it:
+
+```bash
+docker compose --profile automations up -d
+```
+
+Until then `/api/v1/automations/` returns 502, which is expected rather than
+broken.
 
 ### Default Credentials
 
@@ -237,7 +255,9 @@ FastAPI, PostgreSQL, Elasticsearch, Redis.
 ### **open-security-cspm** (In Development)
 
 Multi-cloud security posture management and compliance scanning.
-Not enabled in the default `docker-compose.yml`.
+Defined in the default `docker-compose.yml` without a profile, so it starts
+with everything else. "In development" describes the feature surface, not
+whether the container runs.
 FastAPI, Celery, Redis, Python cloud SDKs.
 
 ### **open-security-guardian**
@@ -248,7 +268,9 @@ Django, PostgreSQL, Celery, Redis.
 ### **open-security-sensor** (In Development)
 
 Endpoint monitoring and telemetry collection.
-Not enabled in the default `docker-compose.yml`.
+Defined in the default `docker-compose.yml` without a profile, so it starts
+with everything else. "In development" describes the feature surface, not
+whether the container runs.
 osquery, Python, HTTPS.
 
 ### **open-security-responder**

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The one service behind a profile is `automations`, which stays down until you
 ask for it:
 
 ```bash
-docker compose --profile automations up -d
+docker-compose --profile automations up -d
 ```
 
 Until then `/api/v1/automations/` returns 502, which is expected rather than


### PR DESCRIPTION
Two claims in the README do not match `docker-compose.yml`.

## cspm and sensor do start

The README says of both:

> Not enabled in the default `docker-compose.yml`.

They are defined there **without a `profiles` key**, so a plain `docker compose up -d` starts both:

| service | `profiles` | starts by default |
|---|---|---|
| cspm | no | yes |
| sensor | no | yes |
| automations | yes | no |

`automations` is the only one behind a profile, and the README did not mention that. "In development" is accurate about the feature surface and stays; "not enabled" is not accurate about the container. Someone reading it has no reason to expect either service to be running, which matters for a platform that talks to cloud accounts.

## The quick start addresses only work on the Docker host

Step 7 sends the reader to `localhost:3000` and `localhost:8000/docs` with nothing said about where those resolve. Every service except the gateway is bound to `127.0.0.1`, and PostgreSQL and Redis publish nothing at all.

That is the right default for a platform holding credentials for cloud accounts, and it is exactly why someone who tries the dashboard from their laptop gets a connection refused with nothing in the documentation to explain it. The README now says which port is reachable from outside, that the rest are not, and what to do about it: go through the gateway or open an SSH tunnel, rather than moving the binding.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)