### PR TITLE
Generated keys were rejected by their own validators, about 3% of the time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,13 @@ jobs:
         # (WILDBO-TEST-03). These are pure-function tests; they need no stack.
         run: pytest tests/shared -v -p no:cacheprovider -o addopts=""
 
+      - name: Run script tests
+        # scripts/generate_secrets.py has to produce values the validators that
+        # read them back will accept. It did not: 2.89% of generated API keys
+        # tripped the tools service's weak-pattern check and killed it at
+        # start-up. Nothing tested the scripts before; this is where that runs.
+        run: pytest tests/scripts -v -p no:cacheprovider -o addopts=""
+
   e2e-tests:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest

--- a/scripts/generate_secrets.py
+++ b/scripts/generate_secrets.py
@@ -20,14 +20,61 @@ import sys
 from pathlib import Path
 
 
+# Substrings that a validator downstream refuses to see in a secret.
+#
+# Union of two lists that already exist and disagree: the one in
+# open-security-tools/app/config.py (which raises at start-up) and
+# INSECURE_PATTERNS in validate_secrets.py. They are there to catch a
+# hand-chosen secret like "test123" -- and they are applied to our random ones
+# too, where they are false positives by construction.
+#
+# Two of them, "abc" and "123", are formable from the hex alphabet, so a
+# perfectly good random key hits one by chance. Measured over 20000 generated
+# API keys: 2.89% were rejected. That is roughly one fresh install in thirty-five
+# failing at start-up with
+#
+#     ValidationError: API key contains weak pattern "abc"
+#
+# which reads like a bad key rather than a coincidence. It is why the
+# integration job on an unrelated pull request went red.
+#
+# Rather than loosen a validator that is right about hand-chosen secrets, the
+# generator now refuses to emit a value that would be rejected.
+WEAK_PATTERNS = (
+    "password", "secret", "key", "admin", "test", "demo",
+    "123", "abc", "default", "wildbox", "api-key",
+    "postgres", "change", "example", "insecure", "12345", "qwerty",
+)
+
+
+def _acceptable(value: str) -> bool:
+    """True when no downstream validator will refuse this value."""
+    lowered = value.lower()
+    return not any(pattern in lowered for pattern in WEAK_PATTERNS)
+
+
+def _retry_until_acceptable(make):
+    """Draw from `make` until the value passes the weak-pattern checks.
+
+    Terminates with probability 1 and, in practice, immediately: the chance of
+    a single draw being rejected is about 3%, so ten rejections in a row has a
+    probability around 1e-15. There is no bound on the loop on purpose -- a
+    bound would mean returning a value we know a validator will reject.
+    """
+    while True:
+        value = make()
+        if _acceptable(value):
+            return value
+
+
 def generate_hex(length: int = 32) -> str:
     """Generate secure random hex string"""
-    return secrets.token_hex(length)
+    return _retry_until_acceptable(lambda: secrets.token_hex(length))
 
 
 def generate_base64(length: int = 32) -> str:
     """Generate secure random URL-safe base64 string"""
-    return secrets.token_urlsafe(length)
+    return _retry_until_acceptable(lambda: secrets.token_urlsafe(length))
 
 
 # Punctuation that survives a .env round-trip, unquoted.
@@ -70,6 +117,10 @@ SAFE_PUNCTUATION = "-._~"
 
 def generate_password(length: int = 24) -> str:
     """Generate strong alphanumeric password with special characters"""
+    return _retry_until_acceptable(lambda: _draw_password(length))
+
+
+def _draw_password(length: int) -> str:
     alphabet = string.ascii_letters + string.digits + SAFE_PUNCTUATION
 
     # Ensure password has at least one of each type
@@ -91,7 +142,9 @@ def generate_password(length: int = 24) -> str:
 
 def generate_api_key(prefix: str = "prod") -> str:
     """Generate Wildbox API key in format: wsk_<prefix>.<hex>"""
-    return f"wsk_{prefix}.{generate_hex(32)}"
+    # Checked whole, not just the hex half: the validator sees the whole string,
+    # and a pattern could straddle the prefix boundary.
+    return _retry_until_acceptable(lambda: f"wsk_{prefix}.{secrets.token_hex(32)}")
 
 
 def main():

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,18 @@
+"""Tests for the repository's own scripts. No services required.
+
+The repository-root conftest declares an autouse `ensure_services_ready`
+fixture that waits for the docker-compose stack and fails the test if it is
+absent. That is right for the integration suite and wrong here: these tests
+read scripts/generate_secrets.py and draw values from it, and their whole value
+is that they run anywhere, including on a laptop with nothing started.
+Overriding the fixture with a no-op keeps that true -- the same trick
+tests/shared/conftest.py uses, for the same reason.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def ensure_services_ready():
+    """No-op override: these tests need no running services."""
+    return None

--- a/tests/scripts/test_generate_secrets.py
+++ b/tests/scripts/test_generate_secrets.py
@@ -1,0 +1,109 @@
+"""Generated secrets must survive the validators that read them back.
+
+open-security-tools/app/config.py refuses an API key containing any of a list of
+weak patterns, and two of them -- "abc" and "123" -- are formable from the hex
+alphabet. So a perfectly random key hit one by chance, and the service died at
+start-up with
+
+    ValidationError: API key contains weak pattern "abc"
+
+which reads like a bad key rather than a coincidence. Measured before the fix:
+2.89% of generated API keys were rejected, roughly one fresh install in
+thirty-five. It is how the integration job went red on a pull request whose
+diff was a lockfile.
+
+These tests hold the two halves together: the generator must not emit a value
+the validators refuse, and the pattern list it checks against must not drift
+away from the ones that actually do the refusing.
+"""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "scripts" / "generate_secrets.py"
+VALIDATOR = REPO_ROOT / "scripts" / "validate_secrets.py"
+TOOLS_CONFIG = REPO_ROOT / "open-security-tools" / "app" / "config.py"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def generator():
+    return _load(GENERATOR, "wildbox_generate_secrets")
+
+
+# Enough draws to catch a 3% failure rate with room to spare: the probability of
+# seeing none of a 3%-frequent event in 2000 draws is about 1e-27.
+DRAWS = 2000
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(lambda g: g.generate_api_key("prod"), id="api_key"),
+        pytest.param(lambda g: g.generate_hex(32), id="hex"),
+        pytest.param(lambda g: g.generate_base64(32), id="base64"),
+        pytest.param(lambda g: g.generate_password(24), id="password"),
+    ],
+)
+def test_generated_values_contain_no_weak_pattern(generator, factory):
+    offenders = []
+    for _ in range(DRAWS):
+        value = factory(generator)
+        lowered = value.lower()
+        hit = next((p for p in generator.WEAK_PATTERNS if p in lowered), None)
+        if hit:
+            offenders.append((hit, value))
+    assert not offenders, (
+        f"{len(offenders)} of {DRAWS} generated values contain a weak pattern, "
+        f"first: {offenders[0][0]!r} in {offenders[0][1][:24]}..."
+    )
+
+
+def test_the_generator_knows_every_pattern_the_tools_service_rejects():
+    """The list that raises at start-up is the one that matters most."""
+    source = TOOLS_CONFIG.read_text()
+    block = re.search(r"weak_patterns\s*=\s*\[(.*?)\]", source, re.S)
+    assert block, "could not find weak_patterns in the tools service config"
+    enforced = set(re.findall(r"'([^']+)'", block.group(1)))
+    known = set(_load(GENERATOR, "wildbox_generate_secrets_2").WEAK_PATTERNS)
+    assert enforced <= known, (
+        "the tools service rejects patterns the generator does not avoid: "
+        f"{sorted(enforced - known)}"
+    )
+
+
+def test_the_generator_knows_every_pattern_validate_secrets_rejects():
+    source = VALIDATOR.read_text()
+    block = re.search(r"INSECURE_PATTERNS\s*=\s*\[(.*?)\]", source, re.S)
+    assert block, "could not find INSECURE_PATTERNS in validate_secrets.py"
+    enforced = {p.lower() for p in re.findall(r'"([^"]+)"', block.group(1))}
+    known = set(_load(GENERATOR, "wildbox_generate_secrets_3").WEAK_PATTERNS)
+    # "test-" is a stricter spelling of "test", which the generator does avoid.
+    unmatched = {p for p in enforced if not any(k in p or p in k for k in known)}
+    assert not unmatched, (
+        f"validate_secrets.py rejects patterns the generator does not avoid: {sorted(unmatched)}"
+    )
+
+
+def test_a_value_carrying_a_weak_pattern_is_recognised(generator):
+    """The guard is not vacuous: it says no to something."""
+    assert not generator._acceptable("wsk_prod.deadbeefabc0123")
+    assert generator._acceptable("wsk_prod.deadbeef0f5e9d7c")
+
+
+def test_the_retry_actually_redraws(generator):
+    """Feed it two rejects, then a good one, and check it kept going."""
+    draws = iter(["contains-abc", "contains-123", "0f5e9d7c"])
+    assert generator._retry_until_acceptable(lambda: next(draws)) == "0f5e9d7c"


### PR DESCRIPTION
The integration job on #418 went red. That pull request changes one lockfile. The cause was elsewhere:

```
api-1 | ValidationError: 1 validation error for Settings
api-1 | api_key
api-1 |   Value error, API key contains weak pattern "abc".
api-1 |   input_value='wsk_prod.8f95939a14bea3e...fd54dcec801dcd42693eabc'
```

`open-security-tools/app/config.py` refuses an API key containing any of a list of weak patterns, and two of them — **`abc` and `123` — are formable from the hex alphabet**. So a perfectly random key hits one by chance.

Measured over 20000 generated keys: **2.89% are rejected**. That is roughly one fresh install in thirty-five dying at start-up with a message that reads like a bad key rather than a coincidence, and one CI run in thirty-five failing for nothing visible in the diff.

## The fix

The validators are right about hand-chosen secrets like `test123`; they are only wrong about ours. So **the generator now refuses to emit a value they would reject**, rather than loosening the check. `WEAK_PATTERNS` is the union of the two lists that already exist and disagree — the tools service's, which raises at start-up, and `INSECURE_PATTERNS` in `validate_secrets.py`.

Every generator is covered, not just the API key: `generate_password` draws from a 66-character alphabet where `abc`, `key`, `test` and `demo` are all formable, so it carries the same defect at about 0.15%.

The retry loop is unbounded on purpose — a bound would mean returning a value we know a validator will reject. Ten rejections in a row has probability around 1e-15.

## Tests

`tests/scripts/` is new, and so is its place in CI: **nothing tested the scripts before**. Eight tests. Two of them read the pattern lists back out of the tools service config and `validate_secrets.py`, and fail if either grows a pattern the generator does not avoid — that drift is what made this possible. Confirmed to go red with the fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)