### PR TITLE
Il cancello licenze accusava la causa sbagliata su un'immagine senza pacchetti di linguaggio

### DIFF
--- a/scripts/check_sbom_licences.py
+++ b/scripts/check_sbom_licences.py
@@ -113,6 +113,12 @@ def main() -> int:
 
     violations = []
     inventory: dict[str, set] = defaultdict(set)
+    # Counted across the WHOLE SBOM, before the language filter. Without these
+    # the "nothing was inspected" branch below cannot tell a broken SBOM from a
+    # service that legitimately has no language dependencies, and it used to
+    # blame the first for the second.
+    components_seen = 0
+    components_with_licences = 0
 
     for path in args.sboms:
         try:
@@ -123,6 +129,9 @@ def main() -> int:
             return 2
         skipped_os = 0
         for comp in doc.get("components", []) or []:
+            components_seen += 1
+            if licences_of(comp):
+                components_with_licences += 1
             if not args.include_os and not is_language_package(comp):
                 skipped_os += 1
                 continue
@@ -150,15 +159,39 @@ def main() -> int:
         return 1
 
     total = sum(len(v) for v in inventory.values())
-    if total == 0:
-        # A gate that inspects nothing passes for the wrong reason. Say so.
+    if total:
+        print(f"No copyleft licences found ({total} component licences checked).")
+        return 0
+
+    # Nothing was inspected. Three different reasons, and they are not the same
+    # incident: the message used to assert the last one for all of them, which
+    # sent the reader looking for a scan misconfiguration that was not there.
+    if components_seen == 0:
         print(
-            "ERROR: no licence data in the SBOM(s). A filesystem scan records "
-            "component names without licences; scan the built image instead.",
+            "ERROR: the SBOM(s) list no components at all. The image scan "
+            "produced nothing, so no licence could be checked.",
             file=sys.stderr,
         )
         return 2
-    print(f"No copyleft licences found ({total} component licences checked).")
+    if components_with_licences == 0:
+        print(
+            f"ERROR: {components_seen} component(s) in the SBOM(s) and a licence "
+            "for none of them. A filesystem scan records component names without "
+            "licences; scan the built image instead.",
+            file=sys.stderr,
+        )
+        return 2
+    # Components are there and carry licences, but none is a language package.
+    # That is what an OS-only image looks like: the gateway is OpenResty on
+    # Alpine, a config-and-Lua reverse proxy with no python/go/npm dependency,
+    # so its SBOM is 81 apk packages and nothing of ours. There is no copyleft
+    # exposure to gate, because nothing of ours is linked in.
+    print(
+        f"No language packages in the SBOM(s): {components_seen} component(s), "
+        f"{components_with_licences} with a licence, all base-image OS packages. "
+        "Nothing of ours is linked in, so there is nothing to gate. "
+        "Use --include-os to check the base image too."
+    )
     return 0
 
 

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for the scripts/ helpers. No services required.
+
+The repository-root conftest declares an autouse `ensure_services_ready` fixture
+that waits for the docker-compose stack and fails the test if it is absent. That
+is right for the integration suite and wrong here: these exercise a script over
+fixture files on disk, and their whole value is that they run without a stack.
+Overriding the fixture with a no-op keeps that true, the same way tests/shared
+and tests/tools already do.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def ensure_services_ready():
+    """No-op override: these tests need no running services."""
+    return None

--- a/tests/scripts/test_check_sbom_licences.py
+++ b/tests/scripts/test_check_sbom_licences.py
@@ -1,0 +1,97 @@
+"""Tests for check_sbom_licences.py, the gate that keeps copyleft out of an MIT platform.
+
+The case that brought these into being: on 2026-09-10 `Test Suite` was red on main
+because the gate reported
+
+    ERROR: no licence data in the SBOM(s). A filesystem scan records component
+    names without licences; scan the built image instead.
+
+on an SBOM that had 82 components and a licence for 81 of them, produced by an image
+scan exactly as the message asked for. The gateway is OpenResty on Alpine, so it has
+no language packages at all, and the gate asserted the one cause that was not true.
+
+A gate that inspects nothing must say so. It must also say WHICH nothing.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_sbom_licences.py"
+
+APK = {"name": "aom-libs", "version": "3.9.0", "type": "library",
+       "licenses": [{"license": {"id": "BSD-2-Clause"}}],
+       "properties": [{"name": "aquasecurity:trivy:PkgType", "value": "alpine"}]}
+
+
+def pkg(name, licence, pkgtype="python-pkg"):
+    c = {"name": name, "version": "1.0", "type": "library"}
+    if licence:
+        c["licenses"] = [{"license": {"id": licence}}]
+    if pkgtype:
+        c["properties"] = [{"name": "aquasecurity:trivy:PkgType", "value": pkgtype}]
+    return c
+
+
+def run(tmp_path, components, *args):
+    p = tmp_path / "sbom.cdx.json"
+    p.write_text(json.dumps({"bomFormat": "CycloneDX", "components": components}))
+    r = subprocess.run([sys.executable, str(SCRIPT), str(p), *args],
+                       capture_output=True, text=True)
+    return r.returncode, r.stdout + r.stderr
+
+
+def test_os_only_image_passes_and_says_why(tmp_path):
+    """OpenResty on Alpine: 81 apk packages, nothing of ours linked in."""
+    rc, out = run(tmp_path, [APK] * 81)
+    assert rc == 0
+    assert "No language packages" in out
+    assert "81 with a licence" in out
+    assert "filesystem scan" not in out          # the wrong cause, previously asserted here
+
+
+def test_a_filesystem_scan_is_still_rejected(tmp_path):
+    """Components without licences is the symptom the old message described, and
+    it must keep failing: that SBOM cannot support a licence decision."""
+    rc, out = run(tmp_path, [pkg("requests", None), pkg("flask", None)])
+    assert rc == 2
+    assert "a licence for none of them" in out
+    assert "scan the built image instead" in out
+
+
+def test_an_empty_sbom_is_rejected_with_its_own_reason(tmp_path):
+    rc, out = run(tmp_path, [])
+    assert rc == 2
+    assert "no components at all" in out
+
+
+def test_copyleft_in_a_language_package_still_fails(tmp_path):
+    """The point of the whole gate. An OS-only pass must not have blunted it."""
+    rc, out = run(tmp_path, [APK, pkg("some-lib", "GPL-3.0-only")])
+    assert rc == 1
+    assert "Copyleft licences found" in out
+    assert "some-lib" in out
+
+
+def test_copyleft_in_the_base_image_is_ignored_by_default(tmp_path):
+    """Alpine is GPL by nature and is not linked into our code."""
+    gpl_apk = dict(APK, name="alpine-baselayout",
+                   licenses=[{"license": {"id": "GPL-2.0-only"}}])
+    rc, out = run(tmp_path, [gpl_apk])
+    assert rc == 0
+    assert "No language packages" in out
+
+
+def test_include_os_gates_the_base_image_too(tmp_path):
+    gpl_apk = dict(APK, name="alpine-baselayout",
+                   licenses=[{"license": {"id": "GPL-2.0-only"}}])
+    rc, out = run(tmp_path, [gpl_apk], "--include-os")
+    assert rc == 1
+    assert "alpine-baselayout" in out
+
+
+def test_permissive_language_package_passes(tmp_path):
+    rc, out = run(tmp_path, [pkg("requests", "Apache-2.0")])
+    assert rc == 0
+    assert "No copyleft licences found" in out

--- a/tests/scripts/test_check_sbom_licences.py
+++ b/tests/scripts/test_check_sbom_licences.py
@@ -20,9 +20,13 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_sbom_licences.py"
 
-APK = {"name": "aom-libs", "version": "3.9.0", "type": "library",
-       "licenses": [{"license": {"id": "BSD-2-Clause"}}],
-       "properties": [{"name": "aquasecurity:trivy:PkgType", "value": "alpine"}]}
+APK = {
+    "name": "aom-libs",
+    "version": "3.9.0",
+    "type": "library",
+    "licenses": [{"license": {"id": "BSD-2-Clause"}}],
+    "properties": [{"name": "aquasecurity:trivy:PkgType", "value": "alpine"}],
+}
 
 
 def pkg(name, licence, pkgtype="python-pkg"):
@@ -37,8 +41,9 @@ def pkg(name, licence, pkgtype="python-pkg"):
 def run(tmp_path, components, *args):
     p = tmp_path / "sbom.cdx.json"
     p.write_text(json.dumps({"bomFormat": "CycloneDX", "components": components}))
-    r = subprocess.run([sys.executable, str(SCRIPT), str(p), *args],
-                       capture_output=True, text=True)
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), *args], capture_output=True, text=True
+    )
     return r.returncode, r.stdout + r.stderr
 
 
@@ -48,7 +53,7 @@ def test_os_only_image_passes_and_says_why(tmp_path):
     assert rc == 0
     assert "No language packages" in out
     assert "81 with a licence" in out
-    assert "filesystem scan" not in out          # the wrong cause, previously asserted here
+    assert "filesystem scan" not in out  # the wrong cause, previously asserted here
 
 
 def test_a_filesystem_scan_is_still_rejected(tmp_path):
@@ -76,16 +81,18 @@ def test_copyleft_in_a_language_package_still_fails(tmp_path):
 
 def test_copyleft_in_the_base_image_is_ignored_by_default(tmp_path):
     """Alpine is GPL by nature and is not linked into our code."""
-    gpl_apk = dict(APK, name="alpine-baselayout",
-                   licenses=[{"license": {"id": "GPL-2.0-only"}}])
+    gpl_apk = dict(
+        APK, name="alpine-baselayout", licenses=[{"license": {"id": "GPL-2.0-only"}}]
+    )
     rc, out = run(tmp_path, [gpl_apk])
     assert rc == 0
     assert "No language packages" in out
 
 
 def test_include_os_gates_the_base_image_too(tmp_path):
-    gpl_apk = dict(APK, name="alpine-baselayout",
-                   licenses=[{"license": {"id": "GPL-2.0-only"}}])
+    gpl_apk = dict(
+        APK, name="alpine-baselayout", licenses=[{"license": {"id": "GPL-2.0-only"}}]
+    )
     rc, out = run(tmp_path, [gpl_apk], "--include-os")
     assert rc == 1
     assert "alpine-baselayout" in out


### PR DESCRIPTION
Chiude il rosso di `Test Suite` su `main`.

## Il sintomo

`Build Docker Images (gateway)` cade su `Check dependency licences`:

```
ERROR: no licence data in the SBOM(s). A filesystem scan records component
names without licences; scan the built image instead.
```

## Il messaggio non e vero

Ho scaricato l SBOM dagli artefatti di quel run ([34461541156](https://github.com/fabriziosalmi/wildbox/actions/runs/34461541156)):

```
componenti: 82
con licenza: 81
generato da: trivy image wildbox-gateway:scan
```

Nessuna scansione del filesystem: il workflow costruisce gia l immagine e ci lancia trivy sopra, esattamente come il messaggio chiede.

## La causa vera

Lo script filtra ai soli pacchetti di linguaggio (`python-pkg`, `gobinary`, `npm`...), perche la base Alpine e GPL per natura e non e linkata nel nostro codice. Ma il gateway e **OpenResty su Alpine**: un reverse proxy di configurazione e Lua, senza alcuna dipendenza Python, Go o npm.

```
PkgType nell SBOM del gateway:  {alpine: 81, nessun PkgType: 1}
```

Dopo il filtro resta zero, e lo script concludeva che l SBOM fosse difettoso.

## Cosa cambia

Zero ispezionati ha **tre** cause distinte, e non sono lo stesso incidente:

| cosa si osserva | cosa significa | esito |
|---|---|---|
| nessun componente | la scansione non ha prodotto niente | errore |
| componenti senza licenze | e davvero una scansione del filesystem | errore |
| componenti con licenze, nessuno di linguaggio | immagine di sola base, niente di nostro linkato | passa, dicendolo |

Il messaggio asseriva la seconda per tutte e tre, e mandava chi legge a cercare una configurazione sbagliata che non esisteva.

## Il cancello non perde i denti

E il punto della modifica, quindi e verificato:

- un pacchetto di linguaggio copyleft **fallisce ancora** (`GPL-3.0-only` su una libreria nostra, exit 1)
- un SBOM senza licenze viene **ancora rifiutato** (exit 2)
- un SBOM vuoto pure, con un messaggio suo
- `--include-os` continua a vagliare anche la base

Sette test in `tests/scripts/`, con un conftest che neutralizza la fixture autouse `ensure_services_ready` come gia fanno `tests/shared` e `tests/tools`: girano su file di prova su disco e non devono pretendere lo stack docker.

## Verifica sull SBOM vero

```
$ python3 scripts/check_sbom_licences.py sbom-gateway.cdx.json
No language packages in the SBOM(s): 82 component(s), 81 with a licence,
all base-image OS packages. Nothing of ours is linked in, so there is
nothing to gate. Use --include-os to check the base image too.
exit=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)