### PR TITLE
Toglie python-nmap: GPL-3.0 spedito in una piattaforma MIT, e mai importato

### DIFF
--- a/open-security-guardian/requirements.in
+++ b/open-security-guardian/requirements.in
@@ -34,7 +34,6 @@ python-dotenv==1.2.2
 pandas==2.1.4
 numpy==1.25.2
 python-dateutil==2.8.2
-python-nmap==0.7.1
 pytenable==1.7.5
 qualysapi==8.1.0
 python-libnmap==0.7.3

--- a/open-security-guardian/requirements.txt
+++ b/open-security-guardian/requirements.txt
@@ -1735,9 +1735,6 @@ python-magic==0.4.27 \
     --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b \
     --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3
     # via -r open-security-guardian/requirements.in
-python-nmap==0.7.1 \
-    --hash=sha256:f75af6b91dd8e3b0c31f869db32163f62ada686945e5b7c25f84bc0f7fad3b64
-    # via -r open-security-guardian/requirements.in
 pytz==2026.3.post1 \
     --hash=sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d \
     --hash=sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815

--- a/open-security-tools/requirements-secure.txt
+++ b/open-security-tools/requirements-secure.txt
@@ -15,7 +15,6 @@ dnspython==2.7.0
 aiodns==3.5.0
 
 # Port scanning dependencies - Latest secure
-python-nmap==0.7.1
 
 # Web vulnerability scanning dependencies - Latest secure
 aiohttp==3.14.1

--- a/open-security-tools/requirements.in
+++ b/open-security-tools/requirements.in
@@ -27,7 +27,6 @@ aiofiles==24.1.0
 dnspython==2.7.0
 aiodns==3.2.0
 python-whois==0.9.4
-python-nmap==0.7.1
 aiohttp==3.14.1
 beautifulsoup4==4.12.3
 requests==2.33.0

--- a/open-security-tools/requirements.txt
+++ b/open-security-tools/requirements.txt
@@ -1427,9 +1427,6 @@ python-dotenv==1.2.2 \
     #   -r open-security-tools/requirements.in
     #   pydantic-settings
     #   uvicorn
-python-nmap==0.7.1 \
-    --hash=sha256:f75af6b91dd8e3b0c31f869db32163f62ada686945e5b7c25f84bc0f7fad3b64
-    # via -r open-security-tools/requirements.in
 python-whois==0.9.4 \
     --hash=sha256:17d60f25524fc811a1f6a66f0298c1e5534551d7a01a77dd5f6406426da734e1 \
     --hash=sha256:77bc7347bf815d65ccd196711c29837652f07585aedad3c3c04dd885651fd7a7


### PR DESCRIPTION
Chiude il rosso di `Test Suite` su `main`, che e apparso appena il cancello licenze ha smesso di sbagliare bersaglio ([#429](https://github.com/fabriziosalmi/wildbox/pull/429)).

## Cosa ha trovato il cancello

```
Copyleft licences found in the dependency tree:
  sbom-tools.cdx.json: python-nmap==0.7.1 is GPL-3.0-or-later
This platform ships under MIT.
```

Non e un falso positivo. `python-nmap` e **GPL-3.0-or-later** (su PyPI: `gpl-3.0.txt`, classifier `GNU General Public License`) ed e dichiarato in **due** servizi, `tools` e `guardian`, quindi installato e spedito dentro le immagini.

## Nessuno lo importa

Cercato su tutto l albero: nessun `import nmap`, nessun `from nmap`, nessun `nmap.PortScanner`.

Il caricamento dinamico non lo raggiunge: `tool_loader` importa solo da `app.tools` (`TOOLS_PACKAGE`) e non esiste alcun tool nmap. Le occorrenze di "nmap" nel codice Python sono uno User-Agent in log di esempio, un commento, l host di prova `scanme.nmap.org`, e la stringa `"nmap"` come nome di tool nel responder.

## Quello che i servizi usano e il binario, non il wrapper

I Dockerfile installano il **binario** nmap:

```
open-security-tools/Dockerfile:33  # nmap is the engine behind several tools
open-security-tools/Dockerfile:43      nmap \
open-security-guardian/Dockerfile:34      nmap \
```

Invocare un programma separato e una situazione di licenza diversa dal linkare una libreria GPL dentro il proprio processo, ed e esattamente il motivo per cui il cancello guarda i soli pacchetti di linguaggio. Togliendo il wrapper Python il binario resta e **non cambia niente in funzione**.

Quindi quello che si toglie e esposizione a copyleft senza alcun beneficio: una dipendenza GPL spedita in un prodotto MIT, che nessuna riga di codice puo raggiungere.

## La diff

I `requirements.txt` sono generati da `uv pip compile --generate-hashes`, quindi la modifica e sui `.in` e la rigenerazione usa il comando esatto scritto nell intestazione dei file.

```
 open-security-guardian/requirements.in      | 1 -
 open-security-guardian/requirements.txt     | 3 ---
 open-security-tools/requirements-secure.txt | 1 -
 open-security-tools/requirements.in         | 1 -
 open-security-tools/requirements.txt        | 3 ---
 5 files changed, 9 deletions(-)
```

Nove righe tolte, **zero aggiunte**: nessun altra versione si e mossa nella rigenerazione.

## Non incluso di proposito

`python-libnmap` (Apache-2.0) in `guardian` e anch esso non importato. Non e un problema di licenza, quindi non lo tocco qui: e igiene delle dipendenze e merita una decisione sua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)