### PR TITLE
Fix ((count++)) killing the script under set -e when the counter is 0

### DIFF
--- a/scripts/generate-api-specs.sh
+++ b/scripts/generate-api-specs.sh
@@ -84,7 +84,7 @@ total_count=${#SERVICES[@]}
 for service in "${!SERVICES[@]}"; do
     port=${SERVICES[$service]}
     if check_service "$service" "$port"; then
-        ((healthy_count++))
+        healthy_count=$((healthy_count + 1))
     fi
 done
 
@@ -107,7 +107,7 @@ for service in "${!SERVICES[@]}"; do
     port=${SERVICES[$service]}
     if check_service "$service" "$port" > /dev/null 2>&1; then
         if download_spec "$service" "$port"; then
-            ((success_count++))
+            success_count=$((success_count + 1))
         fi
     fi
 done


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/generate-api-specs.sh`

**Rationale:** The `for service in "${!SERVICES[@]}"` loop iterates over associative array keys, but the `SERVICES` array is declared with `declare -A SERVICES=(["identity"]="8001" ...)` — in bash, when iterating over associative array keys with `${!SERVICES[@]}`, the keys are unquoted and can be subject to word splitting if any key contains spaces or special characters. However, in this specific file, all keys are simple strings without spaces, so this is not the real defect. The actual real defect is that `((healthy_count++))` and `((success_count++))` can fail with `set -e` if the variable is 0, because `((0++))` returns exit code 1 (since the pre-increment value is 0, which is falsy), causing the script to exit prematurely. This is a well-known bash pitfall with `set -e` and arithmetic expressions.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `5f559fb632b7669b` · HITL-approved before opening.

<details>
<summary><b>How this change was checked</b> — 4 gates before a human saw it</summary>

| gate | result |
|---|---|
| deterministic slop gates | passed — no known no-op / false-guard pattern |
| LLM reviewer | `ship` · 90/100 |
| adversarial panel | survived — 3/3 could not refute (correctness, necessity, reproducibility) |
| human review | read and approved before this PR was opened |

The adversarial panel is three independent skeptics — correctness, necessity, reproducibility — each defaulting to *refuted*, voting “cannot refute” only after failing to find a reason to reject. A gate that did not run is not listed.
</details>
<!-- fabgpt:{"task_id":"5f559fb632b7669b","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":7.38,"prompt_sha":"05ddceedb6fe4041","triage":"INFO","review":{"verdict":"ship","score":90},"escalation":{"verdict":"OK","refuted":0,"model":"gpt-oss-120b"}} -->