### PR TITLE
Two collectors that failed silently: playbook inputs, and the systemd query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
           - responder
           - agents
           - cspm
+          # The sensor was never in this matrix, so its unit tests -- and
+          # until now it had none -- ran nowhere. Its package is sensor/,
+          # not app/; see the coverage case below.
+          - sensor
     
     steps:
       - uses: actions/checkout@v7
@@ -57,6 +61,7 @@ jobs:
           # always empty while looking like it had been collected.
           case "${{ matrix.service }}" in
             guardian) COV="--cov=apps --cov=guardian" ;;
+            sensor)   COV="--cov=sensor" ;;
             *)        COV="--cov=app" ;;
           esac
           if [ -d tests/unit ] && [ -n "$(find tests/unit -name 'test_*.py' -print -quit)" ]; then

--- a/open-security-dashboard/playwright.config.ts
+++ b/open-security-dashboard/playwright.config.ts
@@ -54,6 +54,11 @@ export default defineConfig({
     {
       name: 'backend-chromium',
       use: { ...devices['Desktop Chrome'], ignoreHTTPSErrors: true },
+      // Still only login-flow. The other three specs of #103 were measured
+      // against the running stack on 2026-09-08 and are not ready: of the 31
+      // tests in the four files, 6 passed, 4 skipped and 21 failed. Widening
+      // this would arm a red gate, which is worse than an honest gap -- the
+      // numbers and what they mean are recorded on the issue.
       testMatch: /login-flow\.spec\.ts/,
     },
 
@@ -91,7 +96,10 @@ export default defineConfig({
   /* Playwright manages the dashboard server itself.
      In CI we build first (see workflow) and serve the production build;
      locally we use the dev server and reuse one if it's already running. */
-  webServer: {
+  /* PLAYWRIGHT_SKIP_WEBSERVER: drive a dashboard that is already running --
+     the one in the compose stack -- instead of starting a second Next on the
+     same port. */
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER ? undefined : {
     command: process.env.CI ? 'npm run start' : 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,

--- a/open-security-responder/app/models.py
+++ b/open-security-responder/app/models.py
@@ -7,7 +7,7 @@ Type-safe representations of playbooks, triggers, and execution state.
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from datetime import datetime
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, validator
 
 
 class TriggerType(str, Enum):
@@ -30,10 +30,39 @@ class PlaybookTrigger(BaseModel):
         use_enum_values = True
 
 
+class StepFailurePolicy(str, Enum):
+    """What to do when a step fails"""
+    STOP = "stop"
+    CONTINUE = "continue"
+
+
 class PlaybookStep(BaseModel):
     """Represents a single step in a playbook execution"""
-    
+
+    # Unknown keys are rejected, not ignored.
+    #
+    # pydantic's default is to drop them silently, and that is how
+    # playbooks/all_star_e2e.yml came to write every step's arguments under
+    # `params:` while the engine reads `input`. The playbook looked configured,
+    # loaded without a murmur, and passed nothing: every step ran with an empty
+    # input and died on "missing 2 required positional arguments". A key that
+    # does nothing must be a loading error, and the parser already turns one
+    # into a startup failure the operator can see.
+    #
+    # It follows that every field below has to be honoured somewhere. That is
+    # why retry_count is gone: it was declared here and read by nothing, so a
+    # playbook asking for retries never got them.
+    model_config = ConfigDict(extra="forbid")
+
+    id: Optional[str] = Field(
+        default=None,
+        description="Stable identifier for this step, for humans and logs"
+    )
     name: str = Field(..., description="Unique name for this step")
+    description: Optional[str] = Field(
+        default=None,
+        description="What this step does and why"
+    )
     action: str = Field(..., description="Action in format 'connector.method'")
     input: Optional[Dict[str, Any]] = Field(
         default_factory=dict,
@@ -43,13 +72,13 @@ class PlaybookStep(BaseModel):
         default=None,
         description="Jinja2 condition to evaluate before executing step"
     )
+    on_failure: StepFailurePolicy = Field(
+        default=StepFailurePolicy.STOP,
+        description="Whether a failure of this step ends the run or is recorded and skipped"
+    )
     timeout: Optional[int] = Field(
         default=300,
         description="Timeout in seconds for step execution"
-    )
-    retry_count: Optional[int] = Field(
-        default=0,
-        description="Number of retries on failure"
     )
     
     @validator('action')
@@ -65,6 +94,13 @@ class PlaybookStep(BaseModel):
 
 class Playbook(BaseModel):
     """Main playbook model representing a complete automation workflow"""
+
+    # Same reasoning as PlaybookStep: a top-level key the engine does not read
+    # must fail to load rather than be dropped. playbooks/all_star_e2e.yml
+    # carried an `output:` block mapping step results into a result document;
+    # nothing in the engine has ever rendered it, so the playbook promised an
+    # output shape it did not produce. It is tracked separately.
+    model_config = ConfigDict(extra="forbid")
     
     playbook_id: str = Field(..., description="Unique identifier for the playbook")
     name: str = Field(..., description="Human-readable name")
@@ -112,6 +148,21 @@ class ExecutionStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+
+
+def step_context_key(step: PlaybookStep) -> str:
+    """The key a step's result is filed under in the execution context.
+
+    It is the id when the step has one, and the name otherwise. This is what a
+    later step writes in `{{ steps.<key>.output }}` or in a condition.
+
+    A named function rather than the expression inline, because the two are not
+    interchangeable and the difference is invisible when it is wrong: keying by
+    `name` made every cross-step reference in a playbook that uses ids resolve
+    to nothing -- a false condition, an empty template -- with no error
+    anywhere. Named, it can be tested.
+    """
+    return step.id or step.name
 
 
 class StepExecutionResult(BaseModel):

--- a/open-security-responder/app/workflow_engine.py
+++ b/open-security-responder/app/workflow_engine.py
@@ -19,7 +19,7 @@ from dramatiq.results import Results
 from dramatiq.results.backends import RedisBackend
 
 from .models import (
-    Playbook, PlaybookStep, ExecutionStatus, 
+    Playbook, PlaybookStep, StepFailurePolicy, ExecutionStatus, step_context_key, 
     StepExecutionResult, PlaybookExecutionResult
 )
 from .config import settings
@@ -498,10 +498,19 @@ def execute_playbook_actor(run_id: str, playbook_id: str, trigger_data: Dict[str
                 step_result.duration_seconds = (step_result.end_time - step_result.start_time).total_seconds()
                 step_result.output = action_result
                 
-                # Update context with step result
+                # Update context with step result.
+                #
+                # Keyed by id when the step has one. The key is what a later
+                # step writes in `{{ steps.<key>.output }}`, and playbooks that
+                # give their steps an id refer to them by it -- while this used
+                # to key by `name`, the display label ("🤖 AI-Powered Threat
+                # Analysis"). Every cross-step reference in all_star_e2e.yml
+                # therefore resolved to nothing, silently: conditions read as
+                # false and templates rendered empty. Playbooks without ids are
+                # unaffected, since there `name` is the identifier.
                 if "steps" not in execution_result.context:
                     execution_result.context["steps"] = {}
-                execution_result.context["steps"][step.name] = {
+                execution_result.context["steps"][step_context_key(step)] = {
                     "output": action_result,
                     "status": step_result.status,
                     "duration": step_result.duration_seconds
@@ -533,6 +542,30 @@ def execute_playbook_actor(run_id: str, playbook_id: str, trigger_data: Dict[str
                     level="ERROR"
                 )
                 
+                # on_failure decides whether the run ends here.
+                #
+                # Four steps of playbooks/all_star_e2e.yml declare
+                # `on_failure: "continue"`. Nothing read that key -- the engine
+                # always raised -- so a playbook that asked to carry on stopped
+                # at its first enrichment failure, and the steps after it never
+                # ran. The failure is recorded either way; what changes is
+                # whether the remaining steps get their turn.
+                if step.on_failure == StepFailurePolicy.CONTINUE:
+                    if "steps" not in execution_result.context:
+                        execution_result.context["steps"] = {}
+                    execution_result.context["steps"][step_context_key(step)] = {
+                        "output": None,
+                        "status": step_result.status,
+                        "error": step_result.error,
+                        "duration": step_result.duration_seconds,
+                    }
+                    workflow_engine.add_log(
+                        run_id,
+                        f"Step '{step.name}' declares on_failure=continue; carrying on",
+                        level="WARNING",
+                    )
+                    continue
+
                 # Fail the entire execution
                 raise WorkflowExecutionError(f"Step '{step.name}' failed: {str(e)}")
         

--- a/open-security-responder/playbooks/all_star_e2e.yml
+++ b/open-security-responder/playbooks/all_star_e2e.yml
@@ -32,8 +32,8 @@ steps:
     name: "Validate IP Address"
     action: "system.validate"
     description: "Ensure IP address is properly formatted"
-    params:
-      type: "ipv4"
+    input:
+      type: "ip_address"
       value: "{{ trigger.ip }}"
     timeout: 5
     
@@ -42,7 +42,7 @@ steps:
     name: "🤖 AI-Powered Threat Analysis"
     action: "wildbox.analyze_ioc"
     description: "Use AI to analyze IP reputation and threat level"
-    params:
+    input:
       ioc_type: "ipv4"
       ioc_value: "{{ trigger.ip }}"
       context:
@@ -57,7 +57,7 @@ steps:
     name: "🔍 Network Port Scan"
     action: "wildbox.run_tool"
     description: "Scan common ports to identify exposed services"
-    params:
+    input:
       tool_name: "nmap"
       params:
         target: "{{ trigger.ip }}"
@@ -71,7 +71,7 @@ steps:
     name: "📋 WHOIS Information"
     action: "wildbox.run_tool"
     description: "Gather domain registration and ownership details"
-    params:
+    input:
       tool_name: "whois"
       params:
         target: "{{ trigger.ip }}"
@@ -83,7 +83,7 @@ steps:
     name: "⚖️ Aggregate Threat Assessment"
     action: "system.evaluate"
     description: "Calculate overall threat score based on all findings"
-    params:
+    input:
       condition:
         ai_verdict: "{{ steps.ai_analysis.result.verdict }}"
         ai_confidence: "{{ steps.ai_analysis.result.confidence }}"
@@ -108,7 +108,7 @@ steps:
     action: "wildbox.create_vulnerability"
     description: "Create vulnerability in Guardian if threat detected"
     condition: "{{ steps.threat_assessment.result.severity != 'low' }}"
-    params:
+    input:
       title: "All-Star Test: Potential Threat from {{ trigger.ip }}"
       description: |
         Cross-service integration test detected potential security threat.
@@ -140,28 +140,25 @@ steps:
     name: "📊 Generate Test Report"
     action: "system.create_report"
     description: "Compile comprehensive test results"
-    params:
+    # system.create_report takes (template, data). It used to be given
+    # include_steps and format, which it has no parameters for -- once inputs
+    # actually reached the connector this step raised TypeError. The steps it
+    # wanted to include are named here instead, by id.
+    input:
       template: "all_star_summary"
-      include_steps:
-        - validate_ip
-        - ai_analysis
-        - nmap_scan
-        - whois_lookup
-        - threat_assessment
-        - create_finding
-      format: "json"
+      data:
+        validate_ip: "{{ steps.validate_ip.output }}"
+        ai_analysis: "{{ steps.ai_analysis.output }}"
+        nmap_scan: "{{ steps.nmap_scan.output }}"
+        whois_lookup: "{{ steps.whois_lookup.output }}"
+        threat_assessment: "{{ steps.threat_assessment.output }}"
+        create_finding: "{{ steps.create_finding.output }}"
     timeout: 10
 
-output:
-  format: "json"
-  fields:
-    - test_ip: "{{ trigger.ip }}"
-    - ai_verdict: "{{ steps.ai_analysis.result.verdict }}"
-    - ai_confidence: "{{ steps.ai_analysis.result.confidence }}"
-    - threat_score: "{{ steps.threat_assessment.result.score }}"
-    - severity: "{{ steps.threat_assessment.result.severity }}"
-    - vulnerability_created: "{{ steps.create_finding.executed }}"
-    - vulnerability_id: "{{ steps.create_finding.result.id }}"
-    - services_tested: ["gateway", "responder", "agents", "tools", "guardian"]
-    - total_duration: "{{ execution.duration }}"
-    - status: "{{ execution.status }}"
+# No `output:` block here.
+#
+# It used to map step results into a result document, and nothing in the engine
+# has ever rendered one -- the playbook advertised a result shape it did not
+# produce. The step models now reject keys the engine does not read, so leaving
+# it would stop the service from starting. Output mapping is tracked as its own
+# piece of work.

--- a/open-security-responder/tests/unit/test_playbooks_are_executable.py
+++ b/open-security-responder/tests/unit/test_playbooks_are_executable.py
@@ -34,10 +34,12 @@ os.environ.setdefault("SECRET_KEY", "x" * 40)
 os.environ.setdefault("GATEWAY_INTERNAL_SECRET", "y" * 40)
 
 from app.connectors import connector_registry  # noqa: E402
-from app.models import Playbook, PlaybookStep, step_context_key  # noqa: E402
-from app.playbook_parser import PlaybookParser, PlaybookParseError  # noqa: E402
+from app.models import PlaybookStep, step_context_key  # noqa: E402
+from app.playbook_parser import PlaybookParseError, PlaybookParser  # noqa: E402
 
-PLAYBOOK_FILES = sorted(PLAYBOOKS_DIR.glob("*.yml")) + sorted(PLAYBOOKS_DIR.glob("*.yaml"))
+PLAYBOOK_FILES = sorted(PLAYBOOKS_DIR.glob("*.yml")) + sorted(
+    PLAYBOOKS_DIR.glob("*.yaml")
+)
 
 
 def _connectors():
@@ -89,7 +91,9 @@ def test_actions_exist_on_their_connector(path, playbooks):
     for step in playbook.steps:
         connector_name, action = step.action.split(".", 1)
         connector = connectors.get(connector_name)
-        assert connector is not None, f"{step.action}: no connector named {connector_name!r}"
+        assert (
+            connector is not None
+        ), f"{step.action}: no connector named {connector_name!r}"
         assert callable(
             getattr(connector, action, None)
         ), f"{step.action}: {connector_name} has no action {action!r}"
@@ -131,10 +135,12 @@ def test_cross_step_references_resolve(path, playbooks):
     """`{{ steps.X }}` must name a step of this playbook, by whatever key it gets."""
     playbook = playbooks[yaml.safe_load(path.read_text())["playbook_id"]]
     keys = {step.id or step.name for step in playbook.steps}
-    referenced = set(re.findall(r"steps\.([A-Za-z0-9_]+)", yaml.dump(playbook.model_dump())))
-    assert not (referenced - keys), (
-        f"{path.name} refers to steps that do not exist: {sorted(referenced - keys)}"
+    referenced = set(
+        re.findall(r"steps\.([A-Za-z0-9_]+)", yaml.dump(playbook.model_dump()))
     )
+    assert not (
+        referenced - keys
+    ), f"{path.name} refers to steps that do not exist: {sorted(referenced - keys)}"
 
 
 def test_validation_types_are_ones_the_connector_knows(playbooks):
@@ -153,7 +159,9 @@ def test_validation_types_are_ones_the_connector_knows(playbooks):
 
 def test_context_key_is_the_id_when_there_is_one():
     """The key the engine files a result under, and the key playbooks write."""
-    step = PlaybookStep(id="validate_ip", name="Validate IP Address", action="system.validate")
+    step = PlaybookStep(
+        id="validate_ip", name="Validate IP Address", action="system.validate"
+    )
     assert step_context_key(step) == "validate_ip"
 
 
@@ -173,7 +181,9 @@ def test_references_resolve_against_the_key_the_engine_uses(path, playbooks):
     """
     playbook = playbooks[yaml.safe_load(path.read_text())["playbook_id"]]
     keys = {step_context_key(step) for step in playbook.steps}
-    referenced = set(re.findall(r"steps\.([A-Za-z0-9_]+)", yaml.dump(playbook.model_dump())))
-    assert not (referenced - keys), (
-        f"{path.name}: {sorted(referenced - keys)} is not how the engine keys any of its steps"
+    referenced = set(
+        re.findall(r"steps\.([A-Za-z0-9_]+)", yaml.dump(playbook.model_dump()))
     )
+    assert not (
+        referenced - keys
+    ), f"{path.name}: {sorted(referenced - keys)} is not how the engine keys any of its steps"

--- a/open-security-responder/tests/unit/test_playbooks_are_executable.py
+++ b/open-security-responder/tests/unit/test_playbooks_are_executable.py
@@ -1,0 +1,179 @@
+"""Every shipped playbook must be one the engine can actually execute.
+
+These tests exist because all_star_e2e.yml was none of those things and said so
+to nobody. It wrote each step's arguments under `params:` while PlaybookStep
+declares `input`; pydantic dropped the unknown key, the playbook loaded clean,
+and every step ran with an empty input until the connector raised
+
+    SystemConnector.validate() missing 2 required positional arguments
+
+It also referred to its steps by `id` while the engine keyed the execution
+context by `name`, so every condition and template that mentioned an earlier
+step resolved to nothing -- quietly, as a false condition rather than an error.
+
+A playbook is a configuration file that looks correct by construction. Nothing
+type-checks it, so these tests do: the keys it uses, the actions it names, the
+arguments those actions take, and the steps it points at.
+"""
+
+import inspect
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVICE_ROOT = Path(__file__).resolve().parents[2]
+PLAYBOOKS_DIR = SERVICE_ROOT / "playbooks"
+sys.path.insert(0, str(SERVICE_ROOT))
+
+# Importing app.config builds Settings(), which requires these.
+os.environ.setdefault("SECRET_KEY", "x" * 40)
+os.environ.setdefault("GATEWAY_INTERNAL_SECRET", "y" * 40)
+
+from app.connectors import connector_registry  # noqa: E402
+from app.models import Playbook, PlaybookStep, step_context_key  # noqa: E402
+from app.playbook_parser import PlaybookParser, PlaybookParseError  # noqa: E402
+
+PLAYBOOK_FILES = sorted(PLAYBOOKS_DIR.glob("*.yml")) + sorted(PLAYBOOKS_DIR.glob("*.yaml"))
+
+
+def _connectors():
+    return getattr(connector_registry, "connectors", None) or getattr(
+        connector_registry, "_connectors", {}
+    )
+
+
+@pytest.fixture(scope="module")
+def playbooks():
+    return PlaybookParser(playbooks_directory=str(PLAYBOOKS_DIR)).load_playbooks()
+
+
+def test_there_are_playbooks_to_check():
+    assert PLAYBOOK_FILES, f"no playbooks found in {PLAYBOOKS_DIR}"
+
+
+def test_every_playbook_loads(playbooks):
+    """A playbook that fails to load takes the whole service down at startup."""
+    assert len(playbooks) == len(PLAYBOOK_FILES)
+
+
+def test_unknown_step_keys_are_rejected():
+    """The exact shape of the original defect: `params` where `input` is meant."""
+    with pytest.raises(Exception) as exc:
+        PlaybookStep(name="s", action="system.validate", params={"type": "ip_address"})
+    assert "params" in str(exc.value)
+
+
+def test_unknown_playbook_keys_are_rejected(tmp_path):
+    bad = tmp_path / "bad.yml"
+    bad.write_text(
+        "playbook_id: bad\n"
+        "name: bad\n"
+        "trigger:\n  type: api\n"
+        "steps:\n"
+        "  - name: s\n    action: system.validate\n    input: {type: ip_address, value: '1.1.1.1'}\n"
+        "output:\n  format: json\n"
+    )
+    with pytest.raises(PlaybookParseError) as exc:
+        PlaybookParser(playbooks_directory=str(tmp_path)).load_playbooks()
+    assert "output" in str(exc.value)
+
+
+@pytest.mark.parametrize("path", PLAYBOOK_FILES, ids=lambda p: p.name)
+def test_actions_exist_on_their_connector(path, playbooks):
+    playbook = playbooks[yaml.safe_load(path.read_text())["playbook_id"]]
+    connectors = _connectors()
+    for step in playbook.steps:
+        connector_name, action = step.action.split(".", 1)
+        connector = connectors.get(connector_name)
+        assert connector is not None, f"{step.action}: no connector named {connector_name!r}"
+        assert callable(
+            getattr(connector, action, None)
+        ), f"{step.action}: {connector_name} has no action {action!r}"
+
+
+@pytest.mark.parametrize("path", PLAYBOOK_FILES, ids=lambda p: p.name)
+def test_step_inputs_match_the_action_signature(path, playbooks):
+    """Now that inputs actually reach the connector, a wrong key is a TypeError."""
+    playbook = playbooks[yaml.safe_load(path.read_text())["playbook_id"]]
+    connectors = _connectors()
+    for step in playbook.steps:
+        connector_name, action = step.action.split(".", 1)
+        signature = inspect.signature(getattr(connectors[connector_name], action))
+        accepts_kwargs = any(
+            p.kind is p.VAR_KEYWORD for p in signature.parameters.values()
+        )
+        names = {n for n in signature.parameters if n != "self"}
+        required = {
+            n
+            for n, p in signature.parameters.items()
+            if n != "self"
+            and p.default is inspect.Parameter.empty
+            and p.kind not in (p.VAR_KEYWORD, p.VAR_POSITIONAL)
+        }
+        given = set((step.input or {}).keys())
+        assert not (required - given), (
+            f"{path.name}/{step.id or step.name}: {step.action} needs "
+            f"{sorted(required - given)}"
+        )
+        if not accepts_kwargs:
+            assert not (given - names), (
+                f"{path.name}/{step.id or step.name}: {step.action} does not take "
+                f"{sorted(given - names)}"
+            )
+
+
+@pytest.mark.parametrize("path", PLAYBOOK_FILES, ids=lambda p: p.name)
+def test_cross_step_references_resolve(path, playbooks):
+    """`{{ steps.X }}` must name a step of this playbook, by whatever key it gets."""
+    playbook = playbooks[yaml.safe_load(path.read_text())["playbook_id"]]
+    keys = {step.id or step.name for step in playbook.steps}
+    referenced = set(re.findall(r"steps\.([A-Za-z0-9_]+)", yaml.dump(playbook.model_dump())))
+    assert not (referenced - keys), (
+        f"{path.name} refers to steps that do not exist: {sorted(referenced - keys)}"
+    )
+
+
+def test_validation_types_are_ones_the_connector_knows(playbooks):
+    """system.validate answers "unknown type" without raising, so a typo is silent."""
+    system = _connectors()["system"]
+    supported = set(system.validate("__probe__", "")["supported_types"])
+    for playbook in playbooks.values():
+        for step in playbook.steps:
+            if step.action == "system.validate":
+                requested = (step.input or {}).get("type")
+                assert requested in supported, (
+                    f"{playbook.playbook_id}/{step.id or step.name}: validation type "
+                    f"{requested!r} is not one of {sorted(supported)}"
+                )
+
+
+def test_context_key_is_the_id_when_there_is_one():
+    """The key the engine files a result under, and the key playbooks write."""
+    step = PlaybookStep(id="validate_ip", name="Validate IP Address", action="system.validate")
+    assert step_context_key(step) == "validate_ip"
+
+
+def test_context_key_falls_back_to_the_name():
+    """Playbooks without ids -- triage_ip.yml and friends -- are unaffected."""
+    step = PlaybookStep(name="validate_ip", action="system.validate")
+    assert step_context_key(step) == "validate_ip"
+
+
+@pytest.mark.parametrize("path", PLAYBOOK_FILES, ids=lambda p: p.name)
+def test_references_resolve_against_the_key_the_engine_uses(path, playbooks):
+    """The same check as above, but against the engine's own keying function.
+
+    Written separately and deliberately: the test above computes the key itself,
+    so it stays green if the engine changes how it keys the context -- which is
+    exactly the regression that has to be caught.
+    """
+    playbook = playbooks[yaml.safe_load(path.read_text())["playbook_id"]]
+    keys = {step_context_key(step) for step in playbook.steps}
+    referenced = set(re.findall(r"steps\.([A-Za-z0-9_]+)", yaml.dump(playbook.model_dump())))
+    assert not (referenced - keys), (
+        f"{path.name}: {sorted(referenced - keys)} is not how the engine keys any of its steps"
+    )

--- a/open-security-sensor/pytest.ini
+++ b/open-security-sensor/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+# Don't inherit the repo-root addopts (--html needs a plugin not installed in
+# the per-service unit-test job).
+#
+# Every other Python service has one of these; the sensor had none, because
+# until now it had no tests. Without it pytest walks up to the repository root,
+# finds pytest.ini there, and dies before collecting anything:
+#   error: unrecognized arguments: --html=tests/integration/reports/report.html
+addopts =
+testpaths = tests

--- a/open-security-sensor/sensor/collectors/osquery_manager.py
+++ b/open-security-sensor/sensor/collectors/osquery_manager.py
@@ -370,14 +370,32 @@ class OsqueryManager:
     def _get_services_query(self) -> str:
         """Get platform-specific services query"""
         if is_linux():
-            # Linux uses systemd services
+            # systemd_units exposes none of name, status, pid, path or type.
+            # Its columns are id, description, load_state, active_state,
+            # sub_state, unit_file_state, following, object_path, job_id,
+            # job_type, job_path, fragment_path, user, source_path -- so the
+            # previous query failed outright, every collection cycle, with
+            #
+            #     osquery query failed: Error: no such column: name
+            #
+            # and the service inventory was permanently empty on the platform
+            # this sensor is actually deployed on. Aliased to the names the rest
+            # of the pipeline uses. There is no pid: systemd_units does not
+            # carry one, and a fabricated column is worse than a missing one.
             return '''
-                SELECT name, status, pid, path, 'systemd' as service_type
-                FROM systemd_units 
-                WHERE type = 'service'
+                SELECT id AS name,
+                       active_state AS status,
+                       sub_state,
+                       fragment_path AS path,
+                       'systemd' AS service_type
+                FROM systemd_units
+                WHERE id LIKE '%.service'
             '''
         elif is_macos():
-            # macOS uses launchd  
+            # Unverified. The Linux query above was wrong in every column, and
+            # these two were written the same way, but this machine has no
+            # macOS or Windows osquery to check them against -- so they are
+            # left as they are rather than changed on a guess.
             return '''
                 SELECT name, status, pid, path, 'launchd' as service_type
                 FROM launchd

--- a/open-security-sensor/tests/unit/test_osquery_queries.py
+++ b/open-security-sensor/tests/unit/test_osquery_queries.py
@@ -48,9 +48,34 @@ SYSTEMD_UNITS_COLUMNS = {
 }
 
 SQL_KEYWORDS = {
-    "select", "from", "where", "as", "and", "or", "not", "like", "in", "is",
-    "null", "limit", "order", "by", "group", "having", "union", "join", "on",
-    "left", "inner", "outer", "distinct", "case", "when", "then", "else", "end",
+    "select",
+    "from",
+    "where",
+    "as",
+    "and",
+    "or",
+    "not",
+    "like",
+    "in",
+    "is",
+    "null",
+    "limit",
+    "order",
+    "by",
+    "group",
+    "having",
+    "union",
+    "join",
+    "on",
+    "left",
+    "inner",
+    "outer",
+    "distinct",
+    "case",
+    "when",
+    "then",
+    "else",
+    "end",
 }
 
 
@@ -70,7 +95,11 @@ def _referenced_columns(query: str) -> set:
     # An alias introduced with AS is a name we invent, not one we read.
     aliases = set(re.findall(r"\bAS\s+([A-Za-z_][A-Za-z0-9_]*)", without_strings, re.I))
     words = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", without_strings))
-    return {w for w in words if w.lower() not in SQL_KEYWORDS} - aliases - {"systemd_units"}
+    return (
+        {w for w in words if w.lower() not in SQL_KEYWORDS}
+        - aliases
+        - {"systemd_units"}
+    )
 
 
 def test_the_query_is_still_the_one_we_check():
@@ -93,11 +122,15 @@ def test_the_columns_that_never_existed_are_not_read_back(column):
     # They may appear as aliases -- `id AS name` is the point -- but never as
     # something read from the table.
     read = _referenced_columns(query)
-    assert column not in read, f"{column!r} is read from systemd_units, which has no such column"
+    assert (
+        column not in read
+    ), f"{column!r} is read from systemd_units, which has no such column"
 
 
 def test_the_alias_names_the_pipeline_expects_are_produced():
     """Downstream reads name/status/path; the aliases keep that shape."""
     query = _linux_services_query()
-    aliases = {a.lower() for a in re.findall(r"\bAS\s+([A-Za-z_][A-Za-z0-9_]*)", query, re.I)}
+    aliases = {
+        a.lower() for a in re.findall(r"\bAS\s+([A-Za-z_][A-Za-z0-9_]*)", query, re.I)
+    }
     assert {"name", "status", "path", "service_type"} <= aliases

--- a/open-security-sensor/tests/unit/test_osquery_queries.py
+++ b/open-security-sensor/tests/unit/test_osquery_queries.py
@@ -1,0 +1,103 @@
+"""The queries the sensor issues must reference columns osquery actually has.
+
+The Linux services query asked for `name, status, pid, path` from
+`systemd_units` and filtered on `type = 'service'`. That table has none of those
+five columns, so every collection cycle ended in
+
+    osquery query failed: Error: no such column: name
+
+logged at ERROR and otherwise ignored. The service inventory was permanently
+empty on the platform this sensor is deployed on, and had been since the
+collector was written -- nothing failed loudly enough to notice.
+
+A SQL string is not checked by anything until it runs against a real osquery, on
+a real host, with the right platform. This test moves the check to build time
+for the one table whose schema is pinned below.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+SERVICE_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(SERVICE_ROOT))
+
+COLLECTOR = SERVICE_ROOT / "sensor" / "collectors" / "osquery_manager.py"
+
+# osquery 5.x, verified by running
+#   osqueryi --json "PRAGMA table_info(systemd_units);"
+# inside the sensor image. Update this list from that command, never from
+# memory: getting it wrong is the defect this test exists to catch.
+SYSTEMD_UNITS_COLUMNS = {
+    "id",
+    "description",
+    "load_state",
+    "active_state",
+    "sub_state",
+    "unit_file_state",
+    "following",
+    "object_path",
+    "job_id",
+    "job_type",
+    "job_path",
+    "fragment_path",
+    "user",
+    "source_path",
+}
+
+SQL_KEYWORDS = {
+    "select", "from", "where", "as", "and", "or", "not", "like", "in", "is",
+    "null", "limit", "order", "by", "group", "having", "union", "join", "on",
+    "left", "inner", "outer", "distinct", "case", "when", "then", "else", "end",
+}
+
+
+def _linux_services_query() -> str:
+    source = COLLECTOR.read_text()
+    start = source.index("def _get_services_query")
+    linux = source.index("if is_linux():", start)
+    macos = source.index("elif is_macos():", linux)
+    match = re.search(r"'''(.*?)'''", source[linux:macos], re.S)
+    assert match, "could not find the Linux services query"
+    return match.group(1)
+
+
+def _referenced_columns(query: str) -> set:
+    """Bare identifiers in the query, minus keywords, aliases and literals."""
+    without_strings = re.sub(r"'[^']*'", " ", query)
+    # An alias introduced with AS is a name we invent, not one we read.
+    aliases = set(re.findall(r"\bAS\s+([A-Za-z_][A-Za-z0-9_]*)", without_strings, re.I))
+    words = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", without_strings))
+    return {w for w in words if w.lower() not in SQL_KEYWORDS} - aliases - {"systemd_units"}
+
+
+def test_the_query_is_still_the_one_we_check():
+    assert "systemd_units" in _linux_services_query()
+
+
+def test_linux_services_query_uses_columns_that_exist():
+    referenced = _referenced_columns(_linux_services_query())
+    unknown = referenced - SYSTEMD_UNITS_COLUMNS
+    assert not unknown, (
+        f"systemd_units has no column(s) {sorted(unknown)}; "
+        f"it has {sorted(SYSTEMD_UNITS_COLUMNS)}"
+    )
+
+
+@pytest.mark.parametrize("column", ["name", "status", "pid", "path", "type"])
+def test_the_columns_that_never_existed_are_not_read_back(column):
+    """Named individually so a regression says which one came back."""
+    query = _linux_services_query()
+    # They may appear as aliases -- `id AS name` is the point -- but never as
+    # something read from the table.
+    read = _referenced_columns(query)
+    assert column not in read, f"{column!r} is read from systemd_units, which has no such column"
+
+
+def test_the_alias_names_the_pipeline_expects_are_produced():
+    """Downstream reads name/status/path; the aliases keep that shape."""
+    query = _linux_services_query()
+    aliases = {a.lower() for a in re.findall(r"\bAS\s+([A-Za-z_][A-Za-z0-9_]*)", query, re.I)}
+    assert {"name", "status", "path", "service_type"} <= aliases


### PR DESCRIPTION
Both defects were visible only as log lines during the v0.10.0 CI runs, and both had been wrong since the code was written. Neither had ever failed loudly enough to be noticed.

## The all-star playbook passed nothing to anything

`PlaybookStep` declares `input`; `playbooks/all_star_e2e.yml` wrote every step's arguments under `params:`. Pydantic drops unknown keys, so the playbook loaded clean and each step ran with an empty input until the connector refused:

```
SystemConnector.validate() missing 2 required positional arguments: 'type' and 'value'
```

Fixing the key exposed three more of the same kind:

- **Steps referred to each other by `id`, the engine keyed the context by `name`** — the display label, emoji and all. Every condition and template mentioning an earlier step resolved to nothing: a false condition, an empty render, no error anywhere.
- **`on_failure: "continue"`, on four steps, was read by nothing.** The engine always raised, so a playbook asking to carry on stopped at its first enrichment failure.
- **`system.create_report` takes `(template, data)`** and was handed `include_steps` and `format`; **`system.validate` was asked for type `"ipv4"`**, which it does not know — it answers "unknown type" without raising, so the run continued with `valid=false` and every dependent step skipped.

`retry_count` is removed from the model (declared, honoured nowhere) and the top-level `output:` block from the playbook (it described a result document the engine has never rendered). Both models now **reject** unknown keys instead of dropping them, and the parser turns a validation error into a startup failure an operator can see — which is what makes the rest durable.

## The sensor's service inventory was empty on Linux, permanently

The query asked `systemd_units` for `name, status, pid, path` and filtered on `type = 'service'`. That table has **none of those five columns** — verified with `PRAGMA table_info(systemd_units)` inside the sensor image. Every collection cycle ended in `osquery query failed: Error: no such column: name`, logged at ERROR and otherwise ignored, on the platform the sensor is actually deployed on.

Rewritten against the real columns and aliased to the names the pipeline expects. There is no `pid`: `systemd_units` does not carry one, and a fabricated column is worse than a missing one.

Every other query the sensor issues was checked against a real osquery; the rest are sound. The macOS and Windows branches of the same function are **left alone** — there is no way to verify them from here, so they are marked unverified rather than changed on a guess.

## Tests

Two new files, 23 and 8 tests, asserting what nothing checked before: that every shipped playbook loads, names actions that exist, passes arguments those actions accept, refers only to steps the engine will have keyed, and asks for validation types the connector knows; and that the Linux services query reads only columns `systemd_units` has. **Each was confirmed to go red when the defect it covers is put back.**

`open-security-sensor` joins the unit-test matrix, which it had never been in — its tests would otherwise run nowhere. Verified in a `python:3.11` container: the hash-pinned lock installs and the suite passes with `--cov=sensor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)